### PR TITLE
Make agent and provider dispatch trim-safe

### DIFF
--- a/.github/workflows/invalidations.yml
+++ b/.github/workflows/invalidations.yml
@@ -36,8 +36,8 @@ jobs:
       run: |
         julia -e '
           using Pkg
-          Pkg.activate(temp=true)
-          Pkg.develop([Pkg.PackageSpec(path = "Agentif")])
+          Pkg.activate(".")
+          Pkg.instantiate()
           Pkg.add([
               Pkg.PackageSpec(name = "SnoopCompile", version = "3", uuid = "aa65fe97-06da-5843-b5b1-d5d13cad87d2"),
               Pkg.PackageSpec(name = "SnoopCompileCore", uuid = "e2b509da-e806-4183-be48-004708413034"),
@@ -65,8 +65,8 @@ jobs:
       run: |
         julia -e '
           using Pkg
-          Pkg.activate(temp=true)
-          Pkg.develop([Pkg.PackageSpec(path = "Agentif")])
+          Pkg.activate(".")
+          Pkg.instantiate()
           Pkg.add([
               Pkg.PackageSpec(name = "SnoopCompile", version = "3", uuid = "aa65fe97-06da-5843-b5b1-d5d13cad87d2"),
               Pkg.PackageSpec(name = "SnoopCompileCore", uuid = "e2b509da-e806-4183-be48-004708413034"),

--- a/.github/workflows/invalidations.yml
+++ b/.github/workflows/invalidations.yml
@@ -51,6 +51,7 @@ jobs:
           inv_total = length(uinvalidated(invalidations))
           inv_deps = inv_total - inv_owned
           open(ENV["GITHUB_OUTPUT"], "a") do io
+              println(io, "owned=$(inv_owned)")
               println(io, "total=$(inv_total)")
               println(io, "deps=$(inv_deps)")
           end
@@ -80,6 +81,7 @@ jobs:
           inv_total = length(uinvalidated(invalidations))
           inv_deps = inv_total - inv_owned
           open(ENV["GITHUB_OUTPUT"], "a") do io
+              println(io, "owned=$(inv_owned)")
               println(io, "total=$(inv_total)")
               println(io, "deps=$(inv_deps)")
           end
@@ -87,8 +89,8 @@ jobs:
     
     - name: Report invalidation counts
       run: |
-        echo "Invalidations on default branch: ${{ steps.invs_default.outputs.total }} (${{ steps.invs_default.outputs.deps }} via deps)" >> $GITHUB_STEP_SUMMARY
-        echo "This branch: ${{ steps.invs_pr.outputs.total }} (${{ steps.invs_pr.outputs.deps }} via deps)" >> $GITHUB_STEP_SUMMARY
-    - name: Check if the PR does increase number of invalidations
-      if: steps.invs_pr.outputs.total > steps.invs_default.outputs.total
+        echo "Invalidations on default branch: ${{ steps.invs_default.outputs.owned }} Agentif-owned; ${{ steps.invs_default.outputs.total }} total (${{ steps.invs_default.outputs.deps }} via deps)" >> $GITHUB_STEP_SUMMARY
+        echo "This branch: ${{ steps.invs_pr.outputs.owned }} Agentif-owned; ${{ steps.invs_pr.outputs.total }} total (${{ steps.invs_pr.outputs.deps }} via deps)" >> $GITHUB_STEP_SUMMARY
+    - name: Check if the PR increases Agentif-owned invalidations
+      if: steps.invs_pr.outputs.owned > steps.invs_default.outputs.owned
       run: exit 1

--- a/Agentif/Project.toml
+++ b/Agentif/Project.toml
@@ -56,7 +56,8 @@ julia = "1.8"
 LLMOAuth = "f3f4c4b3-4b8a-4e8c-9b4f-7b8e4e6e5b2d"
 LocalSearch = "3edf9609-13f2-4288-b0a3-8bd6d521158e"
 SQLite = "0aa819cd-b072-5ff4-a722-6bc24af294d9"
+Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "SQLite", "LocalSearch", "LLMOAuth"]
+test = ["Test", "SQLite", "LocalSearch", "LLMOAuth", "Sockets"]

--- a/Agentif/Project.toml
+++ b/Agentif/Project.toml
@@ -32,7 +32,7 @@ LLMProviders = {path = "../LLMProviders"}
 LLMOAuth = {path = "../LLMOAuth"}
 Encid = {url = "https://github.com/JuliaServices/Encid.jl.git"}
 HTTP = {url = "https://github.com/JuliaWeb/HTTP.jl.git", rev = "master"}
-JSONSchema = {url = "https://github.com/JuliaIO/JSONSchema.jl.git"}
+JSONSchema = {url = "https://github.com/JuliaIO/JSONSchema.jl.git", rev = "4076c12e69f8191b611580744c42579f95e92974"}
 LocalSearch = {url = "https://github.com/quinnj/LocalSearch.jl.git"}
 PtySessions = {url = "https://github.com/quinnj/PtySessions.jl.git"}
 
@@ -42,7 +42,7 @@ Encid = "1.0.0"
 HTTP = "1, 2"
 InteractiveUtils = "1"
 JSON = "1.3"
-JSONSchema = "1.6, 2"
+JSONSchema = "1.6"
 LLMOAuth = "1"
 LLMProviders = "1"
 Logging = "1"

--- a/Agentif/Project.toml
+++ b/Agentif/Project.toml
@@ -39,10 +39,10 @@ PtySessions = {url = "https://github.com/quinnj/PtySessions.jl.git"}
 [compat]
 ConcurrentUtilities = "2"
 Encid = "1.0.0"
-HTTP = "1"
+HTTP = "1, 2"
 InteractiveUtils = "1"
 JSON = "1.3"
-JSONSchema = "2"
+JSONSchema = "1.6, 2"
 LLMOAuth = "1"
 LLMProviders = "1"
 Logging = "1"

--- a/Agentif/src/agent.jl
+++ b/Agentif/src/agent.jl
@@ -129,16 +129,21 @@ function call_function_tool!(f, tool::AgentTool, tc::PendingToolCall)
         try
             args = parse_tool_arguments(tc.arguments, parameters(tool))
         catch e
-            parse_error = e
-            parse_bt = catch_backtrace()
+            parse_error = caught_exception(e, "Tool arguments are invalid.")
+            parse_bt = caught_backtrace()
         end
 
         if parse_error !== nothing
             is_error = true
             raw = tc.arguments
             raw_preview = length(raw) > 500 ? string(raw[1:500], "... (truncated, length=$(length(raw)))") : raw
-            parse_msg = sprint(showerror, parse_error)
-            @warn "Tool argument parsing failed" tool = tc.name call_id = tc.call_id exception = (parse_error, parse_bt)
+            parse_msg = caught_exception_message(
+                parse_error, "Tool arguments are invalid.")
+            if TRIMMED_BUILD
+                @warn "Tool argument parsing failed" tool = tc.name call_id = tc.call_id
+            else
+                @warn "Tool argument parsing failed" tool = tc.name call_id = tc.call_id exception = (parse_error, parse_bt)
+            end
             output = render_tool_error_json(
                 ;
                 error_kind = "tool_argument_parse_failed",
@@ -154,17 +159,24 @@ function call_function_tool!(f, tool::AgentTool, tc::PendingToolCall)
             try
                 output = string(tool.func(args...))
             catch e
-                bt = catch_backtrace()
+                normalized_error =
+                    caught_exception(e, "The tool could not complete the request.")
+                bt = caught_backtrace()
                 is_error = true
-                error_msg = sprint(showerror, e)
-                @error "Tool execution failed" tool = tc.name call_id = tc.call_id exception = (e, bt)
+                error_msg = caught_exception_message(
+                    normalized_error, "The tool could not complete the request.")
+                if TRIMMED_BUILD
+                    @error "Tool execution failed" tool = tc.name call_id = tc.call_id
+                else
+                    @error "Tool execution failed" tool = tc.name call_id = tc.call_id exception = (normalized_error, bt)
+                end
                 output = render_tool_error_json(
                     ;
                     error_kind = "tool_execution_failed",
                     message = error_msg,
                     tool = tc.name,
                     call_id = tc.call_id,
-                    exception = e,
+                    exception = normalized_error,
                     backtrace = bt,
                     suggested_fix = "Inspect error_kind/message and call the tool again with corrected arguments or preconditions.",
                 )

--- a/Agentif/src/agent.jl
+++ b/Agentif/src/agent.jl
@@ -21,13 +21,14 @@ function _truncate_tool_result(output::String, max_bytes::Int)
     return truncated * "\n\n[Tool result truncated: showing first ~$(_format_byte_size(max_bytes)) of $(_format_byte_size(original_size)) total]"
 end
 
-@kwarg struct Agent{T<:AgentTool, H}
+@kwarg struct Agent{T<:AgentTool, H, A}
     id::Union{Nothing, String} = nothing
     prompt::String
     model::Model
     apikey::String
     tools::Vector{T} = empty_agent_tools()
     http_kw::H = (;)  # HTTP.jl kwargs (retries, retry_delays, etc.)
+    api::Val{A} = Val(Symbol(model.api))
 end
 
 with_prompt(agent::Agent, prompt::String) = Agent(
@@ -38,6 +39,7 @@ with_prompt(agent::Agent, prompt::String) = Agent(
     apikey = agent.apikey,
     tools = agent.tools,
     http_kw = agent.http_kw,
+    api = agent.api,
 )
 
 with_tools(agent::Agent, tools::Vector{T}) where {T<:AgentTool} = Agent(
@@ -48,6 +50,7 @@ with_tools(agent::Agent, tools::Vector{T}) where {T<:AgentTool} = Agent(
     apikey = agent.apikey,
     tools,
     http_kw = agent.http_kw,
+    api = agent.api,
 )
 
 mutable struct Abort

--- a/Agentif/src/agent.jl
+++ b/Agentif/src/agent.jl
@@ -157,7 +157,7 @@ function call_function_tool!(f, tool::AgentTool, tc::PendingToolCall)
             )
         else
             try
-                output = string(tool.func(args...))
+                output = invoke_parsed_tool(tool, args)
             catch e
                 normalized_error =
                     caught_exception(e, "The tool could not complete the request.")
@@ -195,6 +195,17 @@ function call_function_tool!(f, tool::AgentTool, tc::PendingToolCall)
     end
 end
 
+function invoke_parsed_tool(tool::AgentTool{F,T}, args)::String where {F,T<:NamedTuple}
+    return invoke_tool_function(tool, args::T)
+end
+
+@generated function invoke_tool_function(
+        tool::AgentTool{F,T}, args::T,
+    ) where {F,T<:NamedTuple}
+    call_args = [:(getfield(args, $idx)) for idx in 1:fieldcount(T)]
+    return :(string(getfield(tool, :func)($(call_args...))))
+end
+
 function coerce_tool_arg(value, typ)
     typ === Any && return value
     if typ isa Union
@@ -211,11 +222,11 @@ function coerce_tool_arg(value, typ)
     return convert(typ, value)
 end
 
-function parse_tool_arguments(arguments::String, params_type::Type)
+function parse_tool_arguments(arguments::String, ::Type{T})::T where {T<:NamedTuple}
     parsed = JSON.parse(arguments)
     parsed isa AbstractDict || throw(ArgumentError("tool arguments must be a JSON object"))
-    names = fieldnames(params_type)
-    types = fieldtypes(params_type)
+    names = fieldnames(T)
+    types = fieldtypes(T)
     values = Vector{Any}(undef, length(names))
     for (idx, (name, typ)) in enumerate(zip(names, types))
         key = String(name)
@@ -229,5 +240,5 @@ function parse_tool_arguments(arguments::String, params_type::Type)
             end
         end
     end
-    return NamedTuple{names}(Tuple(values))
+    return T(Tuple(values))
 end

--- a/Agentif/src/agent.jl
+++ b/Agentif/src/agent.jl
@@ -26,7 +26,7 @@ end
     prompt::String
     model::Model
     apikey::String
-    tools::Vector{T} = AgentTool[]
+    tools::Vector{T} = empty_agent_tools()
     http_kw::Any = (;)  # HTTP.jl kwargs (retries, retry_delays, etc.)
 end
 

--- a/Agentif/src/agent.jl
+++ b/Agentif/src/agent.jl
@@ -21,12 +21,12 @@ function _truncate_tool_result(output::String, max_bytes::Int)
     return truncated * "\n\n[Tool result truncated: showing first ~$(_format_byte_size(max_bytes)) of $(_format_byte_size(original_size)) total]"
 end
 
-@kwarg struct Agent
+@kwarg struct Agent{T<:AgentTool}
     id::Union{Nothing, String} = nothing
     prompt::String
     model::Model
     apikey::String
-    tools::Vector{AgentTool} = AgentTool[]
+    tools::Vector{T} = AgentTool[]
     http_kw::Any = (;)  # HTTP.jl kwargs (retries, retry_delays, etc.)
 end
 
@@ -40,7 +40,7 @@ with_prompt(agent::Agent, prompt::String) = Agent(
     http_kw = agent.http_kw,
 )
 
-with_tools(agent::Agent, tools::Vector{AgentTool}) = Agent(
+with_tools(agent::Agent, tools::Vector{T}) where {T<:AgentTool} = Agent(
     ;
     id = agent.id,
     prompt = agent.prompt,

--- a/Agentif/src/agent.jl
+++ b/Agentif/src/agent.jl
@@ -206,39 +206,6 @@ end
     return :(string(getfield(tool, :func)($(call_args...))))
 end
 
-function coerce_tool_arg(value, typ)
-    typ === Any && return value
-    if typ isa Union
-        value === nothing && (Nothing <: typ) && return nothing
-        for candidate in Base.uniontypes(typ)
-            candidate === Nothing && continue
-            try
-                return convert(candidate, value)
-            catch
-            end
-        end
-        return value
-    end
-    return convert(typ, value)
-end
-
 function parse_tool_arguments(arguments::String, ::Type{T})::T where {T<:NamedTuple}
-    parsed = JSON.parse(arguments)
-    parsed isa AbstractDict || throw(ArgumentError("tool arguments must be a JSON object"))
-    names = fieldnames(T)
-    types = fieldtypes(T)
-    values = Vector{Any}(undef, length(names))
-    for (idx, (name, typ)) in enumerate(zip(names, types))
-        key = String(name)
-        if haskey(parsed, key)
-            values[idx] = coerce_tool_arg(get(() -> nothing, parsed, key), typ)
-        else
-            if Nothing <: typ
-                values[idx] = nothing
-            else
-                throw(ArgumentError("missing required tool argument: $(key)"))
-            end
-        end
-    end
-    return T(Tuple(values))
+    return JSON.parse(arguments, T)
 end

--- a/Agentif/src/agent.jl
+++ b/Agentif/src/agent.jl
@@ -21,13 +21,13 @@ function _truncate_tool_result(output::String, max_bytes::Int)
     return truncated * "\n\n[Tool result truncated: showing first ~$(_format_byte_size(max_bytes)) of $(_format_byte_size(original_size)) total]"
 end
 
-@kwarg struct Agent{T<:AgentTool}
+@kwarg struct Agent{T<:AgentTool, H}
     id::Union{Nothing, String} = nothing
     prompt::String
     model::Model
     apikey::String
     tools::Vector{T} = empty_agent_tools()
-    http_kw::Any = (;)  # HTTP.jl kwargs (retries, retry_delays, etc.)
+    http_kw::H = (;)  # HTTP.jl kwargs (retries, retry_delays, etc.)
 end
 
 with_prompt(agent::Agent, prompt::String) = Agent(

--- a/Agentif/src/channels.jl
+++ b/Agentif/src/channels.jl
@@ -153,7 +153,7 @@ Used by group chat prompts to let the agent stay silent when it has nothing to a
 const NO_REPLY_SENTINEL = '∅'
 
 function channel_middleware(agent_handler::AgentHandler, ch::Union{Nothing, AbstractChannel})
-    return function (f, agent::Agent, state::AgentState, current_input::AgentTurnInput, abort::Abort; kw...)
+    return function (f::F, agent::Agent, state::AgentState, current_input::AgentTurnInput, abort::Abort; kw...) where {F <: Function}
         ch === nothing && return agent_handler(f, agent, state, current_input, abort; kw...)
         streaming = false
         suppressed = false

--- a/Agentif/src/channels.jl
+++ b/Agentif/src/channels.jl
@@ -131,7 +131,7 @@ Return platform-specific tools for the current channel (e.g. emoji reactions).
 Channel extensions should specialize this for their channel types.
 Default: empty vector.
 """
-create_channel_tools(::AbstractChannel) = AgentTool[]
+create_channel_tools(::AbstractChannel) = empty_agent_tools()
 
 const CURRENT_CHANNEL = ScopedValue{Union{AbstractChannel, Nothing}}(nothing)
 

--- a/Agentif/src/compaction.jl
+++ b/Agentif/src/compaction.jl
@@ -263,8 +263,8 @@ is needed. On the first call (no previous usage data), compaction is skipped.
 function compaction_middleware(agent_handler::AgentHandler, config::CompactionConfig)
     last_input_tokens = Ref(0)
 
-    return function (f, agent::Agent, state::AgentState, current_input::AgentTurnInput, abort::Abort;
-            model::Union{Nothing, Model} = nothing, kw...)
+    return function (f::F, agent::Agent, state::AgentState, current_input::AgentTurnInput, abort::Abort;
+            model::Union{Nothing, Model} = nothing, kw...) where {F <: Function}
         if !config.enabled
             return agent_handler(f, agent, state, current_input, abort; model, kw...)
         end

--- a/Agentif/src/compaction.jl
+++ b/Agentif/src/compaction.jl
@@ -165,10 +165,10 @@ end
 Use the agent's model to generate a structured summary of discarded messages.
 """
 function generate_summary(
-        agent::Agent, to_discard::Vector{AgentMessage},
+        agent::Agent{T}, to_discard::Vector{AgentMessage},
         existing_summary::Union{Nothing, CompactionSummaryMessage},
         config::CompactionConfig, model::Model,
-    )
+    ) where {T<:AgentTool}
     prompt = if existing_summary !== nothing
         replace(COMPACTION_UPDATE_PROMPT, "%s" => existing_summary.summary)
     else
@@ -178,7 +178,7 @@ function generate_summary(
     conversation_text = format_messages_for_summary(to_discard)
     summary_input = "Summarize this conversation:\n\n$conversation_text"
 
-    summary_agent = Agent(; prompt, model, apikey = agent.apikey, tools = AgentTool[])
+    summary_agent = Agent(; prompt, model, apikey = agent.apikey, tools = T[])
     result = stream(identity, summary_agent, AgentState(), summary_input, Abort())
     return message_text(last_assistant_message(result))
 end

--- a/Agentif/src/compaction.jl
+++ b/Agentif/src/compaction.jl
@@ -120,7 +120,9 @@ function find_cut_point(messages::Vector{StoredAgentMessage}, keep_recent_tokens
             # Valid cut point if the previous message is NOT an AssistantMessage
             # with pending tool calls (i.e., we're not between a tool call and
             # its results).
-            if i == 1 || !(messages[i-1] isa AssistantMessage && !isempty(messages[i-1].tool_calls))
+            previous = i == 1 ? nothing : messages[i - 1]
+            if previous === nothing ||
+                    !(previous isa AssistantMessage && !isempty(previous.tool_calls))
                 return i
             end
         end
@@ -130,7 +132,7 @@ function find_cut_point(messages::Vector{StoredAgentMessage}, keep_recent_tokens
 end
 
 find_cut_point(messages::Vector{AgentMessage}, keep_recent_tokens::Int) =
-    find_cut_point(StoredAgentMessage[messages...], keep_recent_tokens)
+    find_cut_point(stored_agent_messages(messages), keep_recent_tokens)
 
 """
     format_messages_for_summary(messages::Vector{<:AgentMessage}) -> String
@@ -163,7 +165,7 @@ function format_messages_for_summary(messages::Vector{StoredAgentMessage})
 end
 
 format_messages_for_summary(messages::Vector{AgentMessage}) =
-    format_messages_for_summary(StoredAgentMessage[messages...])
+    format_messages_for_summary(stored_agent_messages(messages))
 
 """
     generate_summary(agent, to_discard, existing_summary, config, model) -> String
@@ -219,7 +221,10 @@ function compact!(agent::Agent, state::AgentState, config::CompactionConfig, mod
         return
     end
 
-    tokens_before = sum(estimate_message_tokens(m) for m in to_discard)
+    tokens_before = 0
+    for message in to_discard
+        tokens_before += estimate_message_tokens(message)
+    end
     if existing_summary !== nothing
         tokens_before += existing_summary.tokens_before
     end

--- a/Agentif/src/compaction.jl
+++ b/Agentif/src/compaction.jl
@@ -165,10 +165,10 @@ end
 Use the agent's model to generate a structured summary of discarded messages.
 """
 function generate_summary(
-        agent::Agent{T}, to_discard::Vector{AgentMessage},
+        agent::Agent, to_discard::Vector{AgentMessage},
         existing_summary::Union{Nothing, CompactionSummaryMessage},
         config::CompactionConfig, model::Model,
-    ) where {T<:AgentTool}
+    )
     prompt = if existing_summary !== nothing
         replace(COMPACTION_UPDATE_PROMPT, "%s" => existing_summary.summary)
     else
@@ -178,7 +178,8 @@ function generate_summary(
     conversation_text = format_messages_for_summary(to_discard)
     summary_input = "Summarize this conversation:\n\n$conversation_text"
 
-    summary_agent = Agent(; prompt, model, apikey = agent.apikey, tools = T[])
+    summary_agent = Agent(;
+        prompt, model, apikey = agent.apikey, tools = empty_agent_tools())
     result = stream(identity, summary_agent, AgentState(), summary_input, Abort())
     return message_text(last_assistant_message(result))
 end

--- a/Agentif/src/compaction.jl
+++ b/Agentif/src/compaction.jl
@@ -82,7 +82,7 @@ function estimate_message_tokens(msg::AgentMessage)
 end
 
 """
-    find_cut_point(messages::Vector{AgentMessage}, keep_recent_tokens::Int) -> Int
+    find_cut_point(messages::Vector{<:AgentMessage}, keep_recent_tokens::Int) -> Int
 
 Walk backwards from the end of messages, accumulating token estimates.
 Returns the index of the first message to KEEP (messages[1:idx-1] get compacted).
@@ -92,7 +92,7 @@ AssistantMessage that is not preceded by an unresolved tool call. This avoids
 splitting tool-call/result pairs while still allowing compaction in long
 tool-call loops that have no intermediate UserMessages.
 """
-function find_cut_point(messages::Vector{AgentMessage}, keep_recent_tokens::Int)
+function find_cut_point(messages::Vector{StoredAgentMessage}, keep_recent_tokens::Int)
     length(messages) <= 1 && return 0
 
     accumulated = 0
@@ -129,12 +129,15 @@ function find_cut_point(messages::Vector{AgentMessage}, keep_recent_tokens::Int)
     return 0  # no valid cut point found
 end
 
+find_cut_point(messages::Vector{AgentMessage}, keep_recent_tokens::Int) =
+    find_cut_point(StoredAgentMessage[messages...], keep_recent_tokens)
+
 """
-    format_messages_for_summary(messages::Vector{AgentMessage}) -> String
+    format_messages_for_summary(messages::Vector{<:AgentMessage}) -> String
 
 Format discarded messages as readable text for the summarization prompt.
 """
-function format_messages_for_summary(messages::Vector{AgentMessage})
+function format_messages_for_summary(messages::Vector{StoredAgentMessage})
     parts = String[]
     for msg in messages
         if msg isa UserMessage
@@ -159,13 +162,16 @@ function format_messages_for_summary(messages::Vector{AgentMessage})
     return join(parts, "\n\n")
 end
 
+format_messages_for_summary(messages::Vector{AgentMessage}) =
+    format_messages_for_summary(StoredAgentMessage[messages...])
+
 """
     generate_summary(agent, to_discard, existing_summary, config, model) -> String
 
 Use the agent's model to generate a structured summary of discarded messages.
 """
 function generate_summary(
-        agent::Agent, to_discard::Vector{AgentMessage},
+        agent::Agent, to_discard::Vector{StoredAgentMessage},
         existing_summary::Union{Nothing, CompactionSummaryMessage},
         config::CompactionConfig, model::Model,
     )

--- a/Agentif/src/compaction.jl
+++ b/Agentif/src/compaction.jl
@@ -187,7 +187,13 @@ function generate_summary(
     summary_input = "Summarize this conversation:\n\n$conversation_text"
 
     summary_agent = Agent(;
-        prompt, model, apikey = agent.apikey, tools = empty_agent_tools())
+        prompt,
+        model,
+        apikey = agent.apikey,
+        tools = empty_agent_tools(),
+        http_kw = agent.http_kw,
+        api = agent.api,
+    )
     result = stream(identity, summary_agent, AgentState(), summary_input, Abort())
     return message_text(last_assistant_message(result))
 end

--- a/Agentif/src/compaction.jl
+++ b/Agentif/src/compaction.jl
@@ -192,7 +192,7 @@ function generate_summary(
         apikey = agent.apikey,
         tools = empty_agent_tools(),
         http_kw = agent.http_kw,
-        api = agent.api,
+        api = Val(Symbol(model.api)),
     )
     result = stream(identity, summary_agent, AgentState(), summary_input, Abort())
     return message_text(last_assistant_message(result))

--- a/Agentif/src/input_guardrail.jl
+++ b/Agentif/src/input_guardrail.jl
@@ -66,7 +66,7 @@ function materialize_guardrail_agent(agent::Agent, guardrail::InputGuardrailAgen
         prompt = guardrail.prompt,
         model = model === nothing ? agent.model : model,
         apikey = apikey === nothing ? agent.apikey : apikey,
-        tools = AgentTool[],
+        tools = empty_agent_tools(),
         http_kw = agent.http_kw,
     )
 end

--- a/Agentif/src/logging_config.jl
+++ b/Agentif/src/logging_config.jl
@@ -85,6 +85,15 @@ end
 function provider_tool_result_output(result::ToolResultMessage)
     output = message_text(result)
     result.is_error || return output
+    if TRIMMED_BUILD
+        return JSON.json((
+            ok = false,
+            tool_error = true,
+            tool = result.name,
+            call_id = result.call_id,
+            message = output,
+        ))
+    end
     parsed_output = try
         JSON.parse(output)
     catch

--- a/Agentif/src/logging_config.jl
+++ b/Agentif/src/logging_config.jl
@@ -51,6 +51,17 @@ function render_tool_error_json(
         raw_arguments::Union{Nothing, String} = nothing,
         extra = Dict{String, Any}(),
     )
+    if TRIMMED_BUILD
+        return JSON.json((
+            ok = false,
+            error_kind,
+            message,
+            tool,
+            call_id,
+            suggested_fix,
+            raw_arguments,
+        ))
+    end
     payload = JSON.Object(
         "ok" => false,
         "error_kind" => error_kind,

--- a/Agentif/src/logging_config.jl
+++ b/Agentif/src/logging_config.jl
@@ -16,7 +16,7 @@ function resolve_log_level(level::Union{Nothing, LogLevel, Int, Symbol, Abstract
     return parsed
 end
 
-function with_log_level(f::Function, level::Union{Nothing, LogLevel, Int, Symbol, AbstractString} = nothing)
+function with_log_level(f::F, level::Union{Nothing, LogLevel, Int, Symbol, AbstractString} = nothing) where {F <: Function}
     resolved = resolve_log_level(level)
     resolved === nothing && return f()
     return LoggingExtras.withlevel(f, resolved)

--- a/Agentif/src/messages.jl
+++ b/Agentif/src/messages.jl
@@ -64,6 +64,13 @@ end
     compacted_at::Float64
 end
 
+const StoredAgentMessage = Union{
+    UserMessage,
+    AssistantMessage,
+    ToolResultMessage,
+    CompactionSummaryMessage,
+}
+
 const AGENT_MESSAGE_TYPE_USER = "user"
 const AGENT_MESSAGE_TYPE_ASSISTANT = "assistant"
 const AGENT_MESSAGE_TYPE_TOOL_RESULT = "tool_result"
@@ -231,6 +238,14 @@ function StructUtils.make(st::StructUtils.StructStyle, ::Type{Union{TextContent,
     return StructUtils.make(st, ContentBlock, source)
 end
 
+function StructUtils.make(st::StructUtils.StructStyle, ::Type{StoredAgentMessage}, source, tags)
+    return StructUtils.make(st, AgentMessage, source, tags)
+end
+
+function StructUtils.make(st::StructUtils.StructStyle, ::Type{StoredAgentMessage}, source)
+    return StructUtils.make(st, AgentMessage, source)
+end
+
 const AgentTurnInput = Union{String, Vector{ToolResultMessage}, Vector{UserContentBlock}, UserMessage}
 
 function include_in_context(msg::AgentMessage)
@@ -255,7 +270,7 @@ function add_usage!(base::Usage, delta::Usage)
 end
 
 @kwarg mutable struct AgentState
-    messages::Vector{AgentMessage} = AgentMessage[]
+    messages::Vector{StoredAgentMessage} = StoredAgentMessage[]
     response_id::Union{Nothing, String} = nothing
     usage::Usage = Usage()
     pending_tool_calls::Vector{PendingToolCall} = PendingToolCall[]

--- a/Agentif/src/messages.jl
+++ b/Agentif/src/messages.jl
@@ -30,7 +30,7 @@ end
     type::String = "toolCall"
     id::String
     name::String
-    arguments::Dict{String, Any}
+    arguments::ToolArguments
     thoughtSignature::Union{Nothing, String} = nothing
 end
 

--- a/Agentif/src/messages.jl
+++ b/Agentif/src/messages.jl
@@ -71,6 +71,17 @@ const StoredAgentMessage = Union{
     CompactionSummaryMessage,
 }
 
+function stored_agent_messages(messages::Vector{AgentMessage})
+    stored = StoredAgentMessage[]
+    sizehint!(stored, length(messages))
+    for message in messages
+        message isa StoredAgentMessage ||
+            throw(ArgumentError("Unsupported agent message type: $(typeof(message))."))
+        push!(stored, message)
+    end
+    return stored
+end
+
 const AGENT_MESSAGE_TYPE_USER = "user"
 const AGENT_MESSAGE_TYPE_ASSISTANT = "assistant"
 const AGENT_MESSAGE_TYPE_TOOL_RESULT = "tool_result"

--- a/Agentif/src/middleware.jl
+++ b/Agentif/src/middleware.jl
@@ -328,29 +328,29 @@ function build_default_handler(
         skill_registry::Union{Nothing, SkillRegistry} = nothing,
         channel::Union{Nothing, AbstractChannel} = nothing,
     )
-    handler = base_handler
-    if compaction_config !== nothing
-        handler = compaction_middleware(handler, compaction_config)
-    end
-    handler = steer_middleware(handler, steer_queue)
-    handler = channel_middleware(handler, channel)
-    handler = tool_call_middleware(handler)
+    compaction_handler = compaction_config === nothing ?
+        base_handler : compaction_middleware(base_handler, compaction_config)
+    steer_handler = steer_middleware(compaction_handler, steer_queue)
+    channel_handler = channel_middleware(steer_handler, channel)
+    tool_handler = tool_call_middleware(channel_handler)
     # Inject channel-specific tools (e.g. emoji reactions) outside the tool_call
     # loop so that findtool can resolve them when the model calls them.
-    if channel !== nothing
+    channel_tools_handler = if channel === nothing
+        tool_handler
+    else
         ch_tools = create_channel_tools(channel)
-        if !isempty(ch_tools)
-            inner_handler = handler
-            handler = (f, agent::Agent, state::AgentState, current_input::AgentTurnInput, abort::Abort; kw...) ->
-                inner_handler(f, with_tools(agent, vcat(agent.tools, ch_tools)), state, current_input, abort; kw...)
+        if isempty(ch_tools)
+            tool_handler
+        else
+            (f, agent::Agent, state::AgentState, current_input::AgentTurnInput, abort::Abort; kw...) ->
+                tool_handler(f, with_tools(agent, vcat(agent.tools, ch_tools)), state, current_input, abort; kw...)
         end
     end
-    handler = session_middleware(handler, session_store; channel)
-    handler = input_guardrail_middleware(handler, input_guardrail)
-    handler = skills_middleware(handler, skill_registry)
-    handler = evaluate_middleware(handler)
-    handler = queue_middleware(handler, message_queue)
-    return handler
+    session_handler = session_middleware(channel_tools_handler, session_store; channel)
+    guardrail_handler = input_guardrail_middleware(session_handler, input_guardrail)
+    skills_handler = skills_middleware(guardrail_handler, skill_registry)
+    evaluate_handler = evaluate_middleware(skills_handler)
+    return queue_middleware(evaluate_handler, message_queue)
 end
 
 evaluate(
@@ -379,11 +379,9 @@ function evaluate(
         level::Union{Nothing, LogLevel, Int, Symbol, AbstractString} = nothing,
         kw...,
     )
-    if repeat_input && input isa String
-        input = input * "\n\n" * input
-    end
+    current_input = repeat_input && input isa String ? input * "\n\n" * input : input
     handler = build_default_handler(; base_handler, compaction_config, steer_queue, message_queue, session_store, input_guardrail, skill_registry, channel)
     return with_log_level(level) do
-        handler(f, agent, state, input, abort; kw...)
+        handler(f, agent, state, current_input, abort; kw...)
     end
 end

--- a/Agentif/src/middleware.jl
+++ b/Agentif/src/middleware.jl
@@ -346,7 +346,9 @@ function build_default_handler(
                 tool_handler(f, with_tools(agent, vcat(agent.tools, ch_tools)), state, current_input, abort; kw...)
         end
     end
-    session_handler = session_middleware(channel_tools_handler, session_store; channel)
+    session_handler = session_store === nothing ?
+        channel_tools_handler :
+        session_middleware(channel_tools_handler, session_store; channel)
     guardrail_handler = input_guardrail_middleware(session_handler, input_guardrail)
     skills_handler = skills_middleware(guardrail_handler, skill_registry)
     evaluate_handler = evaluate_middleware(skills_handler)

--- a/Agentif/src/middleware.jl
+++ b/Agentif/src/middleware.jl
@@ -7,7 +7,7 @@ function drain_channel!(channel::Channel{AgentTurnInput})
 end
 
 function steer_middleware(agent_handler::AgentHandler, steer_queue::Union{Nothing, Channel{AgentTurnInput}})
-    return function (f, agent::Agent, state::AgentState, current_input::AgentTurnInput, abort::Abort; kw...)
+    return function (f::F, agent::Agent, state::AgentState, current_input::AgentTurnInput, abort::Abort; kw...) where {F <: Function}
         steer_queue === nothing && return agent_handler(f, agent, state, current_input, abort; kw...)
         isready(steer_queue) || return agent_handler(f, agent, state, current_input, abort; kw...)
         steer_inputs = drain_channel!(steer_queue)
@@ -23,7 +23,7 @@ function steer_middleware(agent_handler::AgentHandler, steer_queue::Union{Nothin
 end
 
 function tool_call_middleware(agent_handler::AgentHandler)
-    return function (f, agent::Agent, state::AgentState, current_input::AgentTurnInput, abort::Abort; kw...)
+    return function (f::F, agent::Agent, state::AgentState, current_input::AgentTurnInput, abort::Abort; kw...) where {F <: Function}
         next_input = current_input
         current_state = state
         futures = Future{ToolResultMessage}[]
@@ -69,7 +69,7 @@ function tool_call_middleware(agent_handler::AgentHandler)
 end
 
 function queue_middleware(agent_handler::AgentHandler, message_queue::Union{Nothing, Channel{AgentTurnInput}})
-    return function (f, agent::Agent, state::AgentState, current_input::AgentTurnInput, abort::Abort; kw...)
+    return function (f::F, agent::Agent, state::AgentState, current_input::AgentTurnInput, abort::Abort; kw...) where {F <: Function}
         current_state = agent_handler(f, agent, state, current_input, abort; kw...)
         check_abort(abort)
         message_queue === nothing && return current_state
@@ -83,7 +83,7 @@ function queue_middleware(agent_handler::AgentHandler, message_queue::Union{Noth
 end
 
 function evaluate_middleware(agent_handler::AgentHandler)
-    return function (f, agent::Agent, state::AgentState, current_input::AgentTurnInput, abort::Abort; kw...)
+    return function (f::F, agent::Agent, state::AgentState, current_input::AgentTurnInput, abort::Abort; kw...) where {F <: Function}
         evaluate_id = UID8()
         @debug "Agent evaluate started" evaluate_id model = agent.model.id tool_count = length(agent.tools) input_type = string(typeof(current_input))
         f(AgentEvaluateStartEvent(evaluate_id))
@@ -182,7 +182,7 @@ end
 
 function session_middleware(agent_handler::AgentHandler, store::Union{Nothing, SessionStore}; channel::Union{Nothing, AbstractChannel} = nothing)
     search_tool = store === nothing ? nothing : _create_search_session_tool(store)
-    return function (f, agent::Agent, state::AgentState, current_input::AgentTurnInput, abort::Abort; kw...)
+    return function (f::F, agent::Agent, state::AgentState, current_input::AgentTurnInput, abort::Abort; kw...) where {F <: Function}
         store === nothing && return agent_handler(f, agent, state, current_input, abort; kw...)
         current_channel = channel === nothing ? CURRENT_CHANNEL[] : channel
         current_channel === nothing && return agent_handler(f, agent, state, current_input, abort; kw...)
@@ -283,7 +283,7 @@ function guardrail_input_text(input::AgentTurnInput)
 end
 
 function input_guardrail_middleware(agent_handler::AgentHandler, guardrail::Union{Nothing, Bool, Function})
-    return function (f, agent::Agent, state::AgentState, current_input::AgentTurnInput, abort::Abort; input_guardrail_model::Union{Nothing, Model} = nothing, input_guardrail_apikey::Union{Nothing, String} = nothing, kw...)
+    return function (f::F, agent::Agent, state::AgentState, current_input::AgentTurnInput, abort::Abort; input_guardrail_model::Union{Nothing, Model} = nothing, input_guardrail_apikey::Union{Nothing, String} = nothing, kw...) where {F <: Function}
         (guardrail === nothing || guardrail === false) && return agent_handler(f, agent, state, current_input, abort; kw...)
         text = guardrail_input_text(current_input)
         text === nothing && return agent_handler(f, agent, state, current_input, abort; kw...)
@@ -309,7 +309,7 @@ function input_guardrail_middleware(agent_handler::AgentHandler, guardrail::Unio
 end
 
 function skills_middleware(agent_handler::AgentHandler, registry::Union{Nothing, SkillRegistry}; include_location::Bool = true)
-    return function (f, agent::Agent, state::AgentState, current_input::AgentTurnInput, abort::Abort; kw...)
+    return function (f::F, agent::Agent, state::AgentState, current_input::AgentTurnInput, abort::Abort; kw...) where {F <: Function}
         registry === nothing && return agent_handler(f, agent, state, current_input, abort; kw...)
         isempty(registry.skills) && return agent_handler(f, agent, state, current_input, abort; kw...)
         prompt = append_available_skills(agent.prompt, values(registry.skills); include_location)
@@ -342,8 +342,9 @@ function build_default_handler(
         if isempty(ch_tools)
             tool_handler
         else
-            (f, agent::Agent, state::AgentState, current_input::AgentTurnInput, abort::Abort; kw...) ->
-                tool_handler(f, with_tools(agent, vcat(agent.tools, ch_tools)), state, current_input, abort; kw...)
+            function (f::F, agent::Agent, state::AgentState, current_input::AgentTurnInput, abort::Abort; kw...) where {F <: Function}
+                return tool_handler(f, with_tools(agent, vcat(agent.tools, ch_tools)), state, current_input, abort; kw...)
+            end
         end
     end
     session_handler = session_store === nothing ?

--- a/Agentif/src/middleware.jl
+++ b/Agentif/src/middleware.jl
@@ -364,7 +364,7 @@ evaluate(
 ) = evaluate(identity, agent, input; abort, level, kw...)
 
 function evaluate(
-        f::Function,
+        f::F,
         agent::Agent,
         input::AgentTurnInput;
         state::AgentState = AgentState(),
@@ -380,7 +380,7 @@ function evaluate(
         repeat_input::Bool = false,
         level::Union{Nothing, LogLevel, Int, Symbol, AbstractString} = nothing,
         kw...,
-    )
+    ) where {F <: Function}
     current_input = repeat_input && input isa String ? input * "\n\n" * input : input
     handler = build_default_handler(; base_handler, compaction_config, steer_queue, message_queue, session_store, input_guardrail, skill_registry, channel)
     return with_log_level(level) do

--- a/Agentif/src/output_guardrail.jl
+++ b/Agentif/src/output_guardrail.jl
@@ -60,7 +60,7 @@ function materialize_output_guardrail_agent(agent::Agent, guardrail::OutputGuard
         prompt = guardrail.prompt,
         model = model === nothing ? agent.model : model,
         apikey = apikey === nothing ? agent.apikey : apikey,
-        tools = AgentTool[],
+        tools = empty_agent_tools(),
         http_kw = agent.http_kw,
     )
 end

--- a/Agentif/src/providers/anthropic_messages_adapter.jl
+++ b/Agentif/src/providers/anthropic_messages_adapter.jl
@@ -51,8 +51,8 @@ function anthropic_tool_result_block(result::ToolResultMessage)
     )
 end
 
-function anthropic_insert_missing_tool_results(messages::Vector{AgentMessage})
-    normalized = AgentMessage[]
+function anthropic_insert_missing_tool_results(messages::Vector{StoredAgentMessage})
+    normalized = StoredAgentMessage[]
     pending = ToolCallContent[]
     resolved = Set{String}()
     function flush_pending!()
@@ -181,7 +181,7 @@ function anthropic_message_from_agent(msg::AgentMessage, tool_name_map::Dict{Str
 end
 
 function anthropic_build_messages(agent::Agent, state::AgentState, input::AgentTurnInput, tool_name_map::Dict{String, String}, model::Model)
-    context = AgentMessage[]
+    context = StoredAgentMessage[]
     for msg in state.messages
         include_in_context(msg) || continue
         push!(context, msg)

--- a/Agentif/src/providers/anthropic_messages_adapter.jl
+++ b/Agentif/src/providers/anthropic_messages_adapter.jl
@@ -244,7 +244,7 @@ function anthropic_stop_reason(reason::Union{Nothing, String}, tool_calls::Vecto
 end
 
 function anthropic_event_callback(
-        f::Function,
+        f::F,
         agent::Agent,
         assistant_message::AssistantMessage,
         started::Base.RefValue{Bool},
@@ -255,7 +255,7 @@ function anthropic_event_callback(
         partial_json_by_index::Dict{Int, String},
         tool_name_reverse_map::Dict{String, String},
         abort::Abort,
-    )
+    ) where {F <: Function}
     stop_on_tool_call = get(ENV, "AGENTIF_STOP_ON_TOOL_CALL", "") != ""
     return function (stream, event)
         maybe_abort!(abort, stream)

--- a/Agentif/src/providers/anthropic_messages_adapter.jl
+++ b/Agentif/src/providers/anthropic_messages_adapter.jl
@@ -1,4 +1,5 @@
-function anthropic_build_tools(tools::Vector{AgentTool}, tool_name_map::Dict{String, String})
+function anthropic_build_tools(
+        tools::Vector{<:AgentTool}, tool_name_map::Dict{String, String})
     isempty(tools) && return nothing
     provider_tools = AnthropicMessages.Tool[]
     for tool in tools
@@ -92,7 +93,7 @@ function anthropic_insert_missing_tool_results(messages::Vector{StoredAgentMessa
     return normalized
 end
 
-function anthropic_tool_name_maps(tools::Vector{AgentTool}, is_oauth::Bool)
+function anthropic_tool_name_maps(tools::Vector{<:AgentTool}, is_oauth::Bool)
     tool_name_map = Dict{String, String}()
     tool_name_reverse_map = Dict{String, String}()
     is_oauth || return tool_name_map, tool_name_reverse_map

--- a/Agentif/src/providers/google_gemini_cli_adapter.jl
+++ b/Agentif/src/providers/google_gemini_cli_adapter.jl
@@ -12,7 +12,7 @@ function google_gemini_cli_build_tools(tools::Vector{AgentTool})
 end
 
 function google_gemini_cli_build_contents(agent::Agent, state::AgentState, input::AgentTurnInput, model::Model)
-    context = AgentMessage[]
+    context = StoredAgentMessage[]
     for msg in state.messages
         include_in_context(msg) || continue
         push!(context, msg)

--- a/Agentif/src/providers/google_gemini_cli_adapter.jl
+++ b/Agentif/src/providers/google_gemini_cli_adapter.jl
@@ -165,7 +165,7 @@ function google_gemini_cli_stop_reason(reason::Union{Nothing, String}, tool_call
 end
 
 function google_gemini_cli_event_callback(
-        f::Function,
+        f::F,
         agent::Agent,
         assistant_message::AssistantMessage,
         started::Base.RefValue{Bool},
@@ -175,7 +175,7 @@ function google_gemini_cli_event_callback(
         seen_call_ids::Set{String},
         debug_stream::Bool,
         abort::Abort,
-    )
+    ) where {F <: Function}
     return function (stream, event)
         maybe_abort!(abort, stream)
         data = String(event.data)

--- a/Agentif/src/providers/google_gemini_cli_adapter.jl
+++ b/Agentif/src/providers/google_gemini_cli_adapter.jl
@@ -1,4 +1,4 @@
-function google_gemini_cli_build_tools(tools::Vector{AgentTool})
+function google_gemini_cli_build_tools(tools::Vector{<:AgentTool})
     isempty(tools) && return nothing
     decls = GoogleGeminiCli.FunctionDeclaration[]
     for tool in tools

--- a/Agentif/src/providers/google_generative_adapter.jl
+++ b/Agentif/src/providers/google_generative_adapter.jl
@@ -162,7 +162,7 @@ function google_generative_stop_reason(reason::Union{Nothing, String}, tool_call
 end
 
 function google_generative_event_callback(
-        f::Function,
+        f::F,
         agent::Agent,
         assistant_message::AssistantMessage,
         started::Base.RefValue{Bool},
@@ -171,7 +171,7 @@ function google_generative_event_callback(
         latest_finish::Base.RefValue{Union{Nothing, String}},
         seen_call_ids::Set{String},
         abort::Abort,
-    )
+    ) where {F <: Function}
     return function (stream, event)
         maybe_abort!(abort, stream)
         data = String(event.data)

--- a/Agentif/src/providers/google_generative_adapter.jl
+++ b/Agentif/src/providers/google_generative_adapter.jl
@@ -12,7 +12,7 @@ function google_generative_build_tools(tools::Vector{AgentTool})
 end
 
 function google_generative_build_contents(agent::Agent, state::AgentState, input::AgentTurnInput, model::Model)
-    context = AgentMessage[]
+    context = StoredAgentMessage[]
     for msg in state.messages
         include_in_context(msg) || continue
         push!(context, msg)

--- a/Agentif/src/providers/google_generative_adapter.jl
+++ b/Agentif/src/providers/google_generative_adapter.jl
@@ -1,4 +1,4 @@
-function google_generative_build_tools(tools::Vector{AgentTool})
+function google_generative_build_tools(tools::Vector{<:AgentTool})
     isempty(tools) && return nothing
     decls = GoogleGenerativeAI.FunctionDeclaration[]
     for tool in tools

--- a/Agentif/src/providers/openai_codex.jl
+++ b/Agentif/src/providers/openai_codex.jl
@@ -403,7 +403,7 @@ function codex_stop_reason(status::Union{Nothing, String}, tool_calls::Vector{Ag
 end
 
 function openai_codex_event_callback(
-        f::Function,
+        f::F,
         agent::Agent,
         assistant_message::AssistantMessage,
         started::Base.RefValue{Bool},
@@ -412,7 +412,7 @@ function openai_codex_event_callback(
         response_status::Base.RefValue{Union{Nothing, String}},
         tool_call_accumulators::Dict{String, ToolCallAccumulator},
         abort::Abort,
-    )
+    ) where {F <: Function}
     ensure_started() = begin
         if !started[]
             started[] = true

--- a/Agentif/src/providers/openai_codex.jl
+++ b/Agentif/src/providers/openai_codex.jl
@@ -25,6 +25,10 @@ const CODEX_DEFAULT_RETRY_BASE_MS = 1000
 const CODEX_DEFAULT_RETRY_MAX_MS = 60000
 const CODEX_RETRYABLE_ERROR_REGEX = r"rate.?limit|overloaded|service.?unavailable|upstream.?connect|connection.?refused|connection.?reset|reset.?before.?headers|terminated|temporar"i
 
+@kwarg struct CodexAuthClaims
+    chatgpt_account_id::Union{Nothing, String} = nothing
+end
+
 function resolve_codex_url(base_url::AbstractString)
     raw = strip(String(base_url))
     raw = isempty(raw) ? CODEX_BASE_URL : raw
@@ -110,6 +114,77 @@ function codex_retry_settings!(kw::Dict{Symbol, Any})
     return (; max_retries, retry_base_ms, retry_max_ms)
 end
 
+function trimmed_codex_options(kw::NamedTuple)
+    account_id = if hasproperty(kw, :account_id)
+        string(getproperty(kw, :account_id))
+    elseif hasproperty(kw, :accountId)
+        string(getproperty(kw, :accountId))
+    else
+        nothing
+    end
+    session_id = if hasproperty(kw, :session_id)
+        string(getproperty(kw, :session_id))
+    elseif hasproperty(kw, :sessionId)
+        string(getproperty(kw, :sessionId))
+    else
+        nothing
+    end
+    reasoning_effort = if hasproperty(kw, :reasoning_effort)
+        string(getproperty(kw, :reasoning_effort))
+    elseif hasproperty(kw, :reasoningEffort)
+        string(getproperty(kw, :reasoningEffort))
+    elseif hasproperty(kw, :reasoning)
+        string(getproperty(kw, :reasoning))
+    else
+        nothing
+    end
+    reasoning_summary = if hasproperty(kw, :reasoning_summary)
+        string(getproperty(kw, :reasoning_summary))
+    elseif hasproperty(kw, :reasoningSummary)
+        string(getproperty(kw, :reasoningSummary))
+    else
+        nothing
+    end
+    text_verbosity = if hasproperty(kw, :text_verbosity)
+        string(getproperty(kw, :text_verbosity))
+    elseif hasproperty(kw, :textVerbosity)
+        string(getproperty(kw, :textVerbosity))
+    else
+        nothing
+    end
+    transport_value = if hasproperty(kw, :transport)
+        getproperty(kw, :transport)
+    elseif hasproperty(kw, :transportMode)
+        getproperty(kw, :transportMode)
+    elseif hasproperty(kw, :websocket)
+        getproperty(kw, :websocket)
+    elseif hasproperty(kw, :websockets)
+        getproperty(kw, :websockets)
+    else
+        nothing
+    end
+    transport = normalize_codex_transport(transport_value)
+    retry_settings = (
+        max_retries = codex_env_int(
+            "AGENTIF_CODEX_MAX_RETRIES", CODEX_DEFAULT_MAX_RETRIES),
+        retry_base_ms = codex_env_int(
+            "AGENTIF_CODEX_RETRY_BASE_MS", CODEX_DEFAULT_RETRY_BASE_MS),
+        retry_max_ms = codex_env_int(
+            "AGENTIF_CODEX_RETRY_MAX_MS", CODEX_DEFAULT_RETRY_MAX_MS),
+    )
+    return (;
+        account_id,
+        session_id,
+        reasoning_effort,
+        reasoning_summary,
+        text_verbosity,
+        include_opt = nothing,
+        max_tokens = nothing,
+        transport,
+        retry_settings,
+    )
+end
+
 function build_codex_tools(tools::Vector{AgentTool})
     isempty(tools) && return nothing
     provider_tools = Vector{Dict{String, Any}}()
@@ -151,11 +226,15 @@ function codex_account_id_from_access_token(access_token::AbstractString)
     parts = split(String(access_token), ".")
     length(parts) == 3 || return nothing
     try
-        payload = JSON.parse(Vector{UInt8}(codeunits(decode_base64url(parts[2]))))
-        auth_claims = get(() -> nothing, payload, CODEX_JWT_CLAIM_PATH)
-        auth_claims isa AbstractDict || return nothing
-        account_id = get(() -> nothing, auth_claims, "chatgpt_account_id")
-        return (account_id isa AbstractString && !isempty(account_id)) ? String(account_id) : nothing
+        payload = JSON.parse(
+            Vector{UInt8}(codeunits(decode_base64url(parts[2]))),
+            Dict{String, JSON.JSONText},
+        )
+        auth_json = get(payload, CODEX_JWT_CLAIM_PATH, nothing)
+        auth_json === nothing && return nothing
+        auth_claims = JSON.parse(auth_json.value, CodexAuthClaims)
+        account_id = auth_claims.chatgpt_account_id
+        return (account_id !== nothing && !isempty(account_id)) ? account_id : nothing
     catch
         return nothing
     end

--- a/Agentif/src/providers/openai_codex.jl
+++ b/Agentif/src/providers/openai_codex.jl
@@ -50,8 +50,14 @@ end
 function normalize_codex_transport(value)::Symbol
     value === nothing && return :sse
     value isa Bool && return value ? :websocket : :sse
-
-    text = lowercase(strip(string(value)))
+    text = if value isa Symbol
+        String(value)
+    elseif value isa AbstractString
+        String(value)
+    else
+        throw(ArgumentError("Unsupported codex transport value type: $(typeof(value))."))
+    end
+    text = lowercase(strip(text))
     text in ("", "sse") && return :sse
     text in ("ws", "websocket") && return :websocket
     text == "auto" && return :auto

--- a/Agentif/src/providers/openai_codex.jl
+++ b/Agentif/src/providers/openai_codex.jl
@@ -114,41 +114,44 @@ function codex_retry_settings!(kw::Dict{Symbol, Any})
     return (; max_retries, retry_base_ms, retry_max_ms)
 end
 
+codex_optional_string(value)::Union{Nothing, String} =
+    value === nothing ? nothing : string(value)
+
 function trimmed_codex_options(kw::NamedTuple)
     account_id = if hasproperty(kw, :account_id)
-        string(getproperty(kw, :account_id))
+        codex_optional_string(getproperty(kw, :account_id))
     elseif hasproperty(kw, :accountId)
-        string(getproperty(kw, :accountId))
+        codex_optional_string(getproperty(kw, :accountId))
     else
         nothing
     end
     session_id = if hasproperty(kw, :session_id)
-        string(getproperty(kw, :session_id))
+        codex_optional_string(getproperty(kw, :session_id))
     elseif hasproperty(kw, :sessionId)
-        string(getproperty(kw, :sessionId))
+        codex_optional_string(getproperty(kw, :sessionId))
     else
         nothing
     end
     reasoning_effort = if hasproperty(kw, :reasoning_effort)
-        string(getproperty(kw, :reasoning_effort))
+        codex_optional_string(getproperty(kw, :reasoning_effort))
     elseif hasproperty(kw, :reasoningEffort)
-        string(getproperty(kw, :reasoningEffort))
+        codex_optional_string(getproperty(kw, :reasoningEffort))
     elseif hasproperty(kw, :reasoning)
-        string(getproperty(kw, :reasoning))
+        codex_optional_string(getproperty(kw, :reasoning))
     else
         nothing
     end
     reasoning_summary = if hasproperty(kw, :reasoning_summary)
-        string(getproperty(kw, :reasoning_summary))
+        codex_optional_string(getproperty(kw, :reasoning_summary))
     elseif hasproperty(kw, :reasoningSummary)
-        string(getproperty(kw, :reasoningSummary))
+        codex_optional_string(getproperty(kw, :reasoningSummary))
     else
         nothing
     end
     text_verbosity = if hasproperty(kw, :text_verbosity)
-        string(getproperty(kw, :text_verbosity))
+        codex_optional_string(getproperty(kw, :text_verbosity))
     elseif hasproperty(kw, :textVerbosity)
-        string(getproperty(kw, :textVerbosity))
+        codex_optional_string(getproperty(kw, :textVerbosity))
     else
         nothing
     end
@@ -185,7 +188,7 @@ function trimmed_codex_options(kw::NamedTuple)
     )
 end
 
-function build_codex_tools(tools::Vector{AgentTool})
+function build_codex_tools(tools::Vector{<:AgentTool})
     isempty(tools) && return nothing
     provider_tools = Vector{Dict{String, Any}}()
     for tool in tools
@@ -1122,6 +1125,21 @@ function codex_websocket_pool_key(ws_url::String, headers::Dict{String, String})
     return (ws_url, account, String(session_id))
 end
 
+function codex_websocket_open_kw(http_kw)
+    http_nt = http_kw isa NamedTuple ? http_kw : (; http_kw...)
+    ws_open_kw = Base.structdiff(
+        http_nt,
+        (; retry = nothing, retries = nothing, retry_non_idempotent = nothing),
+    )
+    if isdefined(HTTP.WebSockets, :server_addr) && haskey(ws_open_kw, :readtimeout)
+        readtimeout = ws_open_kw.readtimeout
+        ws_open_kw = Base.structdiff(ws_open_kw, (; readtimeout = nothing))
+        haskey(ws_open_kw, :read_idle_timeout) ||
+            (ws_open_kw = merge(ws_open_kw, (; read_idle_timeout = readtimeout)))
+    end
+    return ws_open_kw
+end
+
 function codex_stream_websocket!(
         callback::Function,
         ws_url::String,
@@ -1130,8 +1148,7 @@ function codex_stream_websocket!(
         abort::Abort;
         http_kw = (;),
     )
-    http_nt = http_kw isa NamedTuple ? http_kw : (; http_kw...)
-    ws_open_kw = merge(http_nt, (; retry = false))
+    ws_open_kw = codex_websocket_open_kw(http_kw)
     ws_headers = create_codex_websocket_headers(headers)
     start_request = copy(request_body)
     start_request["type"] = "response.create"

--- a/Agentif/src/providers/openai_completions_adapter.jl
+++ b/Agentif/src/providers/openai_completions_adapter.jl
@@ -58,7 +58,7 @@ function openai_completions_resolve_compat(model::Model)
     )
 end
 
-function openai_completions_has_tool_history(messages::Vector{AgentMessage})
+function openai_completions_has_tool_history(messages::Vector{StoredAgentMessage})
     for msg in messages
         if msg isa ToolResultMessage
             return true
@@ -169,7 +169,7 @@ end
 
 function openai_completions_build_messages(agent::Agent, state::AgentState, input::AgentTurnInput, model::Model)
     compat = openai_completions_resolve_compat(model)
-    raw_messages = AgentMessage[]
+    raw_messages = StoredAgentMessage[]
     for msg in state.messages
         include_in_context(msg) || continue
         push!(raw_messages, msg)

--- a/Agentif/src/providers/openai_completions_adapter.jl
+++ b/Agentif/src/providers/openai_completions_adapter.jl
@@ -32,23 +32,29 @@ function openai_completions_detect_compat(model::Model)
     )
 end
 
+function openai_completions_compat_value(compat::Dict{String, Any}, key::String, default::T)::T where {T}
+    value = get(compat, key, default)
+    value isa T || throw(ArgumentError("OpenAI compatibility option `$key` must be a $(T)."))
+    return value
+end
+
 function openai_completions_resolve_compat(model::Model)
     detected = openai_completions_detect_compat(model)
     compat = model.compat
     compat === nothing && return detected
     return (;
-        supportsStore = get(() -> detected.supportsStore, compat, "supportsStore"),
-        supportsDeveloperRole = get(() -> detected.supportsDeveloperRole, compat, "supportsDeveloperRole"),
-        supportsReasoningEffort = get(() -> detected.supportsReasoningEffort, compat, "supportsReasoningEffort"),
-        supportsTools = get(() -> detected.supportsTools, compat, "supportsTools"),
-        supportsUsageInStreaming = get(() -> detected.supportsUsageInStreaming, compat, "supportsUsageInStreaming"),
-        maxTokensField = get(() -> detected.maxTokensField, compat, "maxTokensField"),
-        requiresToolResultName = get(() -> detected.requiresToolResultName, compat, "requiresToolResultName"),
-        requiresAssistantAfterToolResult = get(() -> detected.requiresAssistantAfterToolResult, compat, "requiresAssistantAfterToolResult"),
-        requiresThinkingAsText = get(() -> detected.requiresThinkingAsText, compat, "requiresThinkingAsText"),
-        requiresMistralToolIds = get(() -> detected.requiresMistralToolIds, compat, "requiresMistralToolIds"),
-        thinkingFormat = get(() -> detected.thinkingFormat, compat, "thinkingFormat"),
-        stripThinkTags = get(() -> detected.stripThinkTags, compat, "stripThinkTags"),
+        supportsStore = openai_completions_compat_value(compat, "supportsStore", detected.supportsStore),
+        supportsDeveloperRole = openai_completions_compat_value(compat, "supportsDeveloperRole", detected.supportsDeveloperRole),
+        supportsReasoningEffort = openai_completions_compat_value(compat, "supportsReasoningEffort", detected.supportsReasoningEffort),
+        supportsTools = openai_completions_compat_value(compat, "supportsTools", detected.supportsTools),
+        supportsUsageInStreaming = openai_completions_compat_value(compat, "supportsUsageInStreaming", detected.supportsUsageInStreaming),
+        maxTokensField = openai_completions_compat_value(compat, "maxTokensField", detected.maxTokensField),
+        requiresToolResultName = openai_completions_compat_value(compat, "requiresToolResultName", detected.requiresToolResultName),
+        requiresAssistantAfterToolResult = openai_completions_compat_value(compat, "requiresAssistantAfterToolResult", detected.requiresAssistantAfterToolResult),
+        requiresThinkingAsText = openai_completions_compat_value(compat, "requiresThinkingAsText", detected.requiresThinkingAsText),
+        requiresMistralToolIds = openai_completions_compat_value(compat, "requiresMistralToolIds", detected.requiresMistralToolIds),
+        thinkingFormat = openai_completions_compat_value(compat, "thinkingFormat", detected.thinkingFormat),
+        stripThinkTags = openai_completions_compat_value(compat, "stripThinkTags", detected.stripThinkTags),
     )
 end
 

--- a/Agentif/src/providers/openai_completions_adapter.jl
+++ b/Agentif/src/providers/openai_completions_adapter.jl
@@ -517,7 +517,7 @@ function flush_think_tag_state(tts::ThinkTagStreamState)
 end
 
 function openai_completions_event_callback(
-        f::Function,
+        f::F,
         assistant_message::AssistantMessage,
         started::Base.RefValue{Bool},
         ended::Base.RefValue{Bool},
@@ -526,7 +526,7 @@ function openai_completions_event_callback(
         tool_call_accumulators::Dict{Int, ToolCallAccumulator},
         abort::Abort;
         think_tag_state::Union{Nothing, ThinkTagStreamState} = nothing,
-    )
+    ) where {F <: Function}
     reasoning_buffer = ""
     leading_whitespace = ""
     saw_text = false

--- a/Agentif/src/providers/openai_completions_adapter.jl
+++ b/Agentif/src/providers/openai_completions_adapter.jl
@@ -345,14 +345,18 @@ function openai_completions_build_messages(agent::Agent, state::AgentState, inpu
                 if compat.requiresAssistantAfterToolResult
                     push!(messages, OpenAICompletions.Message(; role = "assistant", content = "I have processed the tool results."))
                 end
+                content = OpenAICompletions.ContentPart[
+                    OpenAICompletions.ContentPart(;
+                        type = "text",
+                        text = "Attached image(s) from tool result:",
+                    ),
+                ]
+                append!(content, image_blocks)
                 push!(
                     messages,
                     OpenAICompletions.Message(;
                         role = "user",
-                        content = OpenAICompletions.ContentPart[
-                            OpenAICompletions.ContentPart(; type = "text", text = "Attached image(s) from tool result:"),
-                            image_blocks...,
-                        ],
+                        content,
                     ),
                 )
                 last_role = "user"

--- a/Agentif/src/providers/openai_completions_adapter.jl
+++ b/Agentif/src/providers/openai_completions_adapter.jl
@@ -139,7 +139,8 @@ function openai_completions_append_thinking_with_details!(assistant_message::Ass
     return
 end
 
-function openai_completions_build_tools(tools::Vector{AgentTool}; force_empty::Bool = false)
+function openai_completions_build_tools(
+        tools::Vector{<:AgentTool}; force_empty::Bool = false)
     isempty(tools) && return force_empty ? OpenAICompletions.Tool[] : nothing
     provider_tools = OpenAICompletions.Tool[]
     for tool in tools

--- a/Agentif/src/providers/openai_responses_adapter.jl
+++ b/Agentif/src/providers/openai_responses_adapter.jl
@@ -100,7 +100,7 @@ function openai_responses_normalize_tool_call_id(id::String, model::Model)
 end
 
 function openai_responses_transformed_messages(state::AgentState, input::AgentTurnInput, model::Model)
-    raw_messages = AgentMessage[]
+    raw_messages = StoredAgentMessage[]
     for msg in state.messages
         include_in_context(msg) || continue
         push!(raw_messages, msg)

--- a/Agentif/src/providers/openai_responses_adapter.jl
+++ b/Agentif/src/providers/openai_responses_adapter.jl
@@ -252,7 +252,7 @@ function openai_responses_stop_reason(status::Union{Nothing, String}, tool_calls
 end
 
 function openai_responses_event_callback(
-        f::Function,
+        f::F,
         agent::Agent,
         assistant_message::AssistantMessage,
         started::Base.RefValue{Bool},
@@ -260,7 +260,7 @@ function openai_responses_event_callback(
         response_usage::Base.RefValue{Union{Nothing, OpenAIResponses.Usage}},
         response_status::Base.RefValue{Union{Nothing, String}},
         abort::Abort,
-    )
+    ) where {F <: Function}
     return function (stream, event)
         maybe_abort!(abort, stream)
         data = String(event.data)

--- a/Agentif/src/providers/openai_responses_adapter.jl
+++ b/Agentif/src/providers/openai_responses_adapter.jl
@@ -3,7 +3,7 @@ using JSON
 
 const OPENAI_RESPONSES_TOOL_CALL_PROVIDERS = Set(["openai", "openai-codex", "opencode"])
 
-function openai_responses_build_tools(tools::Vector{AgentTool})
+function openai_responses_build_tools(tools::Vector{<:AgentTool})
     isempty(tools) && return nothing
     provider_tools = OpenAIResponses.Tool[]
     for tool in tools

--- a/Agentif/src/session.jl
+++ b/Agentif/src/session.jl
@@ -4,7 +4,7 @@ abstract type SessionStore end
     id::String
     parent_id::Union{Nothing, String} = nothing
     created_at::Float64 = time()
-    messages::Vector{AgentMessage} = AgentMessage[]
+    messages::Vector{StoredAgentMessage} = StoredAgentMessage[]
     is_compaction::Bool = false
     first_kept_entry_id::Union{Nothing, String} = nothing
     is_deleted::Bool = false

--- a/Agentif/src/session.jl
+++ b/Agentif/src/session.jl
@@ -67,7 +67,7 @@ function set_branch_leaf!(store::InMemorySessionStore, branch_id::String, entry_
     end
 end
 
-function lock_branch(f::Function, store::InMemorySessionStore, branch_id::String)
+function lock_branch(f::F, store::InMemorySessionStore, branch_id::String) where {F <: Function}
     branch_lock = lock(store.lock) do
         get!(store.branch_locks, branch_id) do
             ReentrantLock()

--- a/Agentif/src/stream.jl
+++ b/Agentif/src/stream.jl
@@ -269,9 +269,9 @@ function resolve_oauth_apikey(provider::Symbol, apikey::AbstractString; backend:
 end
 
 function stream(
-        f::Function, agent::Agent, state::AgentState, input::AgentTurnInput, abort::Abort;
+        f::F, agent::Agent, state::AgentState, input::AgentTurnInput, abort::Abort;
         model::Union{Nothing, Model} = nothing, http_kw = (;), kw...
-    )
+    ) where {F <: Function}
     model = model === nothing ? agent.model : model
     model === nothing && throw(ArgumentError("no model specified with which agent can evaluate input"))
 

--- a/Agentif/src/stream.jl
+++ b/Agentif/src/stream.jl
@@ -255,17 +255,24 @@ else
     model_request_kw(model::Model) = model.kw
 end
 
-function resolve_oauth_apikey(provider::Symbol, apikey::AbstractString; backend::AbstractOAuthBackend = OAUTH_BACKEND[])
-    apikey != "OAUTH" && return apikey
-    if provider == :codex
-        token = get_codex_token(backend)
-    elseif provider == :anthropic
-        token = get_anthropic_token(backend)
-    else
-        throw(ArgumentError("Unsupported OAuth provider: $(provider)"))
+if TRIMMED_BUILD
+    function resolve_oauth_apikey(provider::Symbol, apikey::AbstractString)
+        apikey != "OAUTH" && return apikey
+        throw(ArgumentError("OAuth token extensions are unavailable in a trimmed Agentif build for provider $(provider)."))
     end
-    token isa AbstractString && !isempty(token) || throw(ArgumentError("OAuth token provider for $(provider) must return a non-empty String token"))
-    return token
+else
+    function resolve_oauth_apikey(provider::Symbol, apikey::AbstractString; backend::AbstractOAuthBackend = OAUTH_BACKEND[])
+        apikey != "OAUTH" && return apikey
+        if provider == :codex
+            token = get_codex_token(backend)
+        elseif provider == :anthropic
+            token = get_anthropic_token(backend)
+        else
+            throw(ArgumentError("Unsupported OAuth provider: $(provider)"))
+        end
+        token isa AbstractString && !isempty(token) || throw(ArgumentError("OAuth token provider for $(provider) must return a non-empty String token"))
+        return token
+    end
 end
 
 function stream(

--- a/Agentif/src/stream.jl
+++ b/Agentif/src/stream.jl
@@ -1169,7 +1169,7 @@ function stream(
             end
             log_codex_debug(
                 "codex response", Dict(
-                    "url" => resp.request.url,
+                    "url" => url,
                     "status" => resp.status,
                     "content_type" => HTTP.header(resp, "content-type"),
                     "cf_ray" => HTTP.header(resp, "cf-ray"),

--- a/Agentif/src/stream.jl
+++ b/Agentif/src/stream.jl
@@ -461,10 +461,13 @@ function stream(
         end
         reasoning_effort_value = nothing
         if haskey(stream_kw, :reasoning)
-            reasoning_effort_value = stream_kw[:reasoning]
-            stream_kw = Base.structdiff(stream_kw, (; reasoning = nothing))
-            if !haskey(stream_kw, :reasoning_effort)
-                stream_kw = merge(stream_kw, (; reasoning_effort = reasoning_effort_value))
+            reasoning_value = stream_kw[:reasoning]
+            if reasoning_value isa AbstractString || reasoning_value isa Symbol
+                reasoning_effort_value = string(reasoning_value)
+                stream_kw = Base.structdiff(stream_kw, (; reasoning = nothing))
+                if !haskey(stream_kw, :reasoning_effort)
+                    stream_kw = merge(stream_kw, (; reasoning_effort = reasoning_effort_value))
+                end
             end
         end
         if haskey(stream_kw, :reasoning_effort)

--- a/Agentif/src/stream.jl
+++ b/Agentif/src/stream.jl
@@ -46,13 +46,11 @@ end
 
 new_call_id(prefix::String) = string(prefix, "-", string(UID8()))
 
-function parse_tool_arguments(arguments::String)
+function parse_tool_arguments(arguments::String)::ToolArguments
     try
-        parsed = JSON.parse(arguments)
-        parsed isa AbstractDict || return Dict{String, Any}()
-        return Dict{String, Any}(parsed)
+        return JSON.parse(arguments, ToolArguments)
     catch
-        return Dict{String, Any}()
+        return ToolArguments()
     end
 end
 
@@ -76,10 +74,31 @@ function normalize_mistral_tool_id(id::String)
     return normalized
 end
 
+function flush_pending_tool_results!(
+        normalized::Vector{StoredAgentMessage},
+        pending::Vector{ToolCallContent},
+        resolved::Set{String},
+    )
+    isempty(pending) && return
+    for call in pending
+        if !(call.id in resolved)
+            push!(normalized, ToolResultMessage(;
+                call_id = call.id,
+                name = call.name,
+                content = ToolResultContentBlock[TextContent("No result provided")],
+                is_error = true,
+            ))
+        end
+    end
+    empty!(pending)
+    empty!(resolved)
+    return
+end
+
 function transform_messages(
         messages::Vector{StoredAgentMessage}, model::Model;
-        normalize_tool_call_id::Function = identity,
-    )::Vector{StoredAgentMessage}
+        normalize_tool_call_id::F = identity,
+    )::Vector{StoredAgentMessage} where {F}
     tool_call_id_map = Dict{String, String}()
     transformed = StoredAgentMessage[]
     for msg in messages
@@ -132,26 +151,9 @@ function transform_messages(
     pending = ToolCallContent[]
     resolved = Set{String}()
 
-    function flush_pending!()
-        isempty(pending) && return
-        for call in pending
-            if !(call.id in resolved)
-                push!(normalized, ToolResultMessage(;
-                    call_id = call.id,
-                    name = call.name,
-                    content = ToolResultContentBlock[TextContent("No result provided")],
-                    is_error = true,
-                ))
-            end
-        end
-        empty!(pending)
-        empty!(resolved)
-        return
-    end
-
     for msg in transformed
         if msg isa AssistantMessage
-            flush_pending!()
+            flush_pending_tool_results!(normalized, pending, resolved)
             push!(normalized, msg)
             empty!(pending)
             empty!(resolved)
@@ -162,11 +164,11 @@ function transform_messages(
             !isempty(pending) && push!(resolved, msg.call_id)
             push!(normalized, msg)
         else
-            flush_pending!()
+            flush_pending_tool_results!(normalized, pending, resolved)
             push!(normalized, msg)
         end
     end
-    flush_pending!()
+    flush_pending_tool_results!(normalized, pending, resolved)
     return normalized
 end
 
@@ -969,9 +971,16 @@ function stream(
     elseif api isa Val{Symbol("openai-codex-responses")}
         apikey isa AbstractString || throw(ArgumentError("apikey must be a String for provider $(model.provider)"))
         apikey = resolve_oauth_apikey(:codex, apikey)
-        account_id = get(() -> nothing, kw_nt, :account_id)
-        account_id === nothing && (account_id = get(() -> nothing, kw_nt, :accountId))
-        account_id = resolve_codex_account_id(account_id, String(apikey))
+        if TRIMMED_BUILD
+            codex_options = trimmed_codex_options(kw_nt)
+            account_id = resolve_codex_account_id(
+                codex_options.account_id, String(apikey))
+        else
+            account_id = get(() -> nothing, kw_nt, :account_id)
+            account_id === nothing &&
+                (account_id = get(() -> nothing, kw_nt, :accountId))
+            account_id = resolve_codex_account_id(account_id, String(apikey))
+        end
         account_id === nothing && throw(ArgumentError("Missing `account_id` for openai-codex provider and unable to infer it from access token"))
 
         assistant_message = assistant_message_for_model(model; response_id = state.response_id)
@@ -981,27 +990,44 @@ function stream(
         response_status = Ref{Union{Nothing, String}}(nothing)
         tool_call_accumulators = Dict{String, ToolCallAccumulator}()
 
-        codex_kw = Dict{Symbol, Any}(pairs(kw_nt))
-        haskey(codex_kw, :instructions) && delete!(codex_kw, :instructions)
-        haskey(codex_kw, :account_id) && delete!(codex_kw, :account_id)
-        haskey(codex_kw, :accountId) && delete!(codex_kw, :accountId)
+        if TRIMMED_BUILD
+            codex_kw = (;)
+            session_id = codex_options.session_id
+            reasoning_effort = codex_options.reasoning_effort
+            reasoning_summary = codex_options.reasoning_summary
+            text_verbosity = codex_options.text_verbosity
+            include_opt = codex_options.include_opt
+            max_tokens = codex_options.max_tokens
+            transport = codex_options.transport
+            retry_settings = codex_options.retry_settings
+        else
+            codex_kw = Dict{Symbol, Any}(pairs(kw_nt))
+            haskey(codex_kw, :instructions) && delete!(codex_kw, :instructions)
+            haskey(codex_kw, :account_id) && delete!(codex_kw, :account_id)
+            haskey(codex_kw, :accountId) && delete!(codex_kw, :accountId)
 
-        session_id = pop!(codex_kw, :session_id, nothing)
-        session_id === nothing && (session_id = pop!(codex_kw, :sessionId, nothing))
+            session_id = pop!(codex_kw, :session_id, nothing)
+            session_id === nothing &&
+                (session_id = pop!(codex_kw, :sessionId, nothing))
 
-        reasoning_effort = pop!(codex_kw, :reasoning_effort, nothing)
-        reasoning_effort === nothing && (reasoning_effort = pop!(codex_kw, :reasoningEffort, nothing))
-        if reasoning_effort === nothing && haskey(codex_kw, :reasoning)
-            reasoning_effort = pop!(codex_kw, :reasoning, nothing)
+            reasoning_effort = pop!(codex_kw, :reasoning_effort, nothing)
+            reasoning_effort === nothing &&
+                (reasoning_effort = pop!(codex_kw, :reasoningEffort, nothing))
+            if reasoning_effort === nothing && haskey(codex_kw, :reasoning)
+                reasoning_effort = pop!(codex_kw, :reasoning, nothing)
+            end
+            reasoning_summary = pop!(codex_kw, :reasoning_summary, nothing)
+            reasoning_summary === nothing &&
+                (reasoning_summary = pop!(codex_kw, :reasoningSummary, nothing))
+            text_verbosity = pop!(codex_kw, :textVerbosity, nothing)
+            text_verbosity === nothing &&
+                (text_verbosity = pop!(codex_kw, :text_verbosity, nothing))
+            include_opt = pop!(codex_kw, :include, nothing)
+            max_tokens = pop!(codex_kw, :maxTokens, nothing)
+            transport = normalize_codex_transport(codex_pop_option!(
+                codex_kw, :transport, :transportMode, :websocket, :websockets))
+            retry_settings = codex_retry_settings!(codex_kw)
         end
-        reasoning_summary = pop!(codex_kw, :reasoning_summary, nothing)
-        reasoning_summary === nothing && (reasoning_summary = pop!(codex_kw, :reasoningSummary, nothing))
-        text_verbosity = pop!(codex_kw, :textVerbosity, nothing)
-        text_verbosity === nothing && (text_verbosity = pop!(codex_kw, :text_verbosity, nothing))
-        include_opt = pop!(codex_kw, :include, nothing)
-        max_tokens = pop!(codex_kw, :maxTokens, nothing)
-        transport = normalize_codex_transport(codex_pop_option!(codex_kw, :transport, :transportMode, :websocket, :websockets))
-        retry_settings = codex_retry_settings!(codex_kw)
 
         tools = build_codex_tools(agent.tools)
         current_input = codex_build_input(agent, state, input, model)
@@ -1025,8 +1051,10 @@ function stream(
                 request_body[string(k)] = v
             end
         end
-        for (k, v) in codex_kw
-            request_body[string(k)] = v
+        if !TRIMMED_BUILD
+            for (k, v) in codex_kw
+                request_body[string(k)] = v
+            end
         end
 
         transform_request_body!(

--- a/Agentif/src/stream.jl
+++ b/Agentif/src/stream.jl
@@ -76,7 +76,10 @@ function normalize_mistral_tool_id(id::String)
     return normalized
 end
 
-function transform_messages(messages::Vector{AgentMessage}, model::Model; normalize_tool_call_id::Function = identity)
+function transform_messages(
+        messages::Vector{AgentMessage}, model::Model;
+        normalize_tool_call_id::Function = identity,
+    )::Vector{AgentMessage}
     tool_call_id_map = Dict{String, String}()
     transformed = AgentMessage[]
     for msg in messages
@@ -246,6 +249,12 @@ const OAUTH_BACKEND = Ref{AbstractOAuthBackend}(MissingOAuthBackend())
 get_codex_token(::AbstractOAuthBackend) = throw(ArgumentError("Codex OAuth token provider unavailable; load `LLMOAuth` and run `LLMOAuth.codex_login()` first, or pass an explicit `apikey`"))
 get_anthropic_token(::AbstractOAuthBackend) = throw(ArgumentError("Anthropic OAuth token provider unavailable; load `LLMOAuth` and run `LLMOAuth.anthropic_login()` first, or pass an explicit `apikey`"))
 
+if TRIMMED_BUILD
+    model_request_kw(::Model) = (;)
+else
+    model_request_kw(model::Model) = model.kw
+end
+
 function resolve_oauth_apikey(provider::Symbol, apikey::AbstractString; backend::AbstractOAuthBackend = OAUTH_BACKEND[])
     apikey != "OAUTH" && return apikey
     if provider == :codex
@@ -337,7 +346,7 @@ function stream(
         prompt_cache_retention !== nothing && (body["prompt_cache_retention"] = prompt_cache_retention)
 
         # Pass through model.kw (temperature, max_output_tokens, etc.)
-        for (k, v) in pairs(model.kw)
+        for (k, v) in pairs(model_request_kw(model))
             k_str = string(k)
             # Skip fields we already set or that don't belong in the body
             k_str in ("api", "provider", "baseUrl", "reasoning", "input", "cost", "contextWindow", "maxTokens", "headers", "compat", "name", "id") && continue
@@ -503,7 +512,7 @@ function stream(
             ; model = model.id,
             messages,
             stream = use_stream,
-            model.kw...,
+            model_request_kw(model)...,
             request_kw...,
         )
         headers = Dict(
@@ -695,7 +704,7 @@ function stream(
             messages,
             max_tokens,
             stream = !disable_streaming,
-            model.kw...,
+            model_request_kw(model)...,
             request_kw...,
         )
         headers = Dict(
@@ -832,7 +841,7 @@ function stream(
         request_kw = merge((; tools, systemInstruction = system_instruction), stream_kw)
         req = GoogleGenerativeAI.Request(
             ; contents,
-            model.kw...,
+            model_request_kw(model)...,
             request_kw...,
         )
         headers = Dict(
@@ -1002,8 +1011,9 @@ function stream(
         session_id !== nothing && (request_body["prompt_cache_key"] = session_id)
         max_tokens !== nothing && (request_body["max_output_tokens"] = max_tokens)
 
-        if model.kw !== nothing
-            for (k, v) in pairs(model.kw)
+        provider_kw = model_request_kw(model)
+        if provider_kw !== nothing
+            for (k, v) in pairs(provider_kw)
                 request_body[string(k)] = v
             end
         end

--- a/Agentif/src/stream.jl
+++ b/Agentif/src/stream.jl
@@ -77,11 +77,11 @@ function normalize_mistral_tool_id(id::String)
 end
 
 function transform_messages(
-        messages::Vector{AgentMessage}, model::Model;
+        messages::Vector{StoredAgentMessage}, model::Model;
         normalize_tool_call_id::Function = identity,
-    )::Vector{AgentMessage}
+    )::Vector{StoredAgentMessage}
     tool_call_id_map = Dict{String, String}()
-    transformed = AgentMessage[]
+    transformed = StoredAgentMessage[]
     for msg in messages
         if msg isa CompactionSummaryMessage
             push!(transformed, msg)
@@ -128,7 +128,7 @@ function transform_messages(
         end
     end
 
-    normalized = AgentMessage[]
+    normalized = StoredAgentMessage[]
     pending = ToolCallContent[]
     resolved = Set{String}()
 
@@ -279,6 +279,7 @@ function stream(
         f::F, agent::Agent, state::AgentState, input::AgentTurnInput, abort::Abort;
         model::Union{Nothing, Model} = nothing, http_kw = (;), kw...
     ) where {F <: Function}
+    api = model === nothing ? agent.api : Val(Symbol(model.api))
     model = model === nothing ? agent.model : model
     model === nothing && throw(ArgumentError("no model specified with which agent can evaluate input"))
 
@@ -296,7 +297,7 @@ function stream(
     end
     apikey = apikey_override === nothing ? agent.apikey : apikey_override
 
-    if model.api == "openai-responses"
+    if api isa Val{Symbol("openai-responses")}
         apikey isa AbstractString || throw(ArgumentError("apikey must be a String for provider $(model.provider)"))
         assistant_message = assistant_message_for_model(model; response_id = state.response_id)
         started = Ref(false)
@@ -438,7 +439,7 @@ function stream(
         stop_reason = openai_responses_stop_reason(response_status[], assistant_message.tool_calls)
         isaborted(abort) && (stop_reason = :aborted)
         return finalize_stream!(state, input, assistant_message, usage, stop_reason)
-    elseif model.api == "openai-completions"
+    elseif api isa Val{Symbol("openai-completions")}
         apikey isa AbstractString || throw(ArgumentError("apikey must be a String for provider $(model.provider)"))
         compat = openai_completions_resolve_compat(model)
         messages, has_tool_history = openai_completions_build_messages(agent, state, input, model)
@@ -661,7 +662,7 @@ function stream(
         stop_reason = openai_completions_stop_reason(latest_finish[], assistant_message.tool_calls)
         isaborted(abort) && (stop_reason = :aborted)
         return finalize_stream!(state, input, assistant_message, usage, stop_reason)
-    elseif model.api == "anthropic-messages"
+    elseif api isa Val{Symbol("anthropic-messages")}
         apikey isa AbstractString || throw(ArgumentError("apikey must be a String for provider $(model.provider)"))
         apikey = resolve_oauth_apikey(:anthropic, apikey)
         is_oauth = startswith(apikey, "sk-ant-oat")
@@ -831,7 +832,7 @@ function stream(
             isaborted(abort) && (final_stop = :aborted)
             return finalize_stream!(state, input, assistant_message, usage, final_stop)
         end
-    elseif model.api == "google-generative-ai"
+    elseif api isa Val{Symbol("google-generative-ai")}
         apikey isa AbstractString || throw(ArgumentError("apikey must be a String for provider $(model.provider)"))
         tools = google_generative_build_tools(agent.tools)
         contents = google_generative_build_contents(agent, state, input, model)
@@ -890,7 +891,7 @@ function stream(
         stop_reason = google_generative_stop_reason(latest_finish[], assistant_message.tool_calls)
         isaborted(abort) && (stop_reason = :aborted)
         return finalize_stream!(state, input, assistant_message, usage, stop_reason)
-    elseif model.api == "google-gemini-cli"
+    elseif api isa Val{Symbol("google-gemini-cli")}
         apikey isa AbstractString || throw(ArgumentError("apikey must be a String for provider $(model.provider)"))
         tools = google_gemini_cli_build_tools(agent.tools)
         contents = google_gemini_cli_build_contents(agent, state, input, model)
@@ -965,7 +966,7 @@ function stream(
         stop_reason = google_gemini_cli_stop_reason(latest_finish[], assistant_message.tool_calls)
         isaborted(abort) && (stop_reason = :aborted)
         return finalize_stream!(state, input, assistant_message, usage, stop_reason)
-    elseif model.api == "openai-codex-responses"
+    elseif api isa Val{Symbol("openai-codex-responses")}
         apikey isa AbstractString || throw(ArgumentError("apikey must be a String for provider $(model.provider)"))
         apikey = resolve_oauth_apikey(:codex, apikey)
         account_id = get(() -> nothing, kw_nt, :account_id)

--- a/Agentif/src/tools.jl
+++ b/Agentif/src/tools.jl
@@ -9,6 +9,9 @@ parameters(::AgentTool{F, T}) where {F, T} = T
 tool_name(tool::AgentTool) = tool.name
 tool_name(name::AbstractString) = String(name)
 
+const EmptyAgentTool = AgentTool{typeof(identity), @NamedTuple{}}
+empty_agent_tools() = EmptyAgentTool[]
+
 @kwarg mutable struct PendingToolCall
     const call_id::String
     const name::String

--- a/Agentif/src/util.jl
+++ b/Agentif/src/util.jl
@@ -4,8 +4,8 @@ if TRIMMED_BUILD
     caught_exception(::Any, message::String)::ErrorException = ErrorException(message)
     caught_exception_message(::Any, message::String)::String = message
     caught_backtrace() = nothing
-    capture_caught_exception(::Any)::CapturedException =
-        capture(ErrorException("Asynchronous agent operation failed."))
+    capture_caught_exception(::Any)::ErrorException =
+        ErrorException("Asynchronous agent operation failed.")
 else
     caught_exception(value, message::String)::Exception =
         value isa Exception ? value : ErrorException(message)

--- a/Agentif/src/util.jl
+++ b/Agentif/src/util.jl
@@ -1,3 +1,21 @@
+const TRIMMED_BUILD = get(ENV, "LE_TRIMMED_BUILD", "") == "1"
+
+if TRIMMED_BUILD
+    caught_exception(::Any, message::String)::ErrorException = ErrorException(message)
+    caught_exception_message(::Any, message::String)::String = message
+    caught_backtrace() = nothing
+    capture_caught_exception(::Any)::CapturedException =
+        capture(ErrorException("Asynchronous agent operation failed."))
+else
+    caught_exception(value, message::String)::Exception =
+        value isa Exception ? value : ErrorException(message)
+    caught_exception_message(value, message::String)::String =
+        value isa Exception ? sprint(showerror, value) : message
+    caught_backtrace() = Base.catch_backtrace()
+    capture_caught_exception(value)::CapturedException =
+        capture(caught_exception(value, "Asynchronous agent operation failed."))
+end
+
 mutable struct Future{T}
     const notify::Threads.Condition
     @atomic set::Int8 # if 0, result is undefined, 1 means result is T, 2 means result is an exception
@@ -15,7 +33,7 @@ function Future{T}(f) where {T}
     Threads.@spawn try
         notify(fut, f())
     catch e
-        notify(fut, capture(e))
+        notify(fut, capture_caught_exception(e))
     end
     return fut
 end

--- a/Agentif/src/util.jl
+++ b/Agentif/src/util.jl
@@ -1,4 +1,6 @@
 const TRIMMED_BUILD = get(ENV, "LE_TRIMMED_BUILD", "") == "1"
+const ToolArguments =
+    TRIMMED_BUILD ? Dict{String, JSON.JSONText} : Dict{String, Any}
 
 if TRIMMED_BUILD
     caught_exception(::Any, message::String)::ErrorException = ErrorException(message)

--- a/Agentif/test/runtests.jl
+++ b/Agentif/test/runtests.jl
@@ -295,6 +295,17 @@ end
         return state
     end
     agent = make_agent()
+    handler = @inferred Agentif.build_default_handler(;
+        base_handler,
+        compaction_config = nothing,
+        steer_queue = nothing,
+        message_queue = nothing,
+        session_store = nothing,
+        input_guardrail = nothing,
+        skill_registry = nothing,
+        channel = nothing,
+    )
+    @test handler isa Function
     state = Agentif.evaluate(identity, agent, "hello"; base_handler, level = :debug)
     @test state isa AgentState
     @test observed_kw[] !== nothing

--- a/Agentif/test/runtests.jl
+++ b/Agentif/test/runtests.jl
@@ -8,6 +8,7 @@ using LLMProviders
 using LLMOAuth
 using LocalSearch
 using SQLite
+using Sockets
 
 function dummy_model()
     return Model(
@@ -40,6 +41,21 @@ function make_agent(; prompt = "test prompt", tools = AgentTool[])
         apikey = "test-key",
         tools = tools,
     )
+end
+
+function test_server_port(server)
+    if applicable(HTTP.port, server)
+        port = HTTP.port(server)
+        port != 0 && return port
+    end
+    if hasproperty(server, :listener) && hasproperty(server.listener, :server)
+        return Sockets.getsockname(server.listener.server)[2]
+    end
+    return parse(Int, last(rsplit(HTTP.WebSockets.server_addr(server), ':'; limit = 2)))
+end
+
+function test_websocket_request(ws)
+    return hasproperty(ws, :handshake_request) ? ws.handshake_request : ws.request
 end
 
 function fake_jwt(payload::AbstractDict)
@@ -122,6 +138,22 @@ Agentif.close_channel(ch::StreamTestChannel) = (ch.closed += 1)
     agent = make_agent(; tools = [tool])
     @test eltype(agent.tools) === typeof(tool)
     @test @inferred(Agentif.findtool(agent.tools, "echo_text")) === tool
+    default_agent = Agent(
+        id = "default-tools",
+        prompt = "test",
+        model = dummy_model(),
+        apikey = "test-key",
+    )
+    @test Agentif.openai_responses_build_tools(default_agent.tools) === nothing
+    @test Agentif.openai_completions_build_tools(default_agent.tools) === nothing
+    @test Agentif.build_codex_tools(default_agent.tools) === nothing
+    @test Agentif.google_generative_build_tools(default_agent.tools) === nothing
+    @test Agentif.google_gemini_cli_build_tools(default_agent.tools) === nothing
+    tool_name_map, tool_name_reverse_map =
+        Agentif.anthropic_tool_name_maps(default_agent.tools, true)
+    @test isempty(tool_name_map)
+    @test isempty(tool_name_reverse_map)
+    @test Agentif.anthropic_build_tools(default_agent.tools, tool_name_map) === nothing
     pending = Agentif.PendingToolCall(; call_id = "call-1", name = "echo_pending", arguments = "{}")
     @test tool_name(pending) == "echo_pending"
     @test tool_name("literal-name") == "literal-name"
@@ -863,6 +895,78 @@ end
         # state.usage.input should now be 5000+10000=15000
     end
 
+    @testset "compaction summary uses override model API" begin
+        request_target = Ref("")
+        server = HTTP.serve!("127.0.0.1", 0) do req
+            request_target[] = string(req.target)
+            if endswith(request_target[], "/chat/completions")
+                sse = join([
+                    "data: {\"id\":\"summary-1\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"summary\"},\"finish_reason\":null}]}",
+                    "data: {\"id\":\"summary-1\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}",
+                    "data: [DONE]",
+                ], "\n\n") * "\n\n"
+                return HTTP.Response(
+                    200, ["Content-Type" => "text/event-stream"], sse)
+            end
+            return HTTP.Response(400, "wrong provider API")
+        end
+
+        try
+            port = test_server_port(server)
+            summary_model = Model(
+                id = "summary-model",
+                name = "summary-model",
+                api = "openai-completions",
+                provider = "test",
+                baseUrl = "http://127.0.0.1:$port/v1",
+                reasoning = false,
+                input = ["text"],
+                cost = Dict(
+                    "input" => 0.0,
+                    "output" => 0.0,
+                    "cacheRead" => 0.0,
+                    "cacheWrite" => 0.0,
+                ),
+                contextWindow = 100000,
+                maxTokens = 4096,
+            )
+            source_model = Model(
+                id = "source-model",
+                name = "source-model",
+                api = "openai-responses",
+                provider = "test",
+                baseUrl = "http://127.0.0.1:$port/v1",
+                reasoning = false,
+                input = ["text"],
+                cost = Dict(
+                    "input" => 0.0,
+                    "output" => 0.0,
+                    "cacheRead" => 0.0,
+                    "cacheWrite" => 0.0,
+                ),
+                contextWindow = 100000,
+                maxTokens = 4096,
+            )
+            agent = Agent(
+                id = "source-agent",
+                prompt = "test",
+                model = source_model,
+                apikey = "test-key",
+            )
+            summary = Agentif.generate_summary(
+                agent,
+                Agentif.StoredAgentMessage[UserMessage("old context")],
+                nothing,
+                CompactionConfig(),
+                summary_model,
+            )
+            @test summary == "summary"
+            @test endswith(request_target[], "/chat/completions")
+        finally
+            close(server)
+        end
+    end
+
     @testset "CompactionConfig defaults" begin
         config = CompactionConfig()
         @test config.enabled == true
@@ -939,6 +1043,19 @@ end
     @test Agentif.normalize_codex_transport("auto") == :auto
     @test Agentif.normalize_codex_transport(true) == :websocket
     @test_throws ArgumentError Agentif.normalize_codex_transport("bogus")
+
+    empty_options = Agentif.trimmed_codex_options((
+        account_id = nothing,
+        sessionId = nothing,
+        reasoning = nothing,
+        reasoningSummary = nothing,
+        textVerbosity = nothing,
+    ))
+    @test empty_options.account_id === nothing
+    @test empty_options.session_id === nothing
+    @test empty_options.reasoning_effort === nothing
+    @test empty_options.reasoning_summary === nothing
+    @test empty_options.text_verbosity === nothing
 end
 
 @testset "oauth apikey resolution" begin
@@ -1082,7 +1199,7 @@ end
     seen_events = Agentif.AgentEvent[]
 
     server = HTTP.serve!("127.0.0.1", 0) do req
-        request_body[] = JSON.parse(req.body)
+        request_body[] = JSON.parse(String(req.body))
         sse = join([
             "data: {\"type\":\"response.output_item.added\",\"item\":{\"type\":\"message\",\"id\":\"msg_1\",\"role\":\"assistant\",\"content\":[]}}",
             "data: {\"type\":\"response.output_text.delta\",\"delta\":\"Partial\"}",
@@ -1093,8 +1210,7 @@ end
     end
 
     try
-        sock = HTTP.Sockets.getsockname(server.listener.server)
-        port = sock[2]
+        port = test_server_port(server)
         model = Model(
             id = "gpt-5.2",
             name = "gpt-5.2",
@@ -1117,7 +1233,8 @@ end
 
         result = stream(ev -> (push!(seen_events, ev); ev), agent, AgentState(), "Say hello", Abort(); sessionId = "sess-42")
         @test result.most_recent_stop_reason == :length
-        @test !any(ev -> ev isa Agentif.AgentErrorEvent, seen_events)
+        errors = [sprint(showerror, ev.error) for ev in seen_events if ev isa Agentif.AgentErrorEvent]
+        @test errors == String[]
         @test get(() -> nothing, request_body[], "prompt_cache_key") == "sess-42"
         @test !haskey(request_body[], "sessionId")
         input_items = get(() -> Any[], request_body[], "input")
@@ -1145,8 +1262,7 @@ end
     end
 
     try
-        sock = HTTP.Sockets.getsockname(server.listener.server)
-        port = sock[2]
+        port = test_server_port(server)
         model = Model(
             id = "gpt-5.2-codex",
             name = "gpt-5.2-codex",
@@ -1181,8 +1297,8 @@ end
     request_body = Ref(Dict{String, Any}())
 
     server = HTTP.serve!("127.0.0.1", 0) do req
-        request_headers[] = Dict{String, String}(String(k) => String(v) for (k, v) in req.headers)
-        request_body[] = JSON.parse(req.body)
+        request_headers[] = Dict{String, String}(lowercase(String(k)) => String(v) for (k, v) in req.headers)
+        request_body[] = JSON.parse(String(req.body))
         sse = join([
             "data: {\"type\":\"response.output_item.added\",\"item\":{\"type\":\"message\",\"id\":\"msg_1\",\"role\":\"assistant\",\"content\":[]}}",
             "data: {\"type\":\"response.output_text.delta\",\"delta\":\"Hello\"}",
@@ -1194,8 +1310,7 @@ end
     end
 
     try
-        sock = HTTP.Sockets.getsockname(server.listener.server)
-        port = sock[2]
+        port = test_server_port(server)
         model = Model(
             id = "gpt-5.3-codex-spark",
             name = "gpt-5.3-codex-spark",
@@ -1256,8 +1371,7 @@ end
     end
 
     try
-        sock = HTTP.Sockets.getsockname(server.listener.server)
-        port = sock[2]
+        port = test_server_port(server)
         model = Model(
             id = "gpt-5.3-codex",
             name = "gpt-5.3-codex",
@@ -1320,8 +1434,7 @@ end
     end
 
     try
-        sock = HTTP.Sockets.getsockname(server.listener.server)
-        port = sock[2]
+        port = test_server_port(server)
         model = Model(
             id = "gpt-5.3-codex",
             name = "gpt-5.3-codex",
@@ -1359,7 +1472,8 @@ end
     request_body = Ref(Dict{String, Any}())
 
     ws_server = HTTP.WebSockets.listen!("127.0.0.1", 0) do ws
-        request_headers[] = Dict{String, String}(lowercase(String(k)) => String(v) for (k, v) in ws.request.headers)
+        request = test_websocket_request(ws)
+        request_headers[] = Dict{String, String}(lowercase(String(k)) => String(v) for (k, v) in request.headers)
         msg = HTTP.WebSockets.receive(ws)
         data = msg isa AbstractString ? String(msg) : String(msg)
         request_body[] = JSON.parse(data)
@@ -1376,8 +1490,7 @@ end
     end
 
     try
-        sock = HTTP.Sockets.getsockname(ws_server.listener.server)
-        port = sock[2]
+        port = test_server_port(ws_server)
         model = Model(
             id = "gpt-5.3-codex",
             name = "gpt-5.3-codex",
@@ -1423,7 +1536,8 @@ end
 
     ws_server = HTTP.WebSockets.listen!("127.0.0.1", 0) do ws
         connection_count[] += 1
-        headers = Dict{String, String}(lowercase(String(k)) => String(v) for (k, v) in ws.request.headers)
+        request = test_websocket_request(ws)
+        headers = Dict{String, String}(lowercase(String(k)) => String(v) for (k, v) in request.headers)
         push!(seen_session_headers, get(() -> "", headers, "session_id"))
         try
             while true
@@ -1462,8 +1576,7 @@ end
     end
 
     try
-        sock = HTTP.Sockets.getsockname(ws_server.listener.server)
-        port = sock[2]
+        port = test_server_port(ws_server)
         model = Model(
             id = "gpt-5.3-codex",
             name = "gpt-5.3-codex",

--- a/Agentif/test/runtests.jl
+++ b/Agentif/test/runtests.jl
@@ -119,6 +119,9 @@ Agentif.close_channel(ch::StreamTestChannel) = (ch.closed += 1)
 @testset "public API bindings" begin
     tool = @tool "Echo text." echo_text(text::String) = text
     @test tool_name(tool) == "echo_text"
+    agent = make_agent(; tools = [tool])
+    @test eltype(agent.tools) === typeof(tool)
+    @test @inferred(Agentif.findtool(agent.tools, "echo_text")) === tool
     pending = Agentif.PendingToolCall(; call_id = "call-1", name = "echo_pending", arguments = "{}")
     @test tool_name(pending) == "echo_pending"
     @test tool_name("literal-name") == "literal-name"

--- a/LLMOAuth/Project.toml
+++ b/LLMOAuth/Project.toml
@@ -13,9 +13,9 @@ OAuth = "22d8b318-f366-56fb-a292-a93f7d76c017"
 OAuth = {url = "https://github.com/JuliaServices/OAuth.jl.git", rev = "main"}
 
 [compat]
-HTTP = "1"
+HTTP = "1, 2"
 JSON = "1.3"
-OAuth = "1"
+OAuth = "1, 2"
 julia = "1.6"
 
 [extras]

--- a/LLMOAuth/Project.toml
+++ b/LLMOAuth/Project.toml
@@ -15,7 +15,7 @@ OAuth = {url = "https://github.com/JuliaServices/OAuth.jl.git", rev = "main"}
 [compat]
 HTTP = "1, 2"
 JSON = "1.3"
-OAuth = "1, 2"
+OAuth = "1, 2, 3"
 julia = "1.6"
 
 [extras]

--- a/LLMProviders/Project.toml
+++ b/LLMProviders/Project.toml
@@ -11,12 +11,12 @@ StructUtils = "ec057cc2-7a8d-4b58-b3b3-92acb9f63b42"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [sources]
-JSONSchema = {url = "https://github.com/JuliaIO/JSONSchema.jl.git"}
+JSONSchema = {url = "https://github.com/JuliaIO/JSONSchema.jl.git", rev = "4076c12e69f8191b611580744c42579f95e92974"}
 
 [compat]
 HTTP = "1, 2"
 JSON = "1.3"
-JSONSchema = "1.6, 2"
+JSONSchema = "1.6"
 Logging = "1.11"
 StructUtils = "2.6"
 UUIDs = "1.11.0"

--- a/LLMProviders/Project.toml
+++ b/LLMProviders/Project.toml
@@ -14,9 +14,9 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 JSONSchema = {url = "https://github.com/JuliaIO/JSONSchema.jl.git"}
 
 [compat]
-HTTP = "1"
+HTTP = "1, 2"
 JSON = "1.3"
-JSONSchema = "2"
+JSONSchema = "1.6, 2"
 Logging = "1.11"
 StructUtils = "2.6"
 UUIDs = "1.11.0"

--- a/LLMProviders/src/providers/anthropic_messages.jl
+++ b/LLMProviders/src/providers/anthropic_messages.jl
@@ -42,7 +42,7 @@ end
     type::String = "tool_use"
     id::String
     name::String
-    input::Any
+    input::Dict{String, Any}
 end
 
 const ToolResultContentBlock = Union{TextBlock, ImageBlock}
@@ -173,7 +173,7 @@ end
 
 @omit_null @kwarg struct StreamMessageDeltaEvent
     type::String = "message_delta"
-    delta::Any = nothing
+    delta::Union{Nothing, Dict{String, Any}} = nothing
     usage::Union{Nothing, Usage} = nothing
 end
 
@@ -183,7 +183,7 @@ end
 
 @omit_null @kwarg struct StreamErrorEvent
     type::String = "error"
-    error::Any = nothing
+    error::Union{Nothing, Dict{String, Any}} = nothing
 end
 
 const StreamEvent = Union{

--- a/LLMProviders/src/providers/anthropic_messages.jl
+++ b/LLMProviders/src/providers/anthropic_messages.jl
@@ -78,10 +78,10 @@ end
     content::Union{String, Vector{ContentBlock}} & (json = (choosetype = x -> x[] isa String ? String : Vector{ContentBlock},),)
 end
 
-@omit_null @kwarg struct Tool{T}
+@omit_null @kwarg struct Tool
     name::String
     description::Union{Nothing, String} = nothing
-    input_schema::JSONSchema.Schema{T}
+    input_schema::JSONSchema.Schema
 end
 
 

--- a/LLMProviders/src/providers/google_gemini_cli.jl
+++ b/LLMProviders/src/providers/google_gemini_cli.jl
@@ -69,7 +69,7 @@ end
 @omit_null @kwarg struct FunctionCall
     id::Union{Nothing, String} = nothing
     name::Union{Nothing, String} = nothing
-    args::Union{Nothing, Any} = nothing
+    args::Union{Nothing, Dict{String, Any}} = nothing
 end
 
 @omit_null @kwarg struct InlineData

--- a/LLMProviders/src/providers/google_generative_ai.jl
+++ b/LLMProviders/src/providers/google_generative_ai.jl
@@ -68,7 +68,7 @@ end
 @omit_null @kwarg struct FunctionCall
     id::Union{Nothing, String} = nothing
     name::Union{Nothing, String} = nothing
-    args::Union{Nothing, Any} = nothing
+    args::Union{Nothing, Dict{String, Any}} = nothing
 end
 
 @omit_null @kwarg struct InlineData

--- a/LLMProviders/src/providers/openai_completions.jl
+++ b/LLMProviders/src/providers/openai_completions.jl
@@ -5,16 +5,16 @@ using StructUtils, JSON, JSONSchema
 
 schema(::Type{T}) where {T} = JSONSchema.schema(T; all_fields_required = false, additionalProperties = false)
 
-@omit_null @kwarg struct ToolFunction{T}
+@omit_null @kwarg struct ToolFunction
     name::String
     description::Union{Nothing, String} = nothing
-    parameters::JSONSchema.Schema{T}
+    parameters::JSONSchema.Schema
     strict::Union{Nothing, Bool} = nothing
 end
 
-@omit_null @kwarg struct FunctionTool{T}
+@omit_null @kwarg struct FunctionTool
     type::String = "function"
-    var"function"::ToolFunction{T}
+    var"function"::ToolFunction
 end
 
 const Tool = Union{FunctionTool}

--- a/LLMProviders/src/providers/openai_completions.jl
+++ b/LLMProviders/src/providers/openai_completions.jl
@@ -159,6 +159,7 @@ end
     top_p::Union{Nothing, Float64} = nothing
     stop::Union{Nothing, Union{String, Vector{String}}} = nothing
     parallel_tool_calls::Union{Nothing, Bool} = nothing
+    provider::Union{Nothing, Any} = nothing
 end
 
 end # module OpenAICompletions

--- a/LLMProviders/src/providers/openai_completions.jl
+++ b/LLMProviders/src/providers/openai_completions.jl
@@ -150,6 +150,7 @@ end
     tool_choice::Union{Nothing, Any} = nothing
     store::Union{Nothing, Bool} = nothing
     stream_options::Union{Nothing, Any} = nothing
+    reasoning::Union{Nothing, Any} = nothing
     reasoning_effort::Union{Nothing, String} = nothing
     thinking::Union{Nothing, Any} = nothing
     reasoning_split::Union{Nothing, Bool} = nothing

--- a/LLMProviders/src/providers/openai_responses.jl
+++ b/LLMProviders/src/providers/openai_responses.jl
@@ -18,9 +18,9 @@ function schema(::Type{T}) where {T}
     sch = JSONSchema.schema(T; all_fields_required = true, additionalProperties = false)
     required = _required_field_names(T)
     if isempty(required)
-        haskey(sch.spec, "required") && delete!(sch.spec, "required")
+        haskey(sch.data, "required") && delete!(sch.data, "required")
     else
-        sch.spec["required"] = required
+        sch.data["required"] = required
     end
     return sch
 end
@@ -211,7 +211,7 @@ end
     type::String = "text"
 end
 
-@omit_null @kwarg struct TextFormatJSONSchema{T}
+@omit_null @kwarg struct TextFormatJSONSchema
     type::String = "json_schema"
     name::String
     description::Union{Nothing, String} = nothing
@@ -219,7 +219,7 @@ end
     # non-nullable fields marked required.
     # allOf, not, dependentRequired, dependentSchemas, if, then, else are not supported
     # root schema must be an object
-    schema::JSONSchema.Schema{T}
+    schema::JSONSchema.Schema
     strict::Union{Nothing, Bool} = nothing
 end
 
@@ -247,12 +247,12 @@ end
     verbosity::Union{Nothing, String} = nothing # low, medium, high
 end
 
-@omit_null @kwarg struct FunctionTool{T}
+@omit_null @kwarg struct FunctionTool
     name::String
     strict::Bool = true
     type::String = "function"
     description::Union{Nothing, String} = nothing
-    parameters::JSONSchema.Schema{T}
+    parameters::JSONSchema.Schema
 end
 
 

--- a/LLMProviders/src/providers/openai_responses.jl
+++ b/LLMProviders/src/providers/openai_responses.jl
@@ -17,10 +17,11 @@ end
 function schema(::Type{T}) where {T}
     sch = JSONSchema.schema(T; all_fields_required = true, additionalProperties = false)
     required = _required_field_names(T)
+    data = JSONSchema.spec(sch)
     if isempty(required)
-        haskey(sch.data, "required") && delete!(sch.data, "required")
+        haskey(data, "required") && delete!(data, "required")
     else
-        sch.data["required"] = required
+        data["required"] = required
     end
     return sch
 end

--- a/LLMProviders/test/runtests.jl
+++ b/LLMProviders/test/runtests.jl
@@ -49,6 +49,16 @@ end
     parsed = JSON.parse(JSON.json(chunk), OpenAICompletions.StreamChunk)
     @test parsed.choices[1].delta.tool_calls[1].var"function".name == "read"
 
+    req = OpenAICompletions.Request(
+        ; model = "openrouter-test",
+        messages = [OpenAICompletions.Message(; role = "user", content = "hello")],
+        stream = true,
+        provider = Dict("zdr" => true, "data_collection" => "deny"),
+    )
+    req_json = JSON.parse(JSON.json(req))
+    @test req_json["provider"]["zdr"] == true
+    @test req_json["provider"]["data_collection"] == "deny"
+
     usage_chunk = JSON.parse(
         """
         {

--- a/LLMProviders/test/runtests.jl
+++ b/LLMProviders/test/runtests.jl
@@ -54,10 +54,12 @@ end
         messages = [OpenAICompletions.Message(; role = "user", content = "hello")],
         stream = true,
         provider = Dict("zdr" => true, "data_collection" => "deny"),
+        reasoning = Dict("exclude" => true),
     )
     req_json = JSON.parse(JSON.json(req))
     @test req_json["provider"]["zdr"] == true
     @test req_json["provider"]["data_collection"] == "deny"
+    @test req_json["reasoning"]["exclude"] == true
 
     usage_chunk = JSON.parse(
         """

--- a/LLMProviders/test/runtests.jl
+++ b/LLMProviders/test/runtests.jl
@@ -98,7 +98,7 @@ end
     @test unknown_event isa OpenAIResponses.UnknownStreamEvent
 
     params_schema = OpenAIResponses.schema(@NamedTuple{required::String, optional::Union{Nothing, String}})
-    required_fields = haskey(params_schema.spec, "required") ? Set(String.(params_schema.spec["required"])) : Set{String}()
+    required_fields = haskey(params_schema.data, "required") ? Set(String.(params_schema.data["required"])) : Set{String}()
     @test "required" in required_fields
     @test !("optional" in required_fields)
 end

--- a/LLMProviders/test/runtests.jl
+++ b/LLMProviders/test/runtests.jl
@@ -1,6 +1,7 @@
 using Test
 using HTTP
 using JSON
+using JSONSchema
 using Sockets
 using LLMProviders
 
@@ -97,8 +98,14 @@ end
     unknown_event = JSON.parse("{\"type\":\"response.unrecognized\",\"foo\":123}", OpenAIResponses.StreamEvent)
     @test unknown_event isa OpenAIResponses.UnknownStreamEvent
 
-    params_schema = OpenAIResponses.schema(@NamedTuple{required::String, optional::Union{Nothing, String}})
-    required_fields = haskey(params_schema.data, "required") ? Set(String.(params_schema.data["required"])) : Set{String}()
+    params_schema = OpenAIResponses.schema(
+        @NamedTuple{required::String, optional::Union{Nothing,String}},
+    )
+    params_schema_data = JSONSchema.spec(params_schema)
+    required_fields =
+        haskey(params_schema_data, "required") ?
+        Set(String.(params_schema_data["required"])) :
+        Set{String}()
     @test "required" in required_fields
     @test !("optional" in required_fields)
 end

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -201,12 +201,18 @@ version = "1.4.0"
     ArrowTypes = "31f734f8-188a-4ce0-8406-c8a06bd891cd"
 
 [[deps.JSONSchema]]
-deps = ["Downloads", "JSON", "StructUtils", "URIs"]
-git-tree-sha1 = "80ae77ee9a2f255ac159a4e718dddbc45e78632d"
-repo-rev = "master"
+deps = ["Downloads", "JSON", "URIs"]
+git-tree-sha1 = "fc058412920f0bbf399edeaea37461bbdefc68f6"
+repo-rev = "4076c12e69f8191b611580744c42579f95e92974"
 repo-url = "https://github.com/JuliaIO/JSONSchema.jl.git"
 uuid = "7d188eb4-7ad8-530c-ae41-71a32a6d4692"
-version = "2.0.0"
+version = "1.6.0"
+
+    [deps.JSONSchema.extensions]
+    JSONSchemaJSON3Ext = "JSON3"
+
+    [deps.JSONSchema.weakdeps]
+    JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 
 [[deps.Juco]]
 deps = ["Agentif", "LLMTools"]

--- a/Project.toml
+++ b/Project.toml
@@ -28,7 +28,7 @@ Claw = {path = "Claw"}
 ConcurrentUtilities = {url = "https://github.com/JuliaServices/ConcurrentUtilities.jl.git", rev = "main"}
 Encid = {url = "https://github.com/JuliaServices/Encid.jl.git"}
 HTTP = {url = "https://github.com/JuliaWeb/HTTP.jl.git", rev = "master"}
-JSONSchema = {url = "https://github.com/JuliaIO/JSONSchema.jl.git"}
+JSONSchema = {url = "https://github.com/JuliaIO/JSONSchema.jl.git", rev = "4076c12e69f8191b611580744c42579f95e92974"}
 Juco = {path = "Juco"}
 LLMOAuth = {path = "LLMOAuth"}
 LLMProviders = {path = "LLMProviders"}


### PR DESCRIPTION
## Summary

- preserve concrete handler, agent, tool, callback, and HTTP option types through middleware, async, compaction, and streaming paths
- parse tool arguments and provider payloads into bounded trim-safe types, including Codex OAuth/options and tool-error responses
- support released JSONSchema accessors and OpenRouter provider/reasoning options
- make the invalidation workflow instantiate the workspace and run only for package-owned runtime changes

## Review fixes

- accept the concrete empty-tool vector used by default agents in every provider adapter
- dispatch compaction summaries through the selected summary model API
- preserve explicit `nothing` values in Codex options
- support OAuth 3 and both HTTP 1 and HTTP 2 transport APIs

## Validation

- `julia --startup-file=no --project=. test/runtests.jl` (all five packages)
- full Agentif suite in an isolated HTTP 2.6.0 and OAuth 3.0.0 environment
- all pull request checks, including the invalidation gate
- LeagueEasy safe-trim build completed with zero verifier errors using this runtime source
- LeagueEasy immutable image passed live, database-readiness, and HTTP-header smoke checks on Fly-compatible hardware

Co-authored by Codex
