### PR TITLE
Round 1: correctness & security fix pass across the stack

### DIFF
--- a/Agentif/src/agent.jl
+++ b/Agentif/src/agent.jl
@@ -139,7 +139,7 @@ function call_function_tool!(f, tool::AgentTool, tc::PendingToolCall)
         if parse_error !== nothing
             is_error = true
             raw = tc.arguments
-            raw_preview = length(raw) > 500 ? string(raw[1:500], "... (truncated, length=$(length(raw)))") : raw
+            raw_preview = length(raw) > 500 ? string(first(raw, 500), "... (truncated, length=$(length(raw)))") : raw
             parse_msg = caught_exception_message(
                 parse_error, "Tool arguments are invalid.")
             if TRIMMED_BUILD

--- a/Agentif/src/compaction.jl
+++ b/Agentif/src/compaction.jl
@@ -153,7 +153,9 @@ function format_messages_for_summary(messages::Vector{StoredAgentMessage})
         elseif msg isa ToolResultMessage
             result_text = message_text(msg)
             if length(result_text) > 500
-                result_text = result_text[1:500] * "... (truncated)"
+                # first() is char-safe; result_text[1:500] is byte indexing and
+                # throws on multi-byte tool output right when compaction runs
+                result_text = first(result_text, 500) * "... (truncated)"
             end
             prefix = msg.is_error ? "Tool $(msg.name) error" : "Tool $(msg.name) result"
             push!(parts, "$prefix: $result_text")

--- a/Agentif/src/logging_config.jl
+++ b/Agentif/src/logging_config.jl
@@ -36,7 +36,9 @@ function _format_stacktrace(bt; max_chars::Int = 16_000)
     end
     stack = String(take!(io))
     length(stack) <= max_chars && return stack
-    return stack[1:max_chars] * "\n... [stacktrace truncated]"
+    # first() is char-safe; stack[1:max_chars] is byte indexing and throws when
+    # the cut lands inside a multi-byte char ('…', unicode identifiers)
+    return first(stack, max_chars) * "\n... [stacktrace truncated]"
 end
 
 function render_tool_error_json(

--- a/Agentif/src/messages.jl
+++ b/Agentif/src/messages.jl
@@ -18,6 +18,10 @@ end
     type::String = "thinking"
     thinking::String
     thinkingSignature::Union{Nothing, String} = nothing
+    # Anthropic redacted_thinking: `thinking` is empty and `thinkingSignature`
+    # carries the opaque `data` payload for replay. Defaults to false so
+    # previously persisted sessions load unchanged.
+    redacted::Bool = false
 end
 
 @kwarg mutable struct ImageContent <: ContentBlock
@@ -171,7 +175,7 @@ function set_last_text!(msg::AssistantMessage, text::String)
 end
 
 JSON.lower(x::TextContent) = (; type = x.type, text = x.text, textSignature = x.textSignature)
-JSON.lower(x::ThinkingContent) = (; type = x.type, thinking = x.thinking, thinkingSignature = x.thinkingSignature)
+JSON.lower(x::ThinkingContent) = (; type = x.type, thinking = x.thinking, thinkingSignature = x.thinkingSignature, redacted = x.redacted)
 JSON.lower(x::ImageContent) = (; type = x.type, data = x.data, mimeType = x.mimeType)
 JSON.lower(x::ToolCallContent) = (;
     type = x.type,

--- a/Agentif/src/middleware.jl
+++ b/Agentif/src/middleware.jl
@@ -296,7 +296,14 @@ function input_guardrail_middleware(agent_handler::AgentHandler, guardrail::Unio
             else
                 guardrail_agent = materialize_guardrail_agent(agent, DEFAULT_INPUT_GUARDRAIL_AGENT; model=input_guardrail_model, apikey=input_guardrail_apikey)
                 result_state = stream(identity, guardrail_agent, AgentState(), build_guardrail_input(agent.prompt, text), abort)
-                return try; JSON.parse(last_assistant_message(result_state).text, ValidUserInput).valid_user_input; catch; false; end
+                return try
+                    msg = last_assistant_message(result_state)
+                    msg === nothing && error("input guardrail produced no assistant message")
+                    JSON.parse(message_text(msg), ValidUserInput).valid_user_input
+                catch e
+                    @warn "Input guardrail evaluation failed; rejecting input" exception = (e, catch_backtrace())
+                    false
+                end
             end
         end
         result_state = agent_handler(function (event)

--- a/Agentif/src/providers/anthropic_messages_adapter.jl
+++ b/Agentif/src/providers/anthropic_messages_adapter.jl
@@ -150,6 +150,13 @@ function anthropic_message_from_agent(msg::AgentMessage, tool_name_map::Dict{Str
                 isempty(strip(block.text)) && continue
                 push!(blocks, AnthropicMessages.TextBlock(; text = block.text))
             elseif block isa ThinkingContent
+                if block.redacted
+                    # Replay redacted thinking as-is; the opaque data lives in the signature slot.
+                    data = block.thinkingSignature
+                    (data === nothing || isempty(data)) && continue
+                    push!(blocks, AnthropicMessages.RedactedThinkingBlock(; data))
+                    continue
+                end
                 isempty(strip(block.thinking)) && continue
                 if block.thinkingSignature === nothing || isempty(block.thinkingSignature)
                     push!(blocks, AnthropicMessages.TextBlock(; text = block.thinking))
@@ -228,6 +235,19 @@ function anthropic_usage_from_response(u::Union{Nothing, AnthropicMessages.Usage
     return Usage(; input, output, cacheRead = cache_read, cacheWrite = cache_write, total)
 end
 
+# Merge a message_delta usage into the usage captured at message_start: only fields
+# present in the delta overwrite, so input/cache counts survive backends that only
+# send output_tokens in deltas.
+function anthropic_merge_usage(base::Union{Nothing, AnthropicMessages.Usage}, delta::AnthropicMessages.Usage)
+    base === nothing && return delta
+    return AnthropicMessages.Usage(;
+        input_tokens = delta.input_tokens === nothing ? base.input_tokens : delta.input_tokens,
+        output_tokens = delta.output_tokens === nothing ? base.output_tokens : delta.output_tokens,
+        cache_creation_input_tokens = delta.cache_creation_input_tokens === nothing ? base.cache_creation_input_tokens : delta.cache_creation_input_tokens,
+        cache_read_input_tokens = delta.cache_read_input_tokens === nothing ? base.cache_read_input_tokens : delta.cache_read_input_tokens,
+    )
+end
+
 function anthropic_stop_reason(reason::Union{Nothing, String}, tool_calls::Vector{AgentToolCall})
     if !isempty(tool_calls)
         return :tool_calls
@@ -240,6 +260,14 @@ function anthropic_stop_reason(reason::Union{Nothing, String}, tool_calls::Vecto
         return :stop
     elseif reason == "end_turn"
         return :stop
+    elseif reason == "refusal"
+        return :error
+    elseif reason == "pause_turn"
+        # The server paused a long-running turn; auto-resubmitting to continue is future work.
+        return :stop
+    elseif reason == "error"
+        # Synthesized by the stream driver on HTTP errors.
+        return :error
     end
     return :stop
 end
@@ -273,6 +301,7 @@ function anthropic_event_callback(
                 assistant_message.response_id = parsed.message.id
             end
             parsed.message.stop_reason !== nothing && (stop_reason[] = parsed.message.stop_reason)
+            parsed.message.usage !== nothing && (latest_usage[] = parsed.message.usage)
             if !started[]
                 started[] = true
                 f(MessageStartEvent(:assistant, assistant_message))
@@ -289,6 +318,15 @@ function anthropic_event_callback(
                 )
                 push!(assistant_message.content, block)
                 blocks_by_index[parsed.index] = block
+            elseif parsed.content_block isa AnthropicMessages.RedactedThinkingBlock
+                # Store the opaque data in the signature slot so it can be replayed verbatim.
+                block = ThinkingContent(;
+                    thinking = "",
+                    thinkingSignature = parsed.content_block.data,
+                    redacted = true,
+                )
+                push!(assistant_message.content, block)
+                blocks_by_index[parsed.index] = block
             elseif parsed.content_block isa AnthropicMessages.ToolUseBlock
                 tool_name = anthropic_internal_tool_name(tool_name_reverse_map, parsed.content_block.name)
                 args = parsed.content_block.input isa AbstractDict ? Dict{String, Any}(parsed.content_block.input) : Dict{String, Any}()
@@ -300,6 +338,8 @@ function anthropic_event_callback(
                 push!(assistant_message.content, block)
                 blocks_by_index[parsed.index] = block
                 partial_json_by_index[parsed.index] = ""
+            elseif parsed.content_block isa AnthropicMessages.UnknownContentBlock
+                @debug "Ignoring unknown Anthropic content block" type = parsed.content_block.type index = parsed.index
             end
         elseif parsed isa AnthropicMessages.StreamContentBlockDeltaEvent
             if parsed.delta isa AnthropicMessages.TextDelta
@@ -332,6 +372,8 @@ function anthropic_event_callback(
                 partial *= parsed.delta.partial_json
                 partial_json_by_index[parsed.index] = partial
                 f(MessageUpdateEvent(:assistant, assistant_message, :tool_arguments, parsed.delta.partial_json, block.id))
+            elseif parsed.delta isa AnthropicMessages.UnknownContentBlockDelta
+                @debug "Ignoring unknown Anthropic content block delta" type = parsed.delta.type index = parsed.index
             end
         elseif parsed isa AnthropicMessages.StreamContentBlockStopEvent
             block = get(() -> nothing, blocks_by_index, parsed.index)
@@ -347,7 +389,7 @@ function anthropic_event_callback(
                 stop_on_tool_call && throw(StopStreaming("tool call arguments complete"))
             end
         elseif parsed isa AnthropicMessages.StreamMessageDeltaEvent
-            parsed.usage !== nothing && (latest_usage[] = parsed.usage)
+            parsed.usage !== nothing && (latest_usage[] = anthropic_merge_usage(latest_usage[], parsed.usage))
             delta = parsed.delta
             if delta isa AbstractDict
                 sr = get(delta, "stop_reason", nothing)

--- a/Agentif/src/providers/anthropic_messages_adapter.jl
+++ b/Agentif/src/providers/anthropic_messages_adapter.jl
@@ -401,7 +401,12 @@ function anthropic_event_callback(
                 f(MessageEndEvent(:assistant, assistant_message))
             end
         elseif parsed isa AnthropicMessages.StreamErrorEvent
-            if started[] && !ended[]
+            stop_reason[] = "error"
+            if !started[]
+                started[] = true
+                f(MessageStartEvent(:assistant, assistant_message))
+            end
+            if !ended[]
                 ended[] = true
                 f(MessageEndEvent(:assistant, assistant_message))
             end

--- a/Agentif/src/providers/openai_codex.jl
+++ b/Agentif/src/providers/openai_codex.jl
@@ -296,7 +296,7 @@ function transform_request_body!(
                         string(output)
                     end
                     if length(text) > 16000
-                        text = string(text[1:16000], "\n...[truncated]")
+                        text = string(first(text, 16000), "\n...[truncated]")
                     end
                     push!(
                         mapped, Dict(
@@ -479,7 +479,7 @@ function codex_usage_from_response(u)
     if details isa AbstractDict
         cached_tokens = get(() -> 0, details, "cached_tokens")
     end
-    return Usage(; input = input_tokens - cached_tokens, output = output_tokens, cacheRead = cached_tokens, cacheWrite = 0, total = total_tokens)
+    return Usage(; input = max(0, input_tokens - cached_tokens), output = output_tokens, cacheRead = cached_tokens, cacheWrite = 0, total = total_tokens)
 end
 
 function codex_stop_reason(status::Union{Nothing, String}, tool_calls::Vector{AgentToolCall})
@@ -801,7 +801,7 @@ end
 
 function truncate_text(text::String, limit::Int)
     length(text) <= limit && return text
-    return string(text[1:limit], "...[truncated $(length(text) - limit)]")
+    return string(first(text, limit), "...[truncated $(length(text) - limit)]")
 end
 
 function format_codex_failure(raw_event::AbstractDict{String, Any})
@@ -941,7 +941,9 @@ function codex_retryable_exception(err::Exception)
         inner = err.error
         inner isa Exception && return codex_retryable_exception(inner)
         return codex_retryable_message(string(inner))
-    elseif err isa EOFError || err isa Base.IOError || err isa InterruptException
+    elseif err isa InterruptException
+        return false
+    elseif err isa EOFError || err isa Base.IOError
         return true
     end
     return codex_retryable_message(sprint(showerror, err))

--- a/Agentif/src/providers/openai_codex.jl
+++ b/Agentif/src/providers/openai_codex.jl
@@ -359,7 +359,10 @@ function _split_compound_id(id::AbstractString)
     if idx === nothing
         return (String(id), nothing)
     end
-    return (String(id[1:idx-1]), String(id[idx+1:end]))
+    return (
+        String(id[1:prevind(id, idx)]),
+        String(id[nextind(id, idx):end]),
+    )
 end
 
 function codex_input_from_message(msg::AgentMessage, model::Model)
@@ -934,19 +937,52 @@ function codex_retryable_message(message::AbstractString)
     return occursin(CODEX_RETRYABLE_ERROR_REGEX, lowercase(message))
 end
 
+if TRIMMED_BUILD
+    codex_nested_retryable_exception(::Exception) = false
+else
+    function codex_nested_retryable_exception(err::Exception)
+        if err isa TaskFailedException
+            task = getfield(err, :task)
+            for (nested, _) in Base.current_exceptions(task)
+                nested isa Exception && codex_retryable_exception(nested) && return true
+            end
+        elseif err isa CompositeException
+            for nested in getfield(err, :exceptions)
+                nested isa Exception && codex_retryable_exception(nested) && return true
+            end
+        end
+        return false
+    end
+end
+
 function codex_retryable_exception(err::Exception)
     if err isa HTTP.ConnectError
         return true
-    elseif err isa HTTP.RequestError
-        inner = err.error
+    elseif isdefined(HTTP, :RequestError) && err isa getfield(HTTP, :RequestError)
+        inner = getproperty(err, :error)
+        inner isa Exception && return codex_retryable_exception(inner)
+        return codex_retryable_message(string(inner))
+    elseif isdefined(HTTP, :RequestRetryError) && err isa getfield(HTTP, :RequestRetryError)
+        inner = getproperty(err, :err)
         inner isa Exception && return codex_retryable_exception(inner)
         return codex_retryable_message(string(inner))
     elseif err isa InterruptException
         return false
-    elseif err isa EOFError || err isa Base.IOError
+    elseif err isa EOFError || err isa Base.IOError || err isa HTTP.ParseError
         return true
     end
+    codex_nested_retryable_exception(err) && return true
     return codex_retryable_message(sprint(showerror, err))
+end
+
+function http_recoverable_error(err::Exception)
+    if isdefined(HTTP, :isrecoverable)
+        return getfield(HTTP, :isrecoverable)(err)
+    elseif isdefined(HTTP, :RetryRequest)
+        retry_module = getfield(HTTP, :RetryRequest)
+        return getfield(retry_module, :isrecoverable)(err)
+    end
+    return false
 end
 
 function codex_retry_after_seconds(resp::HTTP.Response)

--- a/Agentif/src/providers/openai_codex.jl
+++ b/Agentif/src/providers/openai_codex.jl
@@ -995,6 +995,10 @@ function codex_stream_sse_with_retry!(
     request_http_kw = merge(http_nt, (; retry = false, status_exception = false))
     payload = JSON.json(request_body)
     attempt = 0
+    # Once any SSE event has been delivered into the (stateful) callback,
+    # re-POSTing would replay the whole response and duplicate its content.
+    events_seen = Ref(false)
+    tracked_callback = sse_tracking_callback(callback, events_seen)
 
     while true
         isaborted(abort) && throw(StopStreaming("aborted"))
@@ -1005,12 +1009,12 @@ function codex_stream_sse_with_retry!(
                 url,
                 headers;
                 body = payload,
-                sse_callback = callback,
+                sse_callback = tracked_callback,
                 request_http_kw...,
             )
         catch err
             err isa StopStreaming && rethrow()
-            if attempt < max_retries && codex_retryable_exception(err)
+            if attempt < max_retries && !events_seen[] && codex_retryable_exception(err)
                 attempt += 1
                 delay_s = codex_retry_delay_seconds(attempt, retry_base_ms, retry_max_ms)
                 log_codex_debug(
@@ -1035,7 +1039,7 @@ function codex_stream_sse_with_retry!(
         info = parse_codex_error(resp)
         info_msg = String(get(() -> "", info, :message))
         retryable = codex_retryable_status(resp.status) || codex_retryable_message(info_msg)
-        if attempt < max_retries && retryable
+        if attempt < max_retries && !events_seen[] && retryable
             attempt += 1
             delay_s = codex_retry_delay_seconds(attempt, retry_base_ms, retry_max_ms; response = resp)
             log_codex_debug(

--- a/Agentif/src/providers/openai_completions_adapter.jl
+++ b/Agentif/src/providers/openai_completions_adapter.jl
@@ -234,7 +234,10 @@ function openai_completions_build_messages(agent::Agent, state::AgentState, inpu
             if !("image" in model.input)
                 parts = OpenAICompletions.ContentPart[part for part in parts if part.type != "image_url"]
             end
-            isempty(parts) && continue
+            if isempty(parts)
+                i += 1
+                continue
+            end
             push!(messages, OpenAICompletions.Message(; role = "user", content = parts))
             last_role = "user"
         elseif msg isa AssistantMessage
@@ -306,6 +309,7 @@ function openai_completions_build_messages(agent::Agent, state::AgentState, inpu
             has_extra = assistant_msg.extra !== nothing && !isempty(assistant_msg.extra)
             has_reasoning = assistant_msg.reasoning_details !== nothing
             if !has_content && assistant_msg.tool_calls === nothing && !has_extra && !has_reasoning
+                i += 1
                 continue
             end
             push!(messages, assistant_msg)
@@ -655,8 +659,10 @@ function openai_completions_event_callback(
                     if isempty(reasoning_buffer)
                         push!(new_text_parts, text_str)
                     else
-                        start_idx = lastindex(reasoning_buffer) + 1
-                        start_idx <= lastindex(text_str) && push!(new_text_parts, text_str[start_idx:end])
+                        # startswith guarantees the prefix bytes match, so the byte
+                        # after the prefix is a valid char boundary in text_str.
+                        start_idx = ncodeunits(reasoning_buffer) + 1
+                        start_idx <= ncodeunits(text_str) && push!(new_text_parts, text_str[start_idx:end])
                     end
                 else
                     push!(new_text_parts, text_str)
@@ -729,12 +735,12 @@ function openai_completions_event_callback(
                     )
                     f(MessageUpdateEvent(:assistant, assistant_message, :tool_arguments, tool_delta.function.arguments, acc.id))
                     if get(ENV, "AGENTIF_STOP_ON_TOOL_CALL", "") != "" && acc.name !== nothing && !isempty(acc.arguments)
-                        try
-                            parsed = JSON.parse(acc.arguments)
-                            parsed isa AbstractDict || throw(ArgumentError("tool arguments not object"))
-                            throw(StopStreaming("tool call arguments complete"))
+                        complete = try
+                            JSON.parse(acc.arguments) isa AbstractDict
                         catch
+                            false
                         end
+                        complete && throw(StopStreaming("tool call arguments complete"))
                     end
                 end
             end

--- a/Agentif/src/providers/openai_completions_adapter.jl
+++ b/Agentif/src/providers/openai_completions_adapter.jl
@@ -432,8 +432,10 @@ function strip_think_tags(text::AbstractString)
     # Implicit-open: everything before first </think> is thinking
     idx = findfirst("</think>", text)
     if idx !== nothing
-        thinking = text[1:first(idx)-1]
-        content = lstrip(text[last(idx)+1:end])
+        # prevind/nextind keep slices on char boundaries: `first(idx)-1` is a
+        # continuation byte when the char right before the tag is multi-byte
+        thinking = text[1:prevind(text, first(idx))]
+        content = lstrip(text[nextind(text, last(idx)):end])
         return thinking, content
     end
     return "", text
@@ -465,6 +467,9 @@ function process_think_tag_chunk(tts::ThinkTagStreamState, chunk::AbstractString
     buf = tts.buffer
     tts.buffer = ""
 
+    # NOTE: all slicing below must stay on char boundaries — the char right
+    # before/after an ASCII tag can be multi-byte, so raw index arithmetic
+    # (`first(idx)-1`, `end-8`) would land on continuation bytes and throw.
     while !isempty(buf)
         if tts.in_think
             # Skip explicit <think> open tag if present
@@ -472,21 +477,22 @@ function process_think_tag_chunk(tts::ThinkTagStreamState, chunk::AbstractString
                 idx = findfirst("<think>", buf)
                 if idx !== nothing && first(idx) == 1
                     tts.saw_explicit_open = true
-                    buf = buf[last(idx)+1:end]
+                    buf = buf[nextind(buf, last(idx)):end]
                     continue
                 end
             end
             # Look for closing </think>
             idx = findfirst("</think>", buf)
             if idx !== nothing
-                write(thinking, buf[1:first(idx)-1])
-                buf = buf[last(idx)+1:end]
+                write(thinking, buf[1:prevind(buf, first(idx))])
+                buf = buf[nextind(buf, last(idx)):end]
                 tts.in_think = false
             else
                 # Buffer last 8 chars in case </think> spans chunks
-                if length(buf) >= 8
-                    write(thinking, buf[1:end-8])
-                    tts.buffer = buf[end-7:end]
+                n = length(buf)
+                if n >= 8
+                    write(thinking, first(buf, n - 8))
+                    tts.buffer = last(buf, 8)
                 else
                     tts.buffer = buf
                 end
@@ -496,15 +502,16 @@ function process_think_tag_chunk(tts::ThinkTagStreamState, chunk::AbstractString
             # Look for opening <think>
             idx = findfirst("<think>", buf)
             if idx !== nothing
-                write(content, buf[1:first(idx)-1])
-                buf = buf[last(idx)+1:end]
+                write(content, buf[1:prevind(buf, first(idx))])
+                buf = buf[nextind(buf, last(idx)):end]
                 tts.in_think = true
                 tts.saw_explicit_open = true
             else
                 # Buffer last 7 chars in case <think> spans chunks
-                if length(buf) >= 7
-                    write(content, buf[1:end-7])
-                    tts.buffer = buf[end-6:end]
+                n = length(buf)
+                if n >= 7
+                    write(content, first(buf, n - 7))
+                    tts.buffer = last(buf, 7)
                 else
                     tts.buffer = buf
                 end

--- a/Agentif/src/providers/openai_completions_adapter.jl
+++ b/Agentif/src/providers/openai_completions_adapter.jl
@@ -190,7 +190,7 @@ function openai_completions_build_messages(agent::Agent, state::AgentState, inpu
             return normalize_mistral_tool_id(id)
         end
         if model.provider == "openai"
-            return length(id) > 40 ? id[1:40] : id
+            return length(id) > 40 ? first(id, 40) : id
         end
         if model.provider == "github-copilot" && occursin("claude", lowercase(model.id))
             normalized = replace(id, r"[^A-Za-z0-9_-]" => "_")

--- a/Agentif/src/providers/openai_responses_adapter.jl
+++ b/Agentif/src/providers/openai_responses_adapter.jl
@@ -414,6 +414,10 @@ function openai_responses_event_callback(
             if response_id !== nothing
                 assistant_message.response_id = response_id
             end
+            if started[] && !ended[]
+                ended[] = true
+                f(MessageEndEvent(:assistant, assistant_message))
+            end
         elseif parsed isa OpenAIResponses.StreamResponseFailedEvent
             response_status[] = parsed.response.status
             response_usage[] = parsed.response.usage
@@ -435,11 +439,6 @@ function openai_responses_event_callback(
         elseif parsed isa OpenAIResponses.StreamResponseIncompleteEvent
             response_status[] = parsed.response.status
             response_usage[] = parsed.response.usage
-            if started[] && !ended[]
-                ended[] = true
-                f(MessageEndEvent(:assistant, assistant_message))
-            end
-        elseif parsed isa OpenAIResponses.StreamOutputDoneEvent || parsed isa OpenAIResponses.StreamDoneEvent
             if started[] && !ended[]
                 ended[] = true
                 f(MessageEndEvent(:assistant, assistant_message))

--- a/Agentif/src/providers/openai_responses_adapter.jl
+++ b/Agentif/src/providers/openai_responses_adapter.jl
@@ -76,7 +76,10 @@ function _responses_split_compound_id(id::AbstractString)
     if idx === nothing
         return (String(id), nothing)
     end
-    return (String(id[1:idx-1]), String(id[idx+1:end]))
+    return (
+        String(id[1:prevind(id, idx)]),
+        String(id[nextind(id, idx):end]),
+    )
 end
 
 function openai_responses_normalize_tool_call_id(id::String, model::Model)

--- a/Agentif/src/skills.jl
+++ b/Agentif/src/skills.jl
@@ -94,11 +94,14 @@ Examples:
         skill_loader(name::String) = begin
             content = load_skill(registry, name)
             meta = get(() -> nothing, registry.skills, name)
-            hint = nothing
-            if meta !== nothing
-                hint = "Use read path=$(meta.skill_file) with offset/limit to load more."
+            max_bytes = MAX_TOOL_RESULT_BYTES[]
+            if max_bytes > 0 && sizeof(content) > max_bytes
+                hint = meta === nothing ? "" :
+                    " Use read path=$(meta.skill_file) with offset/limit to load more."
+                idx = prevind(content, max_bytes + 1)
+                content = string(content[1:idx], "\n\n[Skill truncated: showing first ~$(_format_byte_size(max_bytes)) of $(_format_byte_size(sizeof(content))) total.$(hint)]")
             end
-            return truncate_tool_output(content; label = "Skill", hint = hint)
+            return content
         end,
     )
 end

--- a/Agentif/src/skills.jl
+++ b/Agentif/src/skills.jl
@@ -238,7 +238,9 @@ function unquote(value::AbstractString)
         first_char = stripped[1]
         last_char = stripped[end]
         if (first_char == '"' && last_char == '"') || (first_char == '\'' && last_char == '\'')
-            return stripped[2:(end - 1)]
+            content_start = nextind(stripped, firstindex(stripped))
+            content_end = prevind(stripped, lastindex(stripped))
+            return stripped[content_start:content_end]
         end
     end
     return stripped

--- a/Agentif/src/stream.jl
+++ b/Agentif/src/stream.jl
@@ -56,7 +56,7 @@ sse_retryable_status(status::Integer) = Int(status) in SSE_RETRYABLE_STATUSES
 function sse_recoverable_connection_error(err)
     (err isa InterruptException || err isa StopStreaming || err isa HTTP.StatusError) && return false
     err isa Exception || return false
-    return codex_retryable_exception(err) || HTTP.RetryRequest.isrecoverable(err)
+    return codex_retryable_exception(err) || http_recoverable_error(err)
 end
 
 function sse_retryable_error(err)

--- a/Agentif/src/stream.jl
+++ b/Agentif/src/stream.jl
@@ -38,6 +38,105 @@ const DEFAULT_HTTP_KW = (;
     retry_non_idempotent = true,  # Retry POST requests
 )
 
+# ── SSE-safe retry ────────────────────────────────────────────────────────────
+# HTTP.jl's transport-level retry sits above the layer that feeds SSE events to
+# `sse_callback`, so a connection drop mid-stream would replay the entire
+# response into the same stateful callback closures (doubling text/thinking
+# deltas and corrupting tool-call accumulators). For SSE requests we therefore
+# disable transport retry (`retry = false`) and retry at this level instead,
+# but only while no SSE event has been delivered yet.
+
+# Transient statuses worth retrying before any event has been delivered.
+const SSE_RETRYABLE_STATUSES = (408, 429, 500, 502, 503, 504, 599)
+
+sse_retryable_status(status::Integer) = Int(status) in SSE_RETRYABLE_STATUSES
+
+# Recoverable connection-level failures (EOF/IO errors, connect failures, TLS
+# errors) — never StatusError (handled separately) and never interrupts.
+function sse_recoverable_connection_error(err)
+    (err isa InterruptException || err isa StopStreaming || err isa HTTP.StatusError) && return false
+    err isa Exception || return false
+    return codex_retryable_exception(err) || HTTP.RetryRequest.isrecoverable(err)
+end
+
+function sse_retryable_error(err)
+    err isa HTTP.StatusError && return sse_retryable_status(err.status)
+    return sse_recoverable_connection_error(err)
+end
+
+# Wrap a provider `sse_callback` so the very first delivered event flips
+# `events_seen` (before the provider closure runs, so even a callback that
+# throws still counts as delivery).
+function sse_tracking_callback(callback::Function, events_seen::Base.RefValue{Bool})
+    return function (stream, event)
+        events_seen[] = true
+        return callback(stream, event)
+    end
+end
+
+# Respect caller-provided `http_kw` retry overrides: `retry = false` disables
+# our retry loop entirely, and `retries = N` bounds it at N + 1 attempts.
+function sse_retry_attempts(http_kw::NamedTuple)
+    get(http_kw, :retry, true) === true || return 1
+    return max(1, Int(get(http_kw, :retries, DEFAULT_HTTP_KW.retries)) + 1)
+end
+
+"""
+    sse_request_with_retry(do_request, events_seen, abort; max_attempts, ...)
+
+Run `do_request` (an `HTTP.post` with transport-level retry disabled), retrying
+transient failures (recoverable connection errors, or `HTTP.StatusError` with a
+status in `$(SSE_RETRYABLE_STATUSES)`) with bounded exponential backoff. A
+`Retry-After` header on the failed response is honored (capped at
+`max_delay_ms`). Once any SSE event has been delivered (`events_seen[]`),
+errors are rethrown instead of retried — replaying the response would corrupt
+the stateful callback accumulators.
+"""
+function sse_request_with_retry(
+        do_request::Function,
+        events_seen::Base.RefValue{Bool},
+        abort::Abort;
+        max_attempts::Int,
+        base_delay_ms::Int = CODEX_DEFAULT_RETRY_BASE_MS,
+        max_delay_ms::Int = CODEX_DEFAULT_RETRY_MAX_MS,
+    )
+    attempt = 1
+    while true
+        isaborted(abort) && throw(StopStreaming("aborted"))
+        try
+            return do_request()
+        catch err
+            (err isa StopStreaming || err isa InterruptException) && rethrow()
+            (events_seen[] || attempt >= max_attempts || !sse_retryable_error(err)) && rethrow()
+            response = err isa HTTP.StatusError ? err.response : nothing
+            delay_s = codex_retry_delay_seconds(attempt, base_delay_ms, max_delay_ms; response)
+            attempt += 1
+            codex_sleep_with_abort!(delay_s, abort)
+        end
+    end
+end
+
+# Shared handling for a connection dropped after SSE events already flowed:
+# keep the partial message, surface the failure as an AgentErrorEvent.
+function sse_emit_stream_interrupted!(
+        f::Function,
+        assistant_message::AssistantMessage,
+        started::Base.RefValue{Bool},
+        ended::Base.RefValue{Bool},
+        err,
+    )
+    if !started[]
+        started[] = true
+        f(MessageStartEvent(:assistant, assistant_message))
+    end
+    if !ended[]
+        ended[] = true
+        f(MessageEndEvent(:assistant, assistant_message))
+    end
+    f(AgentErrorEvent(ErrorException("SSE stream interrupted: $(sprint(showerror, err))")))
+    return
+end
+
 mutable struct ToolCallAccumulator
     id::Union{Nothing, String}
     name::Union{Nothing, String}
@@ -121,10 +220,16 @@ function transform_messages(
                     isempty(block.text) && continue
                     push!(blocks, TextContent(; text = block.text, textSignature = is_same ? block.textSignature : nothing))
                 elseif block isa ThinkingContent
-                    isempty(block.thinking) && continue
-                    if is_same && block.thinkingSignature !== nothing && !isempty(block.thinkingSignature)
-                        push!(blocks, ThinkingContent(; thinking = block.thinking, thinkingSignature = block.thinkingSignature))
+                    has_signature = block.thinkingSignature !== nothing && !isempty(block.thinkingSignature)
+                    if is_same && has_signature
+                        # Keep signed blocks even when the visible thinking text is
+                        # empty: redacted_thinking and encrypted reasoning items
+                        # (e.g. Responses with no summary) round-trip through the
+                        # signature and must be replayed for continuity.
+                        push!(blocks, ThinkingContent(; thinking = block.thinking, thinkingSignature = block.thinkingSignature, redacted = block.redacted))
                     else
+                        isempty(block.thinking) && continue
+                        block.redacted && continue
                         push!(blocks, TextContent(; text = block.thinking))
                     end
                 elseif block isa ToolCallContent
@@ -389,23 +494,31 @@ function stream(
         )
         model.headers !== nothing && merge!(headers, model.headers)
         url = joinpath(model.baseUrl, "responses")
+        events_seen = Ref(false)
+        sse_cb = sse_tracking_callback(
+            openai_responses_event_callback(
+                f,
+                agent,
+                assistant_message,
+                started,
+                ended,
+                response_usage,
+                response_status,
+                abort,
+            ),
+            events_seen,
+        )
+        request_http_kw = merge(merged_http_kw, (; retry = false))
         try
-            HTTP.post(
-                url,
-                headers;
-                body = JSON.json(body),
-                sse_callback = openai_responses_event_callback(
-                    f,
-                    agent,
-                    assistant_message,
-                    started,
-                    ended,
-                    response_usage,
-                    response_status,
-                    abort,
-                ),
-                merged_http_kw...,
-            )
+            sse_request_with_retry(events_seen, abort; max_attempts = sse_retry_attempts(merged_http_kw)) do
+                HTTP.post(
+                    url,
+                    headers;
+                    body = JSON.json(body),
+                    sse_callback = sse_cb,
+                    request_http_kw...,
+                )
+            end
         catch e
             if e isa StopStreaming
                 # Expected abort
@@ -426,6 +539,9 @@ function stream(
                     "HTTP $(e.status): $error_body"
                 end
                 f(AgentErrorEvent(ErrorException(error_msg)))
+                response_status[] = "failed"
+            elseif events_seen[] && sse_recoverable_connection_error(e)
+                sse_emit_stream_interrupted!(f, assistant_message, started, ended, e)
                 response_status[] = "failed"
             else
                 rethrow()
@@ -534,25 +650,34 @@ function stream(
         )
         model.headers !== nothing && merge!(headers, model.headers)
         url = joinpath(model.baseUrl, "chat", "completions")
+        stream_failed = Ref(false)
         if use_stream
+            events_seen = Ref(false)
+            sse_cb = sse_tracking_callback(
+                openai_completions_event_callback(
+                    f,
+                    assistant_message,
+                    started,
+                    ended,
+                    latest_usage,
+                    latest_finish,
+                    tool_call_accumulators,
+                    abort;
+                    think_tag_state = compat.stripThinkTags ? ThinkTagStreamState() : nothing,
+                ),
+                events_seen,
+            )
+            request_http_kw = merge(merged_http_kw, (; retry = false))
             try
-                HTTP.post(
-                    url,
-                    headers;
-                    body = JSON.json(req),
-                    sse_callback = openai_completions_event_callback(
-                        f,
-                        assistant_message,
-                        started,
-                        ended,
-                        latest_usage,
-                        latest_finish,
-                        tool_call_accumulators,
-                        abort;
-                        think_tag_state = compat.stripThinkTags ? ThinkTagStreamState() : nothing,
-                    ),
-                    merged_http_kw...,
-                )
+                sse_request_with_retry(events_seen, abort; max_attempts = sse_retry_attempts(merged_http_kw)) do
+                    HTTP.post(
+                        url,
+                        headers;
+                        body = JSON.json(req),
+                        sse_callback = sse_cb,
+                        request_http_kw...,
+                    )
+                end
             catch e
                 if e isa StopStreaming
                     # Expected abort
@@ -574,6 +699,9 @@ function stream(
                     end
                     f(AgentErrorEvent(ErrorException(error_msg)))
                     latest_finish[] = "error"
+                elseif events_seen[] && sse_recoverable_connection_error(e)
+                    sse_emit_stream_interrupted!(f, assistant_message, started, ended, e)
+                    stream_failed[] = true
                 else
                     rethrow()
                 end
@@ -584,7 +712,7 @@ function stream(
                 f(MessageEndEvent(:assistant, assistant_message))
             end
 
-            if !isaborted(abort)
+            if !isaborted(abort) && !stream_failed[]
                 for idx in sort(collect(keys(tool_call_accumulators)))
                     acc = tool_call_accumulators[idx]
                     toolcall_debug(
@@ -665,6 +793,7 @@ function stream(
 
         usage = openai_completions_usage_from_response(latest_usage[])
         stop_reason = openai_completions_stop_reason(latest_finish[], assistant_message.tool_calls)
+        stream_failed[] && (stop_reason = :error)
         isaborted(abort) && (stop_reason = :aborted)
         return finalize_stream!(state, input, assistant_message, usage, stop_reason)
     elseif api isa Val{Symbol("anthropic-messages")}
@@ -752,6 +881,12 @@ function stream(
                         thinkingSignature = block.signature,
                     )
                     push!(assistant_message.content, thinking)
+                elseif block isa AnthropicMessages.RedactedThinkingBlock
+                    push!(assistant_message.content, ThinkingContent(;
+                        thinking = "",
+                        thinkingSignature = block.data,
+                        redacted = true,
+                    ))
                 elseif block isa AnthropicMessages.ToolUseBlock
                     tool_name = anthropic_internal_tool_name(tool_name_reverse_map, block.name)
                     args = block.input isa AbstractDict ? Dict{String, Any}(block.input) : Dict{String, Any}()
@@ -781,26 +916,35 @@ function stream(
             final_stop = anthropic_stop_reason(stop_reason[], assistant_message.tool_calls)
             return finalize_stream!(state, input, assistant_message, usage, final_stop)
         else
+            events_seen = Ref(false)
+            stream_failed = Ref(false)
+            sse_cb = sse_tracking_callback(
+                anthropic_event_callback(
+                    f,
+                    agent,
+                    assistant_message,
+                    started,
+                    ended,
+                    stop_reason,
+                    latest_usage,
+                    blocks_by_index,
+                    partial_json_by_index,
+                    tool_name_reverse_map,
+                    abort,
+                ),
+                events_seen,
+            )
+            request_http_kw = merge(merged_http_kw, (; retry = false))
             try
-                HTTP.post(
-                    url,
-                    headers;
-                    body = JSON.json(req),
-                    sse_callback = anthropic_event_callback(
-                        f,
-                        agent,
-                        assistant_message,
-                        started,
-                        ended,
-                        stop_reason,
-                        latest_usage,
-                        blocks_by_index,
-                        partial_json_by_index,
-                        tool_name_reverse_map,
-                        abort,
-                    ),
-                    merged_http_kw...,
-                )
+                sse_request_with_retry(events_seen, abort; max_attempts = sse_retry_attempts(merged_http_kw)) do
+                    HTTP.post(
+                        url,
+                        headers;
+                        body = JSON.json(req),
+                        sse_callback = sse_cb,
+                        request_http_kw...,
+                    )
+                end
             catch e
                 if e isa StopStreaming
                 elseif e isa HTTP.StatusError
@@ -822,6 +966,9 @@ function stream(
                     end
                     f(AgentErrorEvent(ErrorException(error_msg)))
                     stop_reason[] = "error"
+                elseif events_seen[] && sse_recoverable_connection_error(e)
+                    sse_emit_stream_interrupted!(f, assistant_message, started, ended, e)
+                    stream_failed[] = true
                 else
                     rethrow()
                 end
@@ -834,6 +981,7 @@ function stream(
 
             usage = anthropic_usage_from_response(latest_usage[])
             final_stop = anthropic_stop_reason(stop_reason[], assistant_message.tool_calls)
+            stream_failed[] && (final_stop = :error)
             isaborted(abort) && (final_stop = :aborted)
             return finalize_stream!(state, input, assistant_message, usage, final_stop)
         end
@@ -863,26 +1011,58 @@ function stream(
         )
         model.headers !== nothing && merge!(headers, model.headers)
         url = joinpath(model.baseUrl, "models", "$(model.id):streamGenerateContent")
+        events_seen = Ref(false)
+        stream_failed = Ref(false)
+        sse_cb = sse_tracking_callback(
+            google_generative_event_callback(
+                f,
+                agent,
+                assistant_message,
+                started,
+                ended,
+                latest_usage,
+                latest_finish,
+                seen_call_ids,
+                abort,
+            ),
+            events_seen,
+        )
+        request_http_kw = merge(merged_http_kw, (; retry = false))
         try
-            HTTP.post(
-                url * "?alt=sse",
-                headers;
-                body = JSON.json(req),
-                sse_callback = google_generative_event_callback(
-                    f,
-                    agent,
-                    assistant_message,
-                    started,
-                    ended,
-                    latest_usage,
-                    latest_finish,
-                    seen_call_ids,
-                    abort,
-                ),
-                merged_http_kw...,
-            )
+            sse_request_with_retry(events_seen, abort; max_attempts = sse_retry_attempts(merged_http_kw)) do
+                HTTP.post(
+                    url * "?alt=sse",
+                    headers;
+                    body = JSON.json(req),
+                    sse_callback = sse_cb,
+                    request_http_kw...,
+                )
+            end
         catch e
-            if !(e isa StopStreaming)
+            if e isa StopStreaming
+                # Expected abort
+            elseif e isa HTTP.StatusError
+                if !started[]
+                    started[] = true
+                    f(MessageStartEvent(:assistant, assistant_message))
+                end
+                if !ended[]
+                    ended[] = true
+                    f(MessageEndEvent(:assistant, assistant_message))
+                end
+                error_body = String(e.response.body)
+                error_msg = try
+                    err_json = JSON.parse(error_body)
+                    get(get(() -> Dict(), err_json, "error"), "message", "HTTP $(e.status)")
+                catch
+                    "HTTP $(e.status): $error_body"
+                end
+                f(AgentErrorEvent(ErrorException(error_msg)))
+                stream_failed[] = true
+            elseif events_seen[] && sse_recoverable_connection_error(e)
+                sse_emit_stream_interrupted!(f, assistant_message, started, ended, e)
+                stream_failed[] = true
+            else
                 rethrow()
             end
         end
@@ -894,6 +1074,7 @@ function stream(
 
         usage = google_generative_usage_from_response(latest_usage[])
         stop_reason = google_generative_stop_reason(latest_finish[], assistant_message.tool_calls)
+        stream_failed[] && (stop_reason = :error)
         isaborted(abort) && (stop_reason = :aborted)
         return finalize_stream!(state, input, assistant_message, usage, stop_reason)
     elseif api isa Val{Symbol("google-gemini-cli")}
@@ -938,27 +1119,59 @@ function stream(
         model.headers !== nothing && merge!(headers, model.headers)
 
         debug_stream = get(ENV, "AGENTIF_DEBUG_GEMINI_STREAM", "") != ""
+        events_seen = Ref(false)
+        stream_failed = Ref(false)
+        sse_cb = sse_tracking_callback(
+            google_gemini_cli_event_callback(
+                f,
+                agent,
+                assistant_message,
+                started,
+                ended,
+                latest_usage,
+                latest_finish,
+                seen_call_ids,
+                debug_stream,
+                abort,
+            ),
+            events_seen,
+        )
+        request_http_kw = merge(merged_http_kw, (; retry = false))
         try
-            HTTP.post(
-                url,
-                headers;
-                body = JSON.json(req),
-                sse_callback = google_gemini_cli_event_callback(
-                    f,
-                    agent,
-                    assistant_message,
-                    started,
-                    ended,
-                    latest_usage,
-                    latest_finish,
-                    seen_call_ids,
-                    debug_stream,
-                    abort,
-                ),
-                merged_http_kw...,
-            )
+            sse_request_with_retry(events_seen, abort; max_attempts = sse_retry_attempts(merged_http_kw)) do
+                HTTP.post(
+                    url,
+                    headers;
+                    body = JSON.json(req),
+                    sse_callback = sse_cb,
+                    request_http_kw...,
+                )
+            end
         catch e
-            if !(e isa StopStreaming)
+            if e isa StopStreaming
+                # Expected abort
+            elseif e isa HTTP.StatusError
+                if !started[]
+                    started[] = true
+                    f(MessageStartEvent(:assistant, assistant_message))
+                end
+                if !ended[]
+                    ended[] = true
+                    f(MessageEndEvent(:assistant, assistant_message))
+                end
+                error_body = String(e.response.body)
+                error_msg = try
+                    err_json = JSON.parse(error_body)
+                    get(get(() -> Dict(), err_json, "error"), "message", "HTTP $(e.status)")
+                catch
+                    "HTTP $(e.status): $error_body"
+                end
+                f(AgentErrorEvent(ErrorException(error_msg)))
+                stream_failed[] = true
+            elseif events_seen[] && sse_recoverable_connection_error(e)
+                sse_emit_stream_interrupted!(f, assistant_message, started, ended, e)
+                stream_failed[] = true
+            else
                 rethrow()
             end
         end
@@ -970,6 +1183,7 @@ function stream(
 
         usage = google_gemini_cli_usage_from_response(latest_usage[])
         stop_reason = google_gemini_cli_stop_reason(latest_finish[], assistant_message.tool_calls)
+        stream_failed[] && (stop_reason = :error)
         isaborted(abort) && (stop_reason = :aborted)
         return finalize_stream!(state, input, assistant_message, usage, stop_reason)
     elseif api isa Val{Symbol("openai-codex-responses")}

--- a/Agentif/src/stream.jl
+++ b/Agentif/src/stream.jl
@@ -23,7 +23,7 @@ end
 
 toolcall_preview(::Nothing; limit::Int = 300) = "(nothing)"
 function toolcall_preview(s::AbstractString; limit::Int = 300)
-    return length(s) > limit ? string(s[1:limit], "...(truncated)") : s
+    return length(s) > limit ? string(first(s, limit), "...(truncated)") : s
 end
 
 function toolcall_debug(msg::AbstractString; kw...)
@@ -937,6 +937,7 @@ function stream(
         headers["Accept"] = "text/event-stream"
         model.headers !== nothing && merge!(headers, model.headers)
 
+        debug_stream = get(ENV, "AGENTIF_DEBUG_GEMINI_STREAM", "") != ""
         try
             HTTP.post(
                 url,

--- a/Agentif/test/runtests.jl
+++ b/Agentif/test/runtests.jl
@@ -58,6 +58,36 @@ function test_websocket_request(ws)
     return hasproperty(ws, :handshake_request) ? ws.handshake_request : ws.request
 end
 
+function test_status_error(status::Integer)
+    response = HTTP.Response(status)
+    if applicable(HTTP.StatusError, status, "POST", "/x", response)
+        return HTTP.StatusError(status, "POST", "/x", response)
+    end
+    return HTTP.StatusError(response)
+end
+
+function test_parse_error(message::AbstractString)
+    if applicable(HTTP.ParseError, message)
+        return HTTP.ParseError(message)
+    end
+    return HTTP.ParseError(:INVALID_STATUS_LINE, message)
+end
+
+function test_force_close_stream(http)
+    if hasproperty(http, :tracked)
+        tracked = http.tracked
+        if tracked !== nothing && hasproperty(tracked, :conn)
+            close(tracked.conn)
+            return
+        end
+    end
+    if hasproperty(http, :stream) && hasproperty(http.stream, :io)
+        close(http.stream.io)
+        return
+    end
+    error("Unable to find the test server stream transport")
+end
+
 function fake_jwt(payload::AbstractDict)
     encoded = Base64.base64encode(JSON.json(payload))
     encoded = replace(encoded, '+' => '-', '/' => '_')
@@ -1115,6 +1145,11 @@ end
         @test get(() -> nothing, parsed_output, "tool_error") == true
     end
 
+    @test Agentif._responses_split_compound_id("café|élément") == ("café", "élément")
+    @test Agentif._split_compound_id("appel-é|élément") == ("appel-é", "élément")
+    @test Agentif._responses_split_compound_id("|élément") == ("", "élément")
+    @test Agentif._split_compound_id("appel|") == ("appel", "")
+
     let
         prior = AssistantMessage(
             provider = "openai-codex",
@@ -1158,6 +1193,12 @@ end
         @test get(() -> nothing, content[1], "type") == "output_text"
         @test get(() -> nothing, content[1], "text") == "cross-provider reasoning"
     end
+end
+
+@testset "skill metadata unquoting is UTF-8 safe" begin
+    @test Agentif.unquote("\"café\"") == "café"
+    @test Agentif.unquote("'😀'") == "😀"
+    @test Agentif.unquote("\"\"") == ""
 end
 
 @testset "openai request shaping and usage parity" begin
@@ -1302,8 +1343,7 @@ end
     end
 
     try
-        sock = HTTP.Sockets.getsockname(server.listener.server)
-        port = sock[2]
+        port = test_server_port(server)
         model = Model(
             id = "gpt-5.2",
             name = "gpt-5.2",
@@ -1340,6 +1380,49 @@ end
     end
 end
 
+@testset "anthropic stream error event maps to error" begin
+    seen_events = Agentif.AgentEvent[]
+
+    server = HTTP.serve!("127.0.0.1", 0) do req
+        sse = join([
+            "data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_e\",\"role\":\"assistant\",\"content\":[],\"usage\":{\"input_tokens\":5,\"output_tokens\":0}}}",
+            "data: {\"type\":\"error\",\"error\":{\"type\":\"overloaded_error\",\"message\":\"Overloaded\"}}",
+        ], "\n\n") * "\n\n"
+        return HTTP.Response(200, ["Content-Type" => "text/event-stream"], sse)
+    end
+
+    try
+        port = test_server_port(server)
+        model = Model(
+            id = "claude-test",
+            name = "claude-test",
+            api = "anthropic-messages",
+            provider = "anthropic",
+            baseUrl = "http://127.0.0.1:$port",
+            reasoning = false,
+            input = ["text"],
+            cost = Dict("input" => 0.0, "output" => 0.0, "cacheRead" => 0.0, "cacheWrite" => 0.0),
+            contextWindow = 200000,
+            maxTokens = 8192,
+        )
+        agent = Agent(
+            id = "anthropic-error-test",
+            prompt = "You are helpful.",
+            model = model,
+            apikey = "test-key",
+            tools = AgentTool[],
+        )
+
+        result = stream(ev -> (push!(seen_events, ev); ev), agent, AgentState(), "Hello", Abort())
+        @test result.most_recent_stop_reason == :error
+        @test count(ev -> ev isa Agentif.AgentErrorEvent, seen_events) == 1
+        @test count(ev -> ev isa Agentif.MessageStartEvent, seen_events) == 1
+        @test count(ev -> ev isa Agentif.MessageEndEvent, seen_events) == 1
+    finally
+        close(server)
+    end
+end
+
 @testset "anthropic stream redacted thinking, unknown blocks, and usage merge" begin
     seen_events = Agentif.AgentEvent[]
 
@@ -1362,8 +1445,7 @@ end
     end
 
     try
-        sock = HTTP.Sockets.getsockname(server.listener.server)
-        port = sock[2]
+        port = test_server_port(server)
         model = Model(
             id = "claude-test",
             name = "claude-test",
@@ -1443,8 +1525,7 @@ end
     end
 
     try
-        sock = HTTP.Sockets.getsockname(server.listener.server)
-        port = sock[2]
+        port = test_server_port(server)
         model = Model(
             id = "claude-test",
             name = "claude-test",
@@ -1703,12 +1784,30 @@ end
     @test !Agentif.sse_recoverable_connection_error(InterruptException())
     @test !Agentif.sse_recoverable_connection_error(Agentif.StopStreaming())
     @test !Agentif.sse_recoverable_connection_error(ArgumentError("bad input"))
+    failed_task = @async throw(EOFError())
+    task_error = try
+        wait(failed_task)
+        nothing
+    catch err
+        err
+    end
+    @test task_error isa TaskFailedException
+    @test Agentif.sse_recoverable_connection_error(task_error)
+    failed_parse_task = @async throw(test_parse_error("unexpected EOF while reading HTTP data"))
+    parse_task_error = try
+        wait(failed_parse_task)
+        nothing
+    catch err
+        err
+    end
+    @test parse_task_error isa TaskFailedException
+    @test Agentif.sse_recoverable_connection_error(parse_task_error)
 
     # HTTP.StatusError routes through status-based retryability, not connection recovery
-    status_err = HTTP.StatusError(503, "POST", "/x", HTTP.Response(503))
+    status_err = test_status_error(503)
     @test !Agentif.sse_recoverable_connection_error(status_err)
     @test Agentif.sse_retryable_error(status_err)
-    @test !Agentif.sse_retryable_error(HTTP.StatusError(400, "POST", "/x", HTTP.Response(400)))
+    @test !Agentif.sse_retryable_error(test_status_error(400))
 
     # http_kw overrides are respected
     @test Agentif.sse_retry_attempts(Agentif.DEFAULT_HTTP_KW) == 6
@@ -1775,8 +1874,7 @@ end
     end
 
     try
-        sock = HTTP.Sockets.getsockname(server.listener.server)
-        port = sock[2]
+        port = test_server_port(server)
         model = Model(
             id = "gpt-4.1",
             name = "gpt-4.1",
@@ -1812,7 +1910,7 @@ end
     request_count = Ref(0)
     seen_events = Agentif.AgentEvent[]
 
-    server = HTTP.serve!("127.0.0.1", 0; stream = true) do http
+    server = HTTP.listen!("127.0.0.1", 0) do http
         request_count[] += 1
         read(http)
         sse = join([
@@ -1821,18 +1919,15 @@ end
         ], "\n\n") * "\n\n"
         HTTP.setstatus(http, 200)
         HTTP.setheader(http, "Content-Type" => "text/event-stream")
-        # Declare more bytes than we send so the closed socket is a hard error
-        HTTP.setheader(http, "Content-Length" => string(sizeof(sse) + 4096))
         HTTP.startwrite(http)
         write(http, sse)
         flush(http)
         sleep(0.2)
-        close(http.stream.io)  # drop the connection mid-stream
+        test_force_close_stream(http)  # drop before the terminating chunk/end-stream
     end
 
     try
-        sock = HTTP.Sockets.getsockname(server.listener.server)
-        port = sock[2]
+        port = test_server_port(server)
         model = Model(
             id = "gpt-4.1",
             name = "gpt-4.1",
@@ -1872,7 +1967,7 @@ end
     request_count = Ref(0)
     seen_events = Agentif.AgentEvent[]
 
-    server = HTTP.serve!("127.0.0.1", 0; stream = true) do http
+    server = HTTP.listen!("127.0.0.1", 0) do http
         request_count[] += 1
         read(http)
         sse = join([
@@ -1881,17 +1976,15 @@ end
         ], "\n\n") * "\n\n"
         HTTP.setstatus(http, 200)
         HTTP.setheader(http, "Content-Type" => "text/event-stream")
-        HTTP.setheader(http, "Content-Length" => string(sizeof(sse) + 4096))
         HTTP.startwrite(http)
         write(http, sse)
         flush(http)
         sleep(0.2)
-        close(http.stream.io)  # drop the connection mid-stream
+        test_force_close_stream(http)  # drop before the terminating chunk/end-stream
     end
 
     try
-        sock = HTTP.Sockets.getsockname(server.listener.server)
-        port = sock[2]
+        port = test_server_port(server)
         model = Model(
             id = "gpt-5.3-codex",
             name = "gpt-5.3-codex",
@@ -1950,8 +2043,7 @@ end
     end
 
     try
-        sock = HTTP.Sockets.getsockname(server.listener.server)
-        port = sock[2]
+        port = test_server_port(server)
         model = Model(
             id = "gemini-2.5-flash",
             name = "gemini-2.5-flash",

--- a/Agentif/test/runtests.jl
+++ b/Agentif/test/runtests.jl
@@ -1194,6 +1194,42 @@ end
     @test completions_usage.total == 16
 end
 
+@testset "completions message builder terminates on empty messages" begin
+    model = Model(
+        id = "test-model", name = "test-model", api = "openai-completions",
+        provider = "test", baseUrl = "http://localhost", reasoning = false,
+        input = ["text"],
+        cost = Dict("input" => 0.0, "output" => 0.0, "cacheRead" => 0.0, "cacheWrite" => 0.0),
+        contextWindow = 100000, maxTokens = 4096,
+    )
+    agent = Agent(; id = "a", prompt = "p", model, apikey = "k")
+    state = AgentState()
+    # Empty assistant message (routinely produced by an errored/aborted turn) and
+    # an image-only user message to a text-only model: both used to `continue`
+    # without advancing the loop index, hanging the builder forever.
+    push!(state.messages, AssistantMessage(; provider = "test", api = "openai-completions", model = "test-model"))
+    push!(state.messages, UserMessage(Agentif.UserContentBlock[Agentif.ImageContent("aGk=", "image/png")]))
+    result = Ref{Any}(nothing)
+    t = @async (result[] = Agentif.openai_completions_build_messages(agent, state, "hi", model))
+    timedwait(() -> istaskdone(t), 30.0)
+    @test istaskdone(t)
+    if istaskdone(t)
+        msgs = result[]
+        @test !any(m -> m.role == "assistant", msgs)
+        @test count(m -> m.role == "user", msgs) == 1
+    end
+end
+
+@testset "utf8-safe truncation previews" begin
+    s = repeat("é", 400)  # 2-byte chars: byte-index slicing throws StringIndexError
+    p = Agentif.toolcall_preview(s; limit = 300)
+    @test endswith(p, "...(truncated)")
+    @test startswith(p, repeat("é", 300))
+    t = Agentif.truncate_text(repeat("🐳", 50), 10)  # 4-byte chars
+    @test startswith(t, repeat("🐳", 10))
+    @test occursin("[truncated 40]", t)
+end
+
 @testset "openai_responses stream shapes GPT-5 requests and keeps incomplete as length" begin
     request_body = Ref(Dict{String, Any}())
     seen_events = Agentif.AgentEvent[]

--- a/Agentif/test/runtests.jl
+++ b/Agentif/test/runtests.jl
@@ -1214,7 +1214,7 @@ end
     timedwait(() -> istaskdone(t), 30.0)
     @test istaskdone(t)
     if istaskdone(t)
-        msgs = result[]
+        msgs, _ = result[]
         @test !any(m -> m.role == "assistant", msgs)
         @test count(m -> m.role == "user", msgs) == 1
     end
@@ -1279,6 +1279,195 @@ end
         dev_content = get(() -> Any[], input_items[1], "content")
         @test dev_content isa AbstractVector
         @test get(() -> nothing, dev_content[1], "text") == "# Juice: 0 !important"
+    finally
+        close(server)
+    end
+end
+
+@testset "openai_responses stream ends message once on response.completed" begin
+    seen_events = Agentif.AgentEvent[]
+
+    server = HTTP.serve!("127.0.0.1", 0) do req
+        sse = join([
+            "data: {\"type\":\"response.reasoning_summary_text.delta\",\"delta\":\"Think\",\"item_id\":\"rs_1\"}",
+            # Arrives before the message item begins; must NOT end the message.
+            "data: {\"type\":\"response.reasoning_summary_text.done\",\"text\":\"Think\",\"item_id\":\"rs_1\"}",
+            "data: {\"type\":\"response.output_text.delta\",\"delta\":\"Hello\",\"item_id\":\"msg_1\"}",
+            "data: {\"type\":\"response.output_text.delta\",\"delta\":\" world\",\"item_id\":\"msg_1\"}",
+            "data: {\"type\":\"response.output_text.done\",\"text\":\"Hello world\",\"item_id\":\"msg_1\"}",
+            "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-5.2\",\"status\":\"completed\",\"usage\":{\"input_tokens\":10,\"output_tokens\":4,\"total_tokens\":14}}}",
+            "data: [DONE]",
+        ], "\n\n") * "\n\n"
+        return HTTP.Response(200, ["Content-Type" => "text/event-stream"], sse)
+    end
+
+    try
+        sock = HTTP.Sockets.getsockname(server.listener.server)
+        port = sock[2]
+        model = Model(
+            id = "gpt-5.2",
+            name = "gpt-5.2",
+            api = "openai-responses",
+            provider = "openai",
+            baseUrl = "http://127.0.0.1:$port",
+            reasoning = true,
+            input = ["text"],
+            cost = Dict("input" => 0.0, "output" => 0.0, "cacheRead" => 0.0, "cacheWrite" => 0.0),
+            contextWindow = 128000,
+            maxTokens = 32000,
+        )
+        agent = Agent(
+            id = "responses-end-once-test",
+            prompt = "You are helpful.",
+            model = model,
+            apikey = "test-key",
+            tools = AgentTool[],
+        )
+
+        result = stream(ev -> (push!(seen_events, ev); ev), agent, AgentState(), "Say hello", Abort())
+        @test result.most_recent_stop_reason == :stop
+        @test !any(ev -> ev isa Agentif.AgentErrorEvent, seen_events)
+        end_indices = findall(ev -> ev isa Agentif.MessageEndEvent, seen_events)
+        @test length(end_indices) == 1
+        last_update = findlast(ev -> ev isa Agentif.MessageUpdateEvent, seen_events)
+        @test last_update !== nothing && end_indices[1] > last_update
+        assistant = result.messages[end]
+        @test assistant isa AssistantMessage
+        @test Agentif.message_text(assistant) == "Hello world"
+        @test Agentif.message_thinking(assistant) == "Think"
+    finally
+        close(server)
+    end
+end
+
+@testset "anthropic stream redacted thinking, unknown blocks, and usage merge" begin
+    seen_events = Agentif.AgentEvent[]
+
+    server = HTTP.serve!("127.0.0.1", 0) do req
+        sse = join([
+            "data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_a\",\"role\":\"assistant\",\"content\":[],\"usage\":{\"input_tokens\":100,\"output_tokens\":1,\"cache_read_input_tokens\":40,\"cache_creation_input_tokens\":7}}}",
+            "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"redacted_thinking\",\"data\":\"opaque-blob\"}}",
+            "data: {\"type\":\"content_block_stop\",\"index\":0}",
+            "data: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"server_tool_use\",\"id\":\"srvtoolu_1\",\"name\":\"web_search\",\"input\":{}}}",
+            "data: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"citations_delta\",\"citation\":{\"url\":\"https://example.com\"}}}",
+            "data: {\"type\":\"content_block_stop\",\"index\":1}",
+            "data: {\"type\":\"content_block_start\",\"index\":2,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}",
+            "data: {\"type\":\"content_block_delta\",\"index\":2,\"delta\":{\"type\":\"text_delta\",\"text\":\"Hello\"}}",
+            "data: {\"type\":\"content_block_stop\",\"index\":2}",
+            # Delta usage only carries output_tokens; input/cache from message_start must survive.
+            "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":9}}",
+            "data: {\"type\":\"message_stop\"}",
+        ], "\n\n") * "\n\n"
+        return HTTP.Response(200, ["Content-Type" => "text/event-stream"], sse)
+    end
+
+    try
+        sock = HTTP.Sockets.getsockname(server.listener.server)
+        port = sock[2]
+        model = Model(
+            id = "claude-test",
+            name = "claude-test",
+            api = "anthropic-messages",
+            provider = "anthropic",
+            baseUrl = "http://127.0.0.1:$port",
+            reasoning = true,
+            input = ["text"],
+            cost = Dict("input" => 0.0, "output" => 0.0, "cacheRead" => 0.0, "cacheWrite" => 0.0),
+            contextWindow = 200000,
+            maxTokens = 8192,
+        )
+        agent = Agent(
+            id = "anthropic-redacted-test",
+            prompt = "You are helpful.",
+            model = model,
+            apikey = "test-key",
+            tools = AgentTool[],
+        )
+
+        result = stream(ev -> (push!(seen_events, ev); ev), agent, AgentState(), "Say hello", Abort())
+        @test result.most_recent_stop_reason == :stop
+        @test !any(ev -> ev isa Agentif.AgentErrorEvent, seen_events)
+
+        assistant = result.messages[end]
+        @test assistant isa AssistantMessage
+        thinking_blocks = [b for b in assistant.content if b isa Agentif.ThinkingContent]
+        @test length(thinking_blocks) == 1
+        @test thinking_blocks[1].redacted
+        @test thinking_blocks[1].thinking == ""
+        @test thinking_blocks[1].thinkingSignature == "opaque-blob"
+        @test Agentif.message_text(assistant) == "Hello"
+
+        # Usage from message_start survives a delta that only carries output_tokens.
+        @test result.usage.input == 100
+        @test result.usage.output == 9
+        @test result.usage.cacheRead == 40
+        @test result.usage.cacheWrite == 7
+
+        # Replay: redacted thinking converts back to a redacted_thinking wire block.
+        replayed = Agentif.anthropic_message_from_agent(assistant, Dict{String, String}(), model)
+        @test replayed !== nothing
+        lowered = JSON.parse(JSON.json(replayed))
+        content = lowered["content"]
+        @test content[1]["type"] == "redacted_thinking"
+        @test content[1]["data"] == "opaque-blob"
+        @test content[end]["type"] == "text"
+        @test content[end]["text"] == "Hello"
+
+        # Session persistence round-trip keeps the redacted flag; legacy JSON
+        # without the field still loads with redacted = false.
+        roundtrip = JSON.parse(JSON.json(assistant), Agentif.AgentMessage)
+        @test roundtrip isa AssistantMessage
+        rt_thinking = [b for b in roundtrip.content if b isa Agentif.ThinkingContent]
+        @test length(rt_thinking) == 1 && rt_thinking[1].redacted
+        legacy = JSON.parse("{\"type\":\"thinking\",\"thinking\":\"t\",\"thinkingSignature\":null}", Agentif.ContentBlock)
+        @test legacy isa Agentif.ThinkingContent
+        @test legacy.redacted == false
+    finally
+        close(server)
+    end
+end
+
+@testset "anthropic stream maps refusal to error stop reason" begin
+    seen_events = Agentif.AgentEvent[]
+
+    server = HTTP.serve!("127.0.0.1", 0) do req
+        sse = join([
+            "data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_r\",\"role\":\"assistant\",\"content\":[],\"usage\":{\"input_tokens\":5,\"output_tokens\":1}}}",
+            "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}",
+            "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"I can't help with that.\"}}",
+            "data: {\"type\":\"content_block_stop\",\"index\":0}",
+            "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"refusal\"},\"usage\":{\"output_tokens\":6}}",
+            "data: {\"type\":\"message_stop\"}",
+        ], "\n\n") * "\n\n"
+        return HTTP.Response(200, ["Content-Type" => "text/event-stream"], sse)
+    end
+
+    try
+        sock = HTTP.Sockets.getsockname(server.listener.server)
+        port = sock[2]
+        model = Model(
+            id = "claude-test",
+            name = "claude-test",
+            api = "anthropic-messages",
+            provider = "anthropic",
+            baseUrl = "http://127.0.0.1:$port",
+            reasoning = false,
+            input = ["text"],
+            cost = Dict("input" => 0.0, "output" => 0.0, "cacheRead" => 0.0, "cacheWrite" => 0.0),
+            contextWindow = 200000,
+            maxTokens = 8192,
+        )
+        agent = Agent(
+            id = "anthropic-refusal-test",
+            prompt = "You are helpful.",
+            model = model,
+            apikey = "test-key",
+            tools = AgentTool[],
+        )
+
+        result = stream(ev -> (push!(seen_events, ev); ev), agent, AgentState(), "Do the thing", Abort())
+        @test result.most_recent_stop_reason == :error
+        @test !any(ev -> ev isa Agentif.AgentErrorEvent, seen_events)
     finally
         close(server)
     end
@@ -1497,6 +1686,301 @@ end
         @test result isa AgentState
         @test result.messages[end] isa AssistantMessage
         @test Agentif.message_text(result.messages[end]) == "Hello from body"
+    finally
+        close(server)
+    end
+end
+
+@testset "sse retry helpers" begin
+    @test Agentif.sse_retryable_status(503)
+    @test Agentif.sse_retryable_status(429)
+    @test !Agentif.sse_retryable_status(400)
+    @test !Agentif.sse_retryable_status(401)
+
+    @test Agentif.sse_recoverable_connection_error(EOFError())
+    @test Agentif.sse_recoverable_connection_error(Base.IOError("connection reset", -104))
+    @test Agentif.sse_recoverable_connection_error(HTTP.ConnectError("http://x", EOFError()))
+    @test !Agentif.sse_recoverable_connection_error(InterruptException())
+    @test !Agentif.sse_recoverable_connection_error(Agentif.StopStreaming())
+    @test !Agentif.sse_recoverable_connection_error(ArgumentError("bad input"))
+
+    # HTTP.StatusError routes through status-based retryability, not connection recovery
+    status_err = HTTP.StatusError(503, "POST", "/x", HTTP.Response(503))
+    @test !Agentif.sse_recoverable_connection_error(status_err)
+    @test Agentif.sse_retryable_error(status_err)
+    @test !Agentif.sse_retryable_error(HTTP.StatusError(400, "POST", "/x", HTTP.Response(400)))
+
+    # http_kw overrides are respected
+    @test Agentif.sse_retry_attempts(Agentif.DEFAULT_HTTP_KW) == 6
+    @test Agentif.sse_retry_attempts((; retry = false, retries = 5)) == 1
+    @test Agentif.sse_retry_attempts((; retry = true, retries = 2)) == 3
+    @test Agentif.sse_retry_attempts((; retry = true, retries = 0)) == 1
+
+    # Retry-After honored and capped by max_delay_ms
+    retry_after_resp = HTTP.Response(429, ["Retry-After" => "3"], "")
+    @test Agentif.codex_retry_delay_seconds(1, 1000, 60000; response = retry_after_resp) == 3.0
+    capped_resp = HTTP.Response(503, ["Retry-After" => "500"], "")
+    @test Agentif.codex_retry_delay_seconds(1, 1000, 60000; response = capped_resp) == 60.0
+
+    # Retries transient failures while no SSE event has been delivered
+    events_seen = Ref(false)
+    calls = Ref(0)
+    result = Agentif.sse_request_with_retry(events_seen, Abort(); max_attempts = 3, base_delay_ms = 1, max_delay_ms = 2) do
+        calls[] += 1
+        calls[] < 3 && throw(EOFError())
+        return :ok
+    end
+    @test result == :ok
+    @test calls[] == 3
+
+    # Never retries once an event has been delivered
+    events_seen[] = true
+    calls[] = 0
+    @test_throws EOFError Agentif.sse_request_with_retry(events_seen, Abort(); max_attempts = 3, base_delay_ms = 1, max_delay_ms = 2) do
+        calls[] += 1
+        throw(EOFError())
+    end
+    @test calls[] == 1
+
+    # Never retries non-transient errors
+    events_seen[] = false
+    calls[] = 0
+    @test_throws ArgumentError Agentif.sse_request_with_retry(events_seen, Abort(); max_attempts = 3, base_delay_ms = 1, max_delay_ms = 2) do
+        calls[] += 1
+        throw(ArgumentError("nope"))
+    end
+    @test calls[] == 1
+end
+
+@testset "openai_responses stream retries pre-stream 503 then succeeds" begin
+    request_count = Ref(0)
+    seen_events = Agentif.AgentEvent[]
+
+    server = HTTP.serve!("127.0.0.1", 0) do req
+        request_count[] += 1
+        if request_count[] == 1
+            return HTTP.Response(
+                503,
+                ["Content-Type" => "application/json", "Retry-After" => "0"],
+                "{\"error\":{\"message\":\"temporary outage\"}}",
+            )
+        end
+        sse = join([
+            "data: {\"type\":\"response.output_item.added\",\"item\":{\"type\":\"message\",\"id\":\"msg_1\",\"role\":\"assistant\",\"content\":[]}}",
+            "data: {\"type\":\"response.output_text.delta\",\"delta\":\"Hello\"}",
+            "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-4.1\",\"status\":\"completed\",\"usage\":{\"input_tokens\":1,\"input_tokens_details\":{\"cached_tokens\":0},\"output_tokens\":1,\"total_tokens\":2}}}",
+            "data: [DONE]",
+        ], "\n\n") * "\n\n"
+        return HTTP.Response(200, ["Content-Type" => "text/event-stream"], sse)
+    end
+
+    try
+        sock = HTTP.Sockets.getsockname(server.listener.server)
+        port = sock[2]
+        model = Model(
+            id = "gpt-4.1",
+            name = "gpt-4.1",
+            api = "openai-responses",
+            provider = "openai",
+            baseUrl = "http://127.0.0.1:$port",
+            reasoning = false,
+            input = ["text"],
+            cost = Dict("input" => 0.0, "output" => 0.0, "cacheRead" => 0.0, "cacheWrite" => 0.0),
+            contextWindow = 128000,
+            maxTokens = 32000,
+        )
+        agent = Agent(
+            id = "responses-503-retry-test",
+            prompt = "You are helpful.",
+            model = model,
+            apikey = "test-key",
+            tools = AgentTool[],
+        )
+
+        result = stream(ev -> (push!(seen_events, ev); ev), agent, AgentState(), "Say hello", Abort())
+        @test request_count[] == 2
+        @test !any(ev -> ev isa Agentif.AgentErrorEvent, seen_events)
+        @test result.most_recent_stop_reason == :stop
+        @test result.messages[end] isa AssistantMessage
+        @test Agentif.message_text(result.messages[end]) == "Hello"
+    finally
+        close(server)
+    end
+end
+
+@testset "openai_responses stream surfaces mid-stream disconnect without duplicating deltas" begin
+    request_count = Ref(0)
+    seen_events = Agentif.AgentEvent[]
+
+    server = HTTP.serve!("127.0.0.1", 0; stream = true) do http
+        request_count[] += 1
+        read(http)
+        sse = join([
+            "data: {\"type\":\"response.output_item.added\",\"item\":{\"type\":\"message\",\"id\":\"msg_1\",\"role\":\"assistant\",\"content\":[]}}",
+            "data: {\"type\":\"response.output_text.delta\",\"delta\":\"MARKER_ONCE\"}",
+        ], "\n\n") * "\n\n"
+        HTTP.setstatus(http, 200)
+        HTTP.setheader(http, "Content-Type" => "text/event-stream")
+        # Declare more bytes than we send so the closed socket is a hard error
+        HTTP.setheader(http, "Content-Length" => string(sizeof(sse) + 4096))
+        HTTP.startwrite(http)
+        write(http, sse)
+        flush(http)
+        sleep(0.2)
+        close(http.stream.io)  # drop the connection mid-stream
+    end
+
+    try
+        sock = HTTP.Sockets.getsockname(server.listener.server)
+        port = sock[2]
+        model = Model(
+            id = "gpt-4.1",
+            name = "gpt-4.1",
+            api = "openai-responses",
+            provider = "openai",
+            baseUrl = "http://127.0.0.1:$port",
+            reasoning = false,
+            input = ["text"],
+            cost = Dict("input" => 0.0, "output" => 0.0, "cacheRead" => 0.0, "cacheWrite" => 0.0),
+            contextWindow = 128000,
+            maxTokens = 32000,
+        )
+        agent = Agent(
+            id = "responses-disconnect-test",
+            prompt = "You are helpful.",
+            model = model,
+            apikey = "test-key",
+            tools = AgentTool[],
+        )
+
+        result = stream(ev -> (push!(seen_events, ev); ev), agent, AgentState(), "Say hello", Abort())
+        # Events already flowed, so the request must NOT be replayed
+        @test request_count[] == 1
+        @test result.most_recent_stop_reason == :error
+        @test any(ev -> ev isa Agentif.AgentErrorEvent, seen_events)
+        @test result.messages[end] isa AssistantMessage
+        delivered = Agentif.message_text(result.messages[end])
+        @test length(collect(eachmatch(r"MARKER_ONCE", delivered))) == 1
+        @test count(ev -> ev isa Agentif.MessageUpdateEvent && occursin("MARKER_ONCE", ev.delta), seen_events) == 1
+        @test count(ev -> ev isa Agentif.MessageEndEvent, seen_events) == 1
+    finally
+        close(server)
+    end
+end
+
+@testset "openai_codex stream does not re-POST after mid-stream disconnect" begin
+    request_count = Ref(0)
+    seen_events = Agentif.AgentEvent[]
+
+    server = HTTP.serve!("127.0.0.1", 0; stream = true) do http
+        request_count[] += 1
+        read(http)
+        sse = join([
+            "data: {\"type\":\"response.output_item.added\",\"item\":{\"type\":\"message\",\"id\":\"msg_1\",\"role\":\"assistant\",\"content\":[]}}",
+            "data: {\"type\":\"response.output_text.delta\",\"delta\":\"CODEX_MARKER\"}",
+        ], "\n\n") * "\n\n"
+        HTTP.setstatus(http, 200)
+        HTTP.setheader(http, "Content-Type" => "text/event-stream")
+        HTTP.setheader(http, "Content-Length" => string(sizeof(sse) + 4096))
+        HTTP.startwrite(http)
+        write(http, sse)
+        flush(http)
+        sleep(0.2)
+        close(http.stream.io)  # drop the connection mid-stream
+    end
+
+    try
+        sock = HTTP.Sockets.getsockname(server.listener.server)
+        port = sock[2]
+        model = Model(
+            id = "gpt-5.3-codex",
+            name = "gpt-5.3-codex",
+            api = "openai-codex-responses",
+            provider = "openai-codex",
+            baseUrl = "http://127.0.0.1:$port",
+            reasoning = true,
+            input = ["text"],
+            cost = Dict("input" => 0.0, "output" => 0.0, "cacheRead" => 0.0, "cacheWrite" => 0.0),
+            contextWindow = 128000,
+            maxTokens = 32000,
+        )
+        token = fake_jwt(Dict("https://api.openai.com/auth" => Dict("chatgpt_account_id" => "acct-jwt-disconnect")))
+        agent = Agent(
+            id = "codex-disconnect-test",
+            prompt = "You are helpful.",
+            model = model,
+            apikey = token,
+            tools = AgentTool[],
+        )
+
+        err = try
+            stream(
+                ev -> (push!(seen_events, ev); ev),
+                agent,
+                AgentState(),
+                "Say hello",
+                Abort();
+                max_retries = 3,
+                retry_base_ms = 1,
+                retry_max_ms = 5,
+            )
+            nothing
+        catch e
+            e
+        end
+        @test err isa Exception
+        @test !(err isa Agentif.StopStreaming)
+        # The delivered events must not be replayed by a re-POST
+        @test request_count[] == 1
+        @test count(ev -> ev isa Agentif.MessageUpdateEvent && occursin("CODEX_MARKER", ev.delta), seen_events) == 1
+    finally
+        close(server)
+    end
+end
+
+@testset "google_generative stream surfaces HTTP status errors" begin
+    seen_events = Agentif.AgentEvent[]
+
+    server = HTTP.serve!("127.0.0.1", 0) do req
+        return HTTP.Response(
+            400,
+            ["Content-Type" => "application/json"],
+            "{\"error\":{\"code\":400,\"message\":\"Invalid request\",\"status\":\"INVALID_ARGUMENT\"}}",
+        )
+    end
+
+    try
+        sock = HTTP.Sockets.getsockname(server.listener.server)
+        port = sock[2]
+        model = Model(
+            id = "gemini-2.5-flash",
+            name = "gemini-2.5-flash",
+            api = "google-generative-ai",
+            provider = "google",
+            baseUrl = "http://127.0.0.1:$port",
+            reasoning = false,
+            input = ["text"],
+            cost = Dict("input" => 0.0, "output" => 0.0, "cacheRead" => 0.0, "cacheWrite" => 0.0),
+            contextWindow = 128000,
+            maxTokens = 32000,
+        )
+        agent = Agent(
+            id = "google-status-error-test",
+            prompt = "You are helpful.",
+            model = model,
+            apikey = "test-key",
+            tools = AgentTool[],
+        )
+
+        result = stream(ev -> (push!(seen_events, ev); ev), agent, AgentState(), "Say hello", Abort())
+        @test result.most_recent_stop_reason == :error
+        error_events = filter(ev -> ev isa Agentif.AgentErrorEvent, seen_events)
+        @test length(error_events) == 1
+        @test occursin("Invalid request", sprint(showerror, error_events[1].error))
+        # The assistant message is still started/finalized like the openai branches
+        @test count(ev -> ev isa Agentif.MessageStartEvent, seen_events) == 1
+        @test count(ev -> ev isa Agentif.MessageEndEvent, seen_events) == 1
+        @test result.messages[end] isa AssistantMessage
     finally
         close(server)
     end

--- a/Claw/ext/ClawGitHubExt/ClawGitHubExt.jl
+++ b/Claw/ext/ClawGitHubExt/ClawGitHubExt.jl
@@ -415,7 +415,13 @@ Claw.get_event_types(::GitHubEventSource) = ALL_EVENT_TYPES
 
 function Claw.start!(source::GitHubEventSource, assistant::Claw.AgentAssistant)
     secret = strip(source.secret)
-    webhook_secret = isempty(secret) ? nothing : secret
+    # Fail closed: without a secret GitHub.jl skips HMAC verification entirely,
+    # so anyone who can reach the port can inject forged webhook events (which
+    # get evaluated as trusted agent input).
+    isempty(secret) && error(
+        "GitHubEventSource requires a webhook secret. Set GITHUB_WEBHOOK_SECRET " *
+        "(and configure the same secret on the GitHub webhook) before starting.")
+    webhook_secret = String(secret)
     repos = source.repos !== nothing ? map(GitHub.Repo, source.repos) : nothing
     host = Sockets.IPv4(source.host)
     port = source.port

--- a/Claw/ext/ClawTelegramExt/ClawTelegramExt.jl
+++ b/Claw/ext/ClawTelegramExt/ClawTelegramExt.jl
@@ -392,7 +392,9 @@ function Claw.start!(source::TelegramEventSource, assistant::Claw.AgentAssistant
             for row in Claw.SQLite.DBInterface.execute(assistant.db,
                 "SELECT DISTINCT channel_id FROM claw_event_handlers WHERE channel_id LIKE 'telegram:%'")
                 cid = row.channel_id === missing ? "" : String(row.channel_id)
-                m = match(r"^telegram:(\d+)$", cid)
+                # Group/supergroup chat ids are negative — the sign must be accepted
+                # or persisted group handlers silently resolve to a sink after restart.
+                m = match(r"^telegram:(-?\d+)$", cid)
                 m !== nothing && push!(seed_channels, TelegramChannel(
                     parse(Int64, m.captures[1]), nothing, source.client, IOBuffer(), "", "", "private"))
             end

--- a/Claw/ext/mattermost_run.jl
+++ b/Claw/ext/mattermost_run.jl
@@ -4,3 +4,6 @@ const ClawMattermostExt = Base.get_extension(Claw, :ClawMattermostExt)
 
 source = ClawMattermostExt.MattermostEventSource()
 Claw.run(; event_sources=Claw.EventSource[source])
+
+# Claw.run is non-blocking; keep the process alive so source tasks stay up.
+wait(Base.Event())

--- a/Claw/ext/msteams_run.jl
+++ b/Claw/ext/msteams_run.jl
@@ -4,3 +4,6 @@ const ClawMSTeamsExt = Base.get_extension(Claw, :ClawMSTeamsExt)
 
 source = ClawMSTeamsExt.MSTeamsEventSource()
 Claw.run(; event_sources=Claw.EventSource[source])
+
+# Claw.run is non-blocking; keep the process alive so source tasks stay up.
+wait(Base.Event())

--- a/Claw/ext/signal_run.jl
+++ b/Claw/ext/signal_run.jl
@@ -4,3 +4,6 @@ const ClawSignalExt = Base.get_extension(Claw, :ClawSignalExt)
 
 source = ClawSignalExt.SignalEventSource()
 Claw.run(; event_sources=Claw.EventSource[source])
+
+# Claw.run is non-blocking; keep the process alive so source tasks stay up.
+wait(Base.Event())

--- a/Claw/ext/slack_run.jl
+++ b/Claw/ext/slack_run.jl
@@ -4,3 +4,6 @@ const ClawSlackExt = Base.get_extension(Claw, :ClawSlackExt)
 
 source = ClawSlackExt.SlackEventSource()
 Claw.run(; event_sources=Claw.EventSource[source])
+
+# Claw.run is non-blocking; keep the process alive so source tasks stay up.
+wait(Base.Event())

--- a/Claw/ext/telegram_run.jl
+++ b/Claw/ext/telegram_run.jl
@@ -4,3 +4,6 @@ const ClawTelegramExt = Base.get_extension(Claw, :ClawTelegramExt)
 
 source = ClawTelegramExt.TelegramEventSource()
 Claw.run(; event_sources=Claw.EventSource[source])
+
+# Claw.run is non-blocking; keep the process alive so source tasks stay up.
+wait(Base.Event())

--- a/Claw/src/Claw.jl
+++ b/Claw/src/Claw.jl
@@ -249,19 +249,25 @@ function register_channels!(assistant::AgentAssistant, channels)
 end
 
 function _upsert_event_handler!(db::SQLite.DB, eh::EventHandler)
-    # Transactional so a crash between the DELETE and the re-INSERTs can't leave
-    # a handler with zero subscribed event types (an automation that never fires).
-    SQLite.transaction(db) do
+    SQLite.DBInterface.execute(db,
+        "INSERT OR REPLACE INTO claw_event_handlers (id, prompt, channel_id) VALUES (?, ?, ?)",
+        (eh.id, eh.prompt, eh.channel_id))
+    # Insert new subscriptions before deleting stale ones so a crash mid-upsert
+    # can never leave the handler with zero event types (a dead automation);
+    # worst case is a transient union of old+new until the next upsert.
+    for et_name in eh.event_types
         SQLite.DBInterface.execute(db,
-            "INSERT OR REPLACE INTO claw_event_handlers (id, prompt, channel_id) VALUES (?, ?, ?)",
-            (eh.id, eh.prompt, eh.channel_id))
+            "INSERT OR IGNORE INTO claw_handler_event_types (handler_id, event_type_name) VALUES (?, ?)",
+            (eh.id, et_name))
+    end
+    if isempty(eh.event_types)
         SQLite.DBInterface.execute(db,
             "DELETE FROM claw_handler_event_types WHERE handler_id = ?", (eh.id,))
-        for et_name in eh.event_types
-            SQLite.DBInterface.execute(db,
-                "INSERT OR IGNORE INTO claw_handler_event_types (handler_id, event_type_name) VALUES (?, ?)",
-                (eh.id, et_name))
-        end
+    else
+        placeholders = join(fill("?", length(eh.event_types)), ",")
+        SQLite.DBInterface.execute(db,
+            "DELETE FROM claw_handler_event_types WHERE handler_id = ? AND event_type_name NOT IN ($placeholders)",
+            (eh.id, eh.event_types...))
     end
 end
 

--- a/Claw/src/Claw.jl
+++ b/Claw/src/Claw.jl
@@ -195,8 +195,8 @@ get_event_handlers(::EventSource) = EventHandler[]
 get_tools(::EventSource) = Agentif.AgentTool[]
 start!(::EventSource, ::AgentAssistant) = nothing
 
-function run(; event_sources=nothing, kwargs...)
-    return init!(""; event_sources, kwargs...)
+function run(; db_path::String="", event_sources=nothing, kwargs...)
+    return init!(db_path; event_sources, kwargs...)
 end
 
 # ─── Event interface ───
@@ -249,15 +249,19 @@ function register_channels!(assistant::AgentAssistant, channels)
 end
 
 function _upsert_event_handler!(db::SQLite.DB, eh::EventHandler)
-    SQLite.DBInterface.execute(db,
-        "INSERT OR REPLACE INTO claw_event_handlers (id, prompt, channel_id) VALUES (?, ?, ?)",
-        (eh.id, eh.prompt, eh.channel_id))
-    SQLite.DBInterface.execute(db,
-        "DELETE FROM claw_handler_event_types WHERE handler_id = ?", (eh.id,))
-    for et_name in eh.event_types
+    # Transactional so a crash between the DELETE and the re-INSERTs can't leave
+    # a handler with zero subscribed event types (an automation that never fires).
+    SQLite.transaction(db) do
         SQLite.DBInterface.execute(db,
-            "INSERT OR IGNORE INTO claw_handler_event_types (handler_id, event_type_name) VALUES (?, ?)",
-            (eh.id, et_name))
+            "INSERT OR REPLACE INTO claw_event_handlers (id, prompt, channel_id) VALUES (?, ?, ?)",
+            (eh.id, eh.prompt, eh.channel_id))
+        SQLite.DBInterface.execute(db,
+            "DELETE FROM claw_handler_event_types WHERE handler_id = ?", (eh.id,))
+        for et_name in eh.event_types
+            SQLite.DBInterface.execute(db,
+                "INSERT OR IGNORE INTO claw_handler_event_types (handler_id, event_type_name) VALUES (?, ?)",
+                (eh.id, et_name))
+        end
     end
 end
 
@@ -442,7 +446,7 @@ Returns one entry per handler with: ID, subscribed event types, channel, and a p
             "SELECT event_type_name FROM claw_handler_event_types WHERE handler_id = ?", (row.id,))
             push!(ets, et_row.event_type_name)
         end
-        prompt_preview = length(row.prompt) > 80 ? string(row.prompt[1:80], "...") : row.prompt
+        prompt_preview = length(row.prompt) > 80 ? string(first(row.prompt, 80), "...") : row.prompt
         push!(lines, "- $(row.id) [events: $(join(ets, ", "))] [channel: $ch_id]\n  prompt: $prompt_preview")
     end
     isempty(lines) ? "No event handlers registered" : join(lines, "\n")
@@ -1157,6 +1161,15 @@ function init!(
     CURRENT_ASSISTANT[] = assistant
     # Purge ephemeral tables (re-populated from EventSources)
     SQLite.DBInterface.execute(assistant.db, "DELETE FROM claw_event_types")
+    # Re-seed event types for persisted Tempus jobs: they are only inserted at
+    # add_job time, so the purge above would otherwise orphan them (breaking
+    # list_event_types and add_event_handler validation for those types).
+    for j in Tempus.getJobs(assistant.scheduler.store)
+        et_name = "tempus_job:$(j.name)"
+        SQLite.DBInterface.execute(assistant.db,
+            "INSERT OR IGNORE INTO claw_event_types (name, description) VALUES (?, ?)",
+            (et_name, "Scheduled job: $(j.name)"))
+    end
     # Auto-register LLMToolsEventSource if not already provided
     if !any(es -> es isa LLMToolsEventSource, sources)
         llm_es = LLMToolsEventSource(assistant.config)
@@ -1194,7 +1207,9 @@ function Agentif.finish_streaming(ch::ReplChannel)
     notify(ch.completion)
 end
 Agentif.send_message(ch::ReplChannel, msg) = println(ch.io, msg)
-Agentif.close_channel(::ReplChannel) = nothing
+# Notify on close so `a"..."` never hangs when an evaluation errors out or the
+# response is suppressed (finish_streaming never runs on those paths).
+Agentif.close_channel(ch::ReplChannel) = notify(ch.completion)
 
 struct ReplEventSource <: EventSource end
 

--- a/Claw/src/llmtools.jl
+++ b/Claw/src/llmtools.jl
@@ -714,6 +714,7 @@ Arguments:
 - name (String, required): The name of an existing worker session (as given to start_worker).
 - code (String, required): Julia code to evaluate. Can reference variables/functions from prior calls.
 - run_sync (Bool, optional): If true, blocks until execution completes. Default: false (async).
+- timeout_s (Int, optional): Timeout in seconds for the evaluation. On timeout the worker process is terminated (all its state is lost) and a timeout error is reported. Default: no timeout.
 
 Example:
 - eval_worker("data-proc", "filter(row -> row.age > 30, df) |> nrow", run_sync=true)""",
@@ -721,6 +722,7 @@ Example:
             name::String,
             code::String,
             run_sync::Union{Nothing, Bool} = nothing,
+            timeout_s::Union{Nothing, Int} = nothing,
         ) = begin
             sync = run_sync === nothing ? false : run_sync
             session = _get_session(es, name, :worker)
@@ -730,7 +732,7 @@ Example:
             worker_meta === nothing && error("Worker session '$name' no longer exists in registry")
 
             if sync
-                combined, _ = LLMTools.eval_on_worker(worker_meta, code)
+                combined, _ = LLMTools.eval_on_worker(worker_meta, code; timeout_s = timeout_s)
                 lock(es.lock) do
                     session.last_used = time()
                 end
@@ -744,7 +746,7 @@ Example:
             end
             session.task = Threads.@spawn begin
                 try
-                    combined, _ = LLMTools.eval_on_worker(worker_meta, code)
+                    combined, _ = LLMTools.eval_on_worker(worker_meta, code; timeout_s = timeout_s)
                     lock(es.lock) do
                         s = get(es.sessions, name, nothing)
                         if s !== nothing

--- a/Claw/src/llmtools.jl
+++ b/Claw/src/llmtools.jl
@@ -624,6 +624,7 @@ Arguments:
 - code (String, required): Julia code to evaluate. Runs in a fresh worker process. Output includes both the return value and any stdout/stderr.
 - prompt (String, optional): Notification context prepended to the async completion event. Use to label what this worker is computing — e.g. "CSV parsing results". Ignored when run_sync=true.
 - run_sync (Bool, optional): If true, blocks until execution completes and returns the output. Default: false (async).
+- timeout_s (Int, optional): Timeout in seconds for the initial evaluation. On timeout the worker process is terminated and a timeout error is reported. Default: no timeout.
 
 Examples:
 - start_worker("data-proc", "using CSV, DataFrames; df = CSV.read(\\"data.csv\\", DataFrame); describe(df)", "Data summary")
@@ -633,6 +634,7 @@ Examples:
             code::String,
             prompt::Union{Nothing, String} = nothing,
             run_sync::Union{Nothing, Bool} = nothing,
+            timeout_s::Union{Nothing, Int} = nothing,
         ) = begin
             sync = run_sync === nothing ? false : run_sync
             _validate_name(es, name)
@@ -655,7 +657,7 @@ Examples:
 
             if sync
                 try
-                    combined, _ = LLMTools.eval_on_worker(worker_meta, code)
+                    combined, _ = LLMTools.eval_on_worker(worker_meta, code; timeout_s)
                     return LLMTools.truncate_tool_output(combined; label = "Worker output")
                 catch e
                     LLMTools.remove_session!(LLMTools.WORKER_REGISTRY, registry_id;
@@ -670,7 +672,7 @@ Examples:
                 registry_id = registry_id)
             session.task = Threads.@spawn begin
                 try
-                    combined, _ = LLMTools.eval_on_worker(worker_meta, code)
+                    combined, _ = LLMTools.eval_on_worker(worker_meta, code; timeout_s)
                     lock(es.lock) do
                         s = get(es.sessions, name, nothing)
                         if s !== nothing
@@ -681,6 +683,10 @@ Examples:
                     put!(a.event_queue, WorkerOutputEvent(event_type, name, combined))
                 catch e
                     bt = catch_backtrace()
+                    if e isa LLMTools.WorkerEvalTimeout
+                        LLMTools.remove_session!(LLMTools.WORKER_REGISTRY, registry_id;
+                            mark_status = LLMTools.SESSION_STATUS_ERROR)
+                    end
                     lock(es.lock) do
                         s = get(es.sessions, name, nothing)
                         s !== nothing && (s.status = "error")
@@ -732,11 +738,24 @@ Example:
             worker_meta === nothing && error("Worker session '$name' no longer exists in registry")
 
             if sync
-                combined, _ = LLMTools.eval_on_worker(worker_meta, code; timeout_s = timeout_s)
-                lock(es.lock) do
-                    session.last_used = time()
+                try
+                    combined, _ = LLMTools.eval_on_worker(worker_meta, code; timeout_s)
+                    lock(es.lock) do
+                        session.last_used = time()
+                        session.status = "completed"
+                    end
+                    return LLMTools.truncate_tool_output(combined; label = "Worker output")
+                catch e
+                    if e isa LLMTools.WorkerEvalTimeout
+                        LLMTools.remove_session!(LLMTools.WORKER_REGISTRY, session.registry_id;
+                            mark_status = LLMTools.SESSION_STATUS_ERROR)
+                    end
+                    lock(es.lock) do
+                        session.last_used = time()
+                        session.status = "error"
+                    end
+                    rethrow()
                 end
-                return LLMTools.truncate_tool_output(combined; label = "Worker output")
             end
 
             event_type = session.event_type
@@ -757,6 +776,10 @@ Example:
                     put!(a.event_queue, WorkerOutputEvent(event_type, name, combined))
                 catch e
                     bt = catch_backtrace()
+                    if e isa LLMTools.WorkerEvalTimeout
+                        LLMTools.remove_session!(LLMTools.WORKER_REGISTRY, session.registry_id;
+                            mark_status = LLMTools.SESSION_STATUS_ERROR)
+                    end
                     lock(es.lock) do
                         s = get(es.sessions, name, nothing)
                         s !== nothing && (s.status = "error")

--- a/Claw/test/smoke_test.jl
+++ b/Claw/test/smoke_test.jl
@@ -619,6 +619,13 @@ end
     @test Claw.get_channel(ev) === ch
     @test Claw.event_content(ev) == "hello world"
 
+    # close_channel must notify completion so a"..." never hangs when an
+    # evaluation errors out before finish_streaming runs.
+    ch2 = Claw.ReplChannel()
+    Agentif.close_channel(ch2)
+    waiter = @async wait(ch2.completion)
+    @test timedwait(() -> istaskdone(waiter), 5.0) == :ok
+
     println("  ✓ REPL EventSource passed")
 end
 

--- a/Claw/test/smoke_test.jl
+++ b/Claw/test/smoke_test.jl
@@ -169,6 +169,30 @@ end
     println("  ✓ Phase 2 passed")
 end
 
+@testset "Claw worker timeout cleanup" begin
+    a = make_test_assistant()
+    Claw.CURRENT_ASSISTANT[] = a
+    es = Claw.LLMToolsEventSource(a.config)
+    funcs = Dict(tool.name => tool.func for tool in Claw.get_tools(es))
+
+    started = funcs["start_worker"]("timeout-worker", "x = 1", nothing, false, 10)
+    @test occursin("started asynchronously", started)
+    @test timedwait(
+        () -> lock(es.lock) do
+            session = get(es.sessions, "timeout-worker", nothing)
+            session !== nothing && session.status == "completed"
+        end,
+        15.0,
+    ) == :ok
+
+    session = Claw._get_session(es, "timeout-worker", :worker)
+    @test_throws Claw.LLMTools.WorkerEvalTimeout funcs["eval_worker"](
+        "timeout-worker", "while true end", true, 1)
+    @test session.status == "error"
+    @test Claw.LLMTools.get_session(
+        Claw.LLMTools.WORKER_REGISTRY, session.registry_id) === nothing
+end
+
 # ============================================================================
 # SQLite schema & constructor
 # ============================================================================

--- a/LLMOAuth/src/oauth.jl
+++ b/LLMOAuth/src/oauth.jl
@@ -7,7 +7,7 @@ const ANTHROPIC_REDIRECT_URI = "https://console.anthropic.com/oauth/code/callbac
 const ANTHROPIC_SCOPES = "org:create_api_key user:profile user:inference"
 
 function agentif_dir()
-    return joinpath(homedir(), ".agentif")
+    return get(ENV, "AGENTIF_DIR", joinpath(homedir(), ".agentif"))
 end
 
 function anthropic_auth_path()
@@ -16,8 +16,17 @@ end
 
 function ensure_agentif_dir()
     dir = agentif_dir()
-    isdir(dir) || mkpath(dir)
+    if !isdir(dir)
+        mkpath(dir)
+        chmod(dir, 0o700)
+    end
     return dir
+end
+
+function response_body_snippet(body::AbstractString; max_length::Integer = 200)
+    snippet = strip(body)
+    isempty(snippet) && return "<empty response body>"
+    return length(snippet) <= max_length ? String(snippet) : first(snippet, max_length) * "..."
 end
 
 function anthropic_client_config()
@@ -64,9 +73,10 @@ function anthropic_exchange_code(code::AbstractString, state::AbstractString, ve
     resp = HTTP.post(
         ANTHROPIC_TOKEN_URL,
         ["Content-Type" => "application/json"],
-        JSON.json(payload),
+        JSON.json(payload);
+        status_exception = false,
     )
-    resp.status in 200:299 || throw(ErrorException("Anthropic token exchange failed: $(String(resp.body))"))
+    resp.status in 200:299 || throw(ErrorException("Anthropic token exchange failed (status $(resp.status)): $(response_body_snippet(String(resp.body)))"))
     data = JSON.parse(resp.body)
     token = OAuth.TokenResponse(data; issued_at = Dates.now(Dates.UTC))
     return token
@@ -282,12 +292,35 @@ function codex_exchange_code(code::AbstractString, verifier::OAuth.PKCEVerifier)
                 "code_verifier" => verifier.verifier,
                 "redirect_uri" => CODEX_REDIRECT_URI,
             )
-        ),
+        );
+        status_exception = false,
     )
-    resp.status in 200:299 || throw(ErrorException("Codex token exchange failed: $(String(resp.body))"))
+    resp.status in 200:299 || throw(ErrorException("Codex token exchange failed (status $(resp.status)): $(response_body_snippet(String(resp.body)))"))
     data = JSON.parse(resp.body)
     token = OAuth.TokenResponse(data; issued_at = Dates.now(Dates.UTC))
     return token
+end
+
+"""
+    codex_is_invalid_grant(status, body) -> Bool
+
+Classify a token-endpoint response as an `invalid_grant` failure, i.e. the
+stored refresh token was revoked or expired: HTTP 400/401 with
+`invalid_grant` in the response body.
+"""
+function codex_is_invalid_grant(status::Integer, body::AbstractString)
+    return status in (400, 401) && occursin("invalid_grant", body)
+end
+
+function codex_refresh_failure(status::Integer, body::AbstractString)
+    if codex_is_invalid_grant(status, body)
+        # Callers refresh under the codex refresh-token lock, so it is safe to
+        # clear the stored credentials here; leaving a revoked refresh token in
+        # place would make every future refresh fail the same way.
+        rm(codex_auth_path(); force = true)
+        return ErrorException("Stored Codex credentials were revoked or expired (invalid_grant); re-run codex_login() to authenticate again")
+    end
+    return ErrorException("Codex token refresh failed (status $(status)): $(response_body_snippet(body))")
 end
 
 function codex_refresh_token(refresh_token::String)
@@ -300,9 +333,10 @@ function codex_refresh_token(refresh_token::String)
                 "refresh_token" => refresh_token,
                 "client_id" => CODEX_CLIENT_ID,
             )
-        ),
+        );
+        status_exception = false,
     )
-    resp.status in 200:299 || throw(ErrorException("Codex token refresh failed: $(String(resp.body))"))
+    resp.status in 200:299 || throw(codex_refresh_failure(resp.status, String(resp.body)))
     data = JSON.parse(resp.body)
     token = OAuth.TokenResponse(data; issued_at = Dates.now(Dates.UTC))
     return token
@@ -312,18 +346,33 @@ end
     codex_save_credentials(creds::CodexCredentials)
 
 Save Codex credentials to the auth file, including the account ID.
+
+The file contains access and refresh tokens, so it is written owner-read/write
+only (0o600) and atomically: the JSON is written to a temp file in the same
+directory, chmodded, then moved over the destination so readers never observe
+a partial file.
 """
 function codex_save_credentials(creds::CodexCredentials)
-    ensure_agentif_dir()
+    dir = ensure_agentif_dir()
+    path = codex_auth_path()
     data = Dict(
         "access_token" => creds.access_token,
         "refresh_token" => creds.refresh_token,
         "expires_at" => Dates.format(creds.expires_at, Dates.ISODateTimeFormat),
         "account_id" => creds.account_id,
     )
-    return open(codex_auth_path(), "w") do io
-        write(io, JSON.json(data))
+    tmp = tempname(dir)
+    try
+        open(tmp, "w") do io
+            write(io, JSON.json(data))
+        end
+        chmod(tmp, 0o600)
+        mv(tmp, path; force = true)
+        chmod(path, 0o600)
+    finally
+        ispath(tmp) && tmp != path && rm(tmp; force = true)
     end
+    return nothing
 end
 
 """
@@ -343,6 +392,17 @@ function codex_load_credentials()
         expires_at,
         data["account_id"],
     )
+end
+
+# Run `f` while holding the codex refresh-token file lock so credential reads,
+# refreshes, and saves cannot interleave across processes.
+function with_codex_refresh_lock(f::Function)
+    config = codex_client_config()
+    store = config.refresh_token_store
+    if store isa OAuth.FileBasedRefreshTokenStore
+        return OAuth.with_refresh_token_lock(f, store, config.verbose)
+    end
+    return f()
 end
 
 """
@@ -429,7 +489,9 @@ function codex_login(; open_browser::Bool = true, timeout::Real = 180)
         # Exchange the code for tokens
         token = codex_exchange_code(code, verifier)
         creds = codex_credentials_from_token(token)
-        codex_save_credentials(creds)
+        with_codex_refresh_lock() do
+            codex_save_credentials(creds)
+        end
 
         println("Successfully authenticated with Codex!")
         return (creds.access_token, creds.account_id)
@@ -447,14 +509,9 @@ Get valid Codex credentials, refreshing the token if necessary.
 Throws an error if no stored credentials exist or refresh fails.
 """
 function codex_credentials(; skew_seconds::Integer = 60)
-    config = codex_client_config()
-    store = config.refresh_token_store
-    if store isa OAuth.FileBasedRefreshTokenStore
-        return OAuth.with_refresh_token_lock(store, config.verbose) do
-            _codex_credentials_unlocked(skew_seconds)
-        end
+    return with_codex_refresh_lock() do
+        _codex_credentials_unlocked(skew_seconds)
     end
-    return _codex_credentials_unlocked(skew_seconds)
 end
 
 function _codex_credentials_unlocked(skew_seconds::Integer)

--- a/LLMOAuth/src/oauth.jl
+++ b/LLMOAuth/src/oauth.jl
@@ -304,12 +304,20 @@ end
 """
     codex_is_invalid_grant(status, body) -> Bool
 
-Classify a token-endpoint response as an `invalid_grant` failure, i.e. the
-stored refresh token was revoked or expired: HTTP 400/401 with
-`invalid_grant` in the response body.
+Classify a token-endpoint response as a permanently-rejected refresh token, so the
+stored credentials can be cleared instead of failing the same way forever.
+
+A 401 from the token endpoint means the refresh token itself was rejected — retrying
+it can never succeed — so it is always terminal. Observed in the wild when another
+client (e.g. the `codex` CLI) rotates the token out from under us: HTTP 401 with
+`"type": "invalid_request_error"` and "Your refresh token has already been used",
+which carries no `invalid_grant` string. A 400 is terminal only when the body
+identifies a grant/refresh-token problem (per RFC 6749, `invalid_grant`).
 """
 function codex_is_invalid_grant(status::Integer, body::AbstractString)
-    return status in (400, 401) && occursin("invalid_grant", body)
+    status == 401 && return true
+    return status == 400 &&
+        (occursin("invalid_grant", body) || occursin("refresh token", lowercase(body)))
 end
 
 function codex_refresh_failure(status::Integer, body::AbstractString)
@@ -318,7 +326,7 @@ function codex_refresh_failure(status::Integer, body::AbstractString)
         # clear the stored credentials here; leaving a revoked refresh token in
         # place would make every future refresh fail the same way.
         rm(codex_auth_path(); force = true)
-        return ErrorException("Stored Codex credentials were revoked or expired (invalid_grant); re-run codex_login() to authenticate again")
+        return ErrorException("Stored Codex credentials were rejected (status $(status)): $(response_body_snippet(body)). They have been cleared; re-run codex_login() to authenticate again")
     end
     return ErrorException("Codex token refresh failed (status $(status)): $(response_body_snippet(body))")
 end

--- a/LLMOAuth/src/oauth.jl
+++ b/LLMOAuth/src/oauth.jl
@@ -18,8 +18,10 @@ function ensure_agentif_dir()
     dir = agentif_dir()
     if !isdir(dir)
         mkpath(dir)
-        chmod(dir, 0o700)
     end
+    # Existing installations may have been created with a process umask that
+    # left this credential directory readable by other users.
+    chmod(dir, 0o700)
     return dir
 end
 
@@ -307,17 +309,19 @@ end
 Classify a token-endpoint response as a permanently-rejected refresh token, so the
 stored credentials can be cleared instead of failing the same way forever.
 
-A 401 from the token endpoint means the refresh token itself was rejected — retrying
-it can never succeed — so it is always terminal. Observed in the wild when another
-client (e.g. the `codex` CLI) rotates the token out from under us: HTTP 401 with
-`"type": "invalid_request_error"` and "Your refresh token has already been used",
-which carries no `invalid_grant` string. A 400 is terminal only when the body
-identifies a grant/refresh-token problem (per RFC 6749, `invalid_grant`).
+Observed in the wild when another client (e.g. the `codex` CLI) rotates the token
+out from under us: HTTP 401 with `"type": "invalid_request_error"` and "Your
+refresh token has already been used", which carries no `invalid_grant` string.
+Both 400 and 401 are terminal only when the body identifies a grant or refresh
+token problem. A 401 can also mean `invalid_client`; clearing a valid refresh
+token in that case does not fix the client configuration failure.
 """
 function codex_is_invalid_grant(status::Integer, body::AbstractString)
-    status == 401 && return true
-    return status == 400 &&
-        (occursin("invalid_grant", body) || occursin("refresh token", lowercase(body)))
+    status in (400, 401) || return false
+    normalized = lowercase(body)
+    return occursin("invalid_grant", normalized) ||
+        occursin("refresh token", normalized) ||
+        occursin("refresh_token", normalized)
 end
 
 function codex_refresh_failure(status::Integer, body::AbstractString)
@@ -369,15 +373,18 @@ function codex_save_credentials(creds::CodexCredentials)
         "expires_at" => Dates.format(creds.expires_at, Dates.ISODateTimeFormat),
         "account_id" => creds.account_id,
     )
-    tmp = tempname(dir)
+    # mktemp creates the file with mode 0600. This closes the window where
+    # `open(tempname(...), "w")` could expose token content under a loose umask
+    # before the later chmod.
+    tmp, io = mktemp(dir; cleanup = false)
     try
-        open(tmp, "w") do io
-            write(io, JSON.json(data))
-        end
         chmod(tmp, 0o600)
+        write(io, JSON.json(data))
+        close(io)
         mv(tmp, path; force = true)
         chmod(path, 0o600)
     finally
+        isopen(io) && close(io)
         ispath(tmp) && tmp != path && rm(tmp; force = true)
     end
     return nothing

--- a/LLMOAuth/test/runtests.jl
+++ b/LLMOAuth/test/runtests.jl
@@ -69,3 +69,73 @@ end
     @test creds.refresh_token == "refresh-old"
     @test creds.account_id == "acct-xyz"
 end
+
+@testset "Codex credential file atomic save and permissions" begin
+    dir = joinpath(mktempdir(), "agentif")
+    withenv("AGENTIF_DIR" => dir) do
+        creds = LLMOAuth.CodexCredentials(
+            "access-token",
+            "refresh-token",
+            DateTime(2030, 1, 1),
+            "acct-123",
+        )
+        LLMOAuth.codex_save_credentials(creds)
+        path = LLMOAuth.codex_auth_path()
+        @test path == joinpath(dir, "codex_auth.json")
+        @test isfile(path)
+        @test filemode(path) & 0o777 == 0o600
+        @test filemode(dir) & 0o777 == 0o700
+        loaded = LLMOAuth.codex_load_credentials()
+        @test loaded.access_token == creds.access_token
+        @test loaded.refresh_token == creds.refresh_token
+        @test loaded.expires_at == creds.expires_at
+        @test loaded.account_id == creds.account_id
+
+        # Overwriting keeps tight permissions and leaves no temp files behind.
+        creds2 = LLMOAuth.CodexCredentials("access-2", "refresh-2", DateTime(2031, 1, 1), "acct-456")
+        LLMOAuth.codex_save_credentials(creds2)
+        @test filemode(path) & 0o777 == 0o600
+        @test LLMOAuth.codex_load_credentials().refresh_token == "refresh-2"
+        @test readdir(dir) == ["codex_auth.json"]
+    end
+end
+
+@testset "Codex invalid_grant classification" begin
+    @test !LLMOAuth.codex_is_invalid_grant(200, "{\"access_token\": \"ok\"}")
+    @test LLMOAuth.codex_is_invalid_grant(400, "{\"error\": \"invalid_grant\"}")
+    @test LLMOAuth.codex_is_invalid_grant(401, "{\"error\": \"invalid_grant\", \"error_description\": \"revoked\"}")
+    @test !LLMOAuth.codex_is_invalid_grant(401, "{\"error\": \"invalid_token\"}")
+    @test !LLMOAuth.codex_is_invalid_grant(500, "{\"error\": \"invalid_grant\"}")
+    @test !LLMOAuth.codex_is_invalid_grant(400, "{\"error\": \"invalid_request\"}")
+end
+
+@testset "Codex refresh failure clears revoked credentials" begin
+    dir = joinpath(mktempdir(), "agentif")
+    withenv("AGENTIF_DIR" => dir) do
+        creds = LLMOAuth.CodexCredentials("access", "refresh", DateTime(2030, 1, 1), "acct-123")
+        LLMOAuth.codex_save_credentials(creds)
+        path = LLMOAuth.codex_auth_path()
+
+        # A non-invalid_grant failure keeps the stored credentials.
+        err = LLMOAuth.codex_refresh_failure(500, "{\"error\": \"server_error\"}")
+        @test err isa ErrorException
+        @test occursin("status 500", err.msg)
+        @test occursin("server_error", err.msg)
+        @test isfile(path)
+
+        # invalid_grant deletes the stored credentials and points at codex_login().
+        err = LLMOAuth.codex_refresh_failure(400, "{\"error\": \"invalid_grant\"}")
+        @test err isa ErrorException
+        @test occursin("re-run codex_login()", err.msg)
+        @test !isfile(path)
+    end
+end
+
+@testset "Response body snippet" begin
+    @test LLMOAuth.response_body_snippet("short") == "short"
+    @test LLMOAuth.response_body_snippet("   ") == "<empty response body>"
+    snippet = LLMOAuth.response_body_snippet(repeat("x", 500))
+    @test length(snippet) == 203
+    @test startswith(snippet, repeat("x", 200))
+    @test endswith(snippet, "...")
+end

--- a/LLMOAuth/test/runtests.jl
+++ b/LLMOAuth/test/runtests.jl
@@ -104,7 +104,13 @@ end
     @test !LLMOAuth.codex_is_invalid_grant(200, "{\"access_token\": \"ok\"}")
     @test LLMOAuth.codex_is_invalid_grant(400, "{\"error\": \"invalid_grant\"}")
     @test LLMOAuth.codex_is_invalid_grant(401, "{\"error\": \"invalid_grant\", \"error_description\": \"revoked\"}")
-    @test !LLMOAuth.codex_is_invalid_grant(401, "{\"error\": \"invalid_token\"}")
+    # A 401 from the token endpoint always means the refresh token was rejected.
+    @test LLMOAuth.codex_is_invalid_grant(401, "{\"error\": \"invalid_token\"}")
+    # Real-world shape when another client rotates the token out from under us:
+    # 401, no `invalid_grant` string anywhere in the body.
+    @test LLMOAuth.codex_is_invalid_grant(401,
+        "{\"error\": {\"message\": \"Your refresh token has already been used to generate a new access token. Please try signing in again.\", \"type\": \"invalid_request_error\"}}")
+    @test LLMOAuth.codex_is_invalid_grant(400, "{\"error\": {\"message\": \"refresh token expired\"}}")
     @test !LLMOAuth.codex_is_invalid_grant(500, "{\"error\": \"invalid_grant\"}")
     @test !LLMOAuth.codex_is_invalid_grant(400, "{\"error\": \"invalid_request\"}")
 end

--- a/LLMOAuth/test/runtests.jl
+++ b/LLMOAuth/test/runtests.jl
@@ -97,6 +97,11 @@ end
         @test filemode(path) & 0o777 == 0o600
         @test LLMOAuth.codex_load_credentials().refresh_token == "refresh-2"
         @test readdir(dir) == ["codex_auth.json"]
+
+        # Tighten an existing credential directory created by an older version.
+        chmod(dir, 0o755)
+        LLMOAuth.codex_save_credentials(creds2)
+        @test filemode(dir) & 0o777 == 0o700
     end
 end
 
@@ -104,13 +109,16 @@ end
     @test !LLMOAuth.codex_is_invalid_grant(200, "{\"access_token\": \"ok\"}")
     @test LLMOAuth.codex_is_invalid_grant(400, "{\"error\": \"invalid_grant\"}")
     @test LLMOAuth.codex_is_invalid_grant(401, "{\"error\": \"invalid_grant\", \"error_description\": \"revoked\"}")
-    # A 401 from the token endpoint always means the refresh token was rejected.
-    @test LLMOAuth.codex_is_invalid_grant(401, "{\"error\": \"invalid_token\"}")
+    # A 401 can instead report invalid client authentication. Keep credentials
+    # because deleting them cannot repair the client configuration.
+    @test !LLMOAuth.codex_is_invalid_grant(401, "{\"error\": \"invalid_client\"}")
+    @test !LLMOAuth.codex_is_invalid_grant(401, "{\"error\": \"invalid_token\"}")
     # Real-world shape when another client rotates the token out from under us:
     # 401, no `invalid_grant` string anywhere in the body.
     @test LLMOAuth.codex_is_invalid_grant(401,
         "{\"error\": {\"message\": \"Your refresh token has already been used to generate a new access token. Please try signing in again.\", \"type\": \"invalid_request_error\"}}")
     @test LLMOAuth.codex_is_invalid_grant(400, "{\"error\": {\"message\": \"refresh token expired\"}}")
+    @test LLMOAuth.codex_is_invalid_grant(400, "{\"error\": \"invalid_refresh_token\"}")
     @test !LLMOAuth.codex_is_invalid_grant(500, "{\"error\": \"invalid_grant\"}")
     @test !LLMOAuth.codex_is_invalid_grant(400, "{\"error\": \"invalid_request\"}")
 end

--- a/LLMProviders/src/models.jl
+++ b/LLMProviders/src/models.jl
@@ -98,7 +98,6 @@ function calculateCost(model::Model, usage)
         "cacheWrite" => (cache_write_rate / 1000000) * usage.cacheWrite,
     )
     cost["total"] = cost["input"] + cost["output"] + cost["cacheRead"] + cost["cacheWrite"]
-    usage.cost = cost
     return cost
 end
 

--- a/LLMProviders/src/providers/anthropic_messages.jl
+++ b/LLMProviders/src/providers/anthropic_messages.jl
@@ -27,6 +27,11 @@ end
     signature::Union{Nothing, String} = nothing
 end
 
+@omit_null @kwarg struct RedactedThinkingBlock
+    type::String = "redacted_thinking"
+    data::String = ""
+end
+
 @omit_null @kwarg struct ImageSource
     type::String = "base64"
     media_type::String
@@ -54,14 +59,26 @@ const ToolResultContentBlock = Union{TextBlock, ImageBlock}
     is_error::Union{Nothing, Bool} = nothing
 end
 
-const ContentBlock = Union{TextBlock, ThinkingBlock, ImageBlock, ToolUseBlock, ToolResultBlock}
+# Catch-all so unrecognized content block types (e.g. server_tool_use) parse
+# without throwing; mirrors OpenAIResponses.UnknownOutput.
+@omit_null @kwarg struct UnknownContentBlock
+    type::Union{Nothing, String} = nothing
+end
+
+const ContentBlock = Union{TextBlock, ThinkingBlock, RedactedThinkingBlock, ImageBlock, ToolUseBlock, ToolResultBlock, UnknownContentBlock}
 
 JSON.@choosetype ContentBlock x -> begin
-    type = x.type[]
+    type = try
+        x.type[]
+    catch
+        nothing
+    end
     if type == "text"
         return TextBlock
     elseif type == "thinking"
         return ThinkingBlock
+    elseif type == "redacted_thinking"
+        return RedactedThinkingBlock
     elseif type == "image"
         return ImageBlock
     elseif type == "tool_use"
@@ -69,7 +86,7 @@ JSON.@choosetype ContentBlock x -> begin
     elseif type == "tool_result"
         return ToolResultBlock
     else
-        return Any
+        return UnknownContentBlock
     end
 end
 
@@ -132,10 +149,19 @@ end
     partial_json::String
 end
 
-const ContentBlockDelta = Union{TextDelta, ThinkingDelta, SignatureDelta, InputJsonDelta}
+# Catch-all so unrecognized delta types (e.g. citations_delta) parse without throwing.
+@omit_null @kwarg struct UnknownContentBlockDelta
+    type::Union{Nothing, String} = nothing
+end
+
+const ContentBlockDelta = Union{TextDelta, ThinkingDelta, SignatureDelta, InputJsonDelta, UnknownContentBlockDelta}
 
 JSON.@choosetype ContentBlockDelta x -> begin
-    type = x.type[]
+    type = try
+        x.type[]
+    catch
+        nothing
+    end
     if type == "text_delta"
         return TextDelta
     elseif type == "thinking_delta"
@@ -145,7 +171,7 @@ JSON.@choosetype ContentBlockDelta x -> begin
     elseif type == "input_json_delta"
         return InputJsonDelta
     else
-        return Any
+        return UnknownContentBlockDelta
     end
 end
 

--- a/LLMProviders/test/runtests.jl
+++ b/LLMProviders/test/runtests.jl
@@ -11,12 +11,13 @@ const AnthropicMessages = LLMProviders.AnthropicMessages
 const GoogleGenerativeAI = LLMProviders.GoogleGenerativeAI
 const GoogleGeminiCli = LLMProviders.GoogleGeminiCli
 
-mutable struct DummyUsage
+# Mirrors the field surface of Agentif.Usage (which has no `cost` field);
+# calculateCost must not require or mutate one.
+struct DummyUsage
     input::Int
     output::Int
     cacheRead::Int
     cacheWrite::Int
-    cost::Any
 end
 
 @testset "Future" begin
@@ -210,14 +211,13 @@ end
     @test provider in LLMProviders.getProviders()
     @test any(m -> m.id == "unit-model", LLMProviders.getModels(provider))
 
-    usage = DummyUsage(1000, 2000, 3000, 4000, nothing)
+    usage = DummyUsage(1000, 2000, 3000, 4000)
     cost = LLMProviders.calculateCost(model, usage)
     @test cost["input"] == 0.001
     @test cost["output"] == 0.004
     @test cost["cacheRead"] == 0.0
     @test cost["cacheWrite"] == 0.0
     @test cost["total"] == 0.005
-    @test usage.cost === cost
 end
 
 @testset "discover_models!" begin

--- a/LLMProviders/test/runtests.jl
+++ b/LLMProviders/test/runtests.jl
@@ -134,6 +134,62 @@ end
 
     msg = JSON.parse("{\"role\":\"user\",\"content\":\"hi\"}", AnthropicMessages.Message)
     @test msg.content == "hi"
+
+    # redacted_thinking parses as a first-class block
+    redacted_event = JSON.parse(
+        "{\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"redacted_thinking\",\"data\":\"EmwKAhgB\"}}",
+        AnthropicMessages.StreamEvent,
+    )
+    @test redacted_event isa AnthropicMessages.StreamContentBlockStartEvent
+    @test redacted_event.content_block isa AnthropicMessages.RedactedThinkingBlock
+    @test redacted_event.content_block.data == "EmwKAhgB"
+
+    # redacted_thinking serializes back to the wire shape for replay
+    lowered = JSON.parse(JSON.json(AnthropicMessages.RedactedThinkingBlock(; data = "opaque")))
+    @test lowered["type"] == "redacted_thinking"
+    @test lowered["data"] == "opaque"
+
+    # unknown content block types parse to the catch-all instead of throwing
+    unknown_block_event = JSON.parse(
+        "{\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"server_tool_use\",\"id\":\"srvtoolu_1\",\"name\":\"web_search\",\"input\":{}}}",
+        AnthropicMessages.StreamEvent,
+    )
+    @test unknown_block_event isa AnthropicMessages.StreamContentBlockStartEvent
+    @test unknown_block_event.content_block isa AnthropicMessages.UnknownContentBlock
+    @test unknown_block_event.content_block.type == "server_tool_use"
+
+    # unknown delta types parse to the catch-all instead of throwing
+    unknown_delta_event = JSON.parse(
+        "{\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"citations_delta\",\"citation\":{\"type\":\"web_search_result_location\"}}}",
+        AnthropicMessages.StreamEvent,
+    )
+    @test unknown_delta_event isa AnthropicMessages.StreamContentBlockDeltaEvent
+    @test unknown_delta_event.delta isa AnthropicMessages.UnknownContentBlockDelta
+    @test unknown_delta_event.delta.type == "citations_delta"
+
+    # non-streaming Response tolerates unknown and redacted blocks
+    response = JSON.parse(
+        """
+        {
+          "id": "msg_1",
+          "model": "claude-test",
+          "role": "assistant",
+          "stop_reason": "end_turn",
+          "content": [
+            {"type": "server_tool_use", "id": "srvtoolu_1", "name": "web_search", "input": {"query": "x"}},
+            {"type": "redacted_thinking", "data": "opaque"},
+            {"type": "text", "text": "done"}
+          ],
+          "usage": {"input_tokens": 3, "output_tokens": 5}
+        }
+        """,
+        AnthropicMessages.Response,
+    )
+    @test response.content[1] isa AnthropicMessages.UnknownContentBlock
+    @test response.content[2] isa AnthropicMessages.RedactedThinkingBlock
+    @test response.content[2].data == "opaque"
+    @test response.content[3] isa AnthropicMessages.TextBlock
+    @test response.content[3].text == "done"
 end
 
 @testset "GoogleGenerativeAI" begin

--- a/LLMTools/src/predefined_tools.jl
+++ b/LLMTools/src/predefined_tools.jl
@@ -197,29 +197,33 @@ function glob_to_regex(pattern::String)
     normalized = replace(pattern, '\\' => '/')
     out = IOBuffer()
     print(out, "^")
+    # Step by character with nextind — `idx += 1` byte-stepping throws
+    # StringIndexError on multi-byte (non-ASCII) glob patterns.
     idx = 1
-    while idx <= lastindex(normalized)
+    last_idx = lastindex(normalized)
+    while idx <= last_idx
         char = normalized[idx]
+        next = nextind(normalized, idx)
         if char == '*'
-            if idx < lastindex(normalized) && normalized[idx + 1] == '*'
+            if next <= last_idx && normalized[next] == '*'
                 print(out, ".*")
-                idx += 2
+                idx = nextind(normalized, next)
             else
                 print(out, "[^/]*")
-                idx += 1
+                idx = next
             end
             continue
         elseif char == '?'
             print(out, "[^/]")
-            idx += 1
+            idx = next
             continue
         elseif char in ('\\', '.', '+', '(', ')', '[', ']', '{', '}', '^', '$', '|')
             print(out, "\\", char)
-            idx += 1
+            idx = next
             continue
         end
         print(out, char)
-        idx += 1
+        idx = next
     end
     print(out, "\$")
     return Regex(String(take!(out)))
@@ -235,7 +239,9 @@ end
 
 
 function strip_dir_suffix(entry::String)
-    return endswith(entry, "/") ? entry[1:(end - 1)] : entry
+    # `end - 1` is byte arithmetic: with a multi-byte char right before the
+    # trailing "/", it lands on a continuation byte and throws StringIndexError.
+    return endswith(entry, "/") ? entry[1:prevind(entry, lastindex(entry))] : entry
 end
 
 function create_read_tool(base_dir::AbstractString)
@@ -344,7 +350,12 @@ Errors if: file not found, oldText not found, oldText matches more than once, or
             occurrences > 1 && throw(ArgumentError("found $(occurrences) occurrences in $(path); provide more context to make it unique"))
             idx = findfirst(oldText, content)
             idx === nothing && throw(ArgumentError("could not find the exact text in $(path)"))
-            new_content = content[1:(idx.start - 1)] * newText * content[(idx.stop + 1):end]
+            # idx is a byte range; idx.start - 1 / idx.stop + 1 can land mid-character
+            # when the surrounding text (or the last char of oldText) is multi-byte.
+            # prevind/nextind keep the splice on character boundaries; both handle the
+            # match-at-start (prevind -> 0, content[1:0] == "") and match-at-end
+            # (nextind -> ncodeunits+1, empty tail range) edges.
+            new_content = content[1:prevind(content, idx.start)] * newText * content[nextind(content, idx.stop):end]
             new_content == content && throw(ArgumentError("replacement produced identical content for $(path)"))
             open(resolved, "w") do io
                 write(io, new_content)
@@ -963,6 +974,44 @@ function get_temp_file_meta(file_id::String)
 end
 
 """
+    repair_utf8(s::AbstractString) -> String
+
+Return `s` with any invalid UTF-8 sequences replaced by U+FFFD, so the result
+is always valid UTF-8. Julia string iteration is total over malformed data:
+each invalid byte sequence yields one or more `Char`s with `isvalid(c) == false`,
+which we substitute with the replacement character.
+"""
+function repair_utf8(s::AbstractString)
+    isvalid(s) && return String(s)
+    io = IOBuffer()
+    for c in s
+        print(io, isvalid(c) ? c : '�')
+    end
+    return String(take!(io))
+end
+
+"""
+    decode_numeric_entity(entity::AbstractString) -> String
+
+Decode an HTML numeric character reference (`&#123;` or `&#x7B;`) into a string.
+Invalid input — non-parsing digits, values that overflow `Int`, values outside
+the Unicode scalar range, or surrogate code points (which would encode to
+invalid UTF-8) — yields the replacement character U+FFFD instead of throwing.
+"""
+function decode_numeric_entity(entity::AbstractString)
+    # entity is a full regex match like "&#65;" or "&#x1F600;" (ASCII by
+    # construction, so byte indexing below is safe); strip "&#" and ";"
+    body = SubString(entity, 3, prevind(entity, lastindex(entity)))
+    hex = startswith(body, "x") || startswith(body, "X")
+    digits_str = hex ? SubString(body, 2) : body
+    v = tryparse(Int, digits_str; base = hex ? 16 : 10)
+    if v === nothing || v < 0 || v > 0x10FFFF || (0xD800 <= v <= 0xDFFF)
+        return "�"
+    end
+    return string(Char(v))
+end
+
+"""
     extract_text_from_html(html::String) -> String
 
 Extract readable text from HTML, stripping tags and decoding entities.
@@ -1001,9 +1050,11 @@ function extract_text_from_html(html::String)
         text = replace(text, entity => char)
     end
 
-    # Decode numeric entities (&#123; and &#x7B;)
-    text = replace(text, r"&#(\d+);" => m -> string(Char(parse(Int, m.captures[1]))))
-    text = replace(text, r"&#x([0-9a-fA-F]+);" => m -> string(Char(parse(Int, m.captures[1], base = 16))))
+    # Decode numeric entities (&#123; and &#x7B;). The substitution function
+    # receives the full matched substring; decode_numeric_entity substitutes
+    # U+FFFD for anything unparseable, out of range, or a surrogate.
+    text = replace(text, r"&#\d+;" => decode_numeric_entity)
+    text = replace(text, r"&#x[0-9a-fA-F]+;" => decode_numeric_entity)
 
     # Normalize whitespace: collapse multiple spaces/newlines
     text = replace(text, r"[ \t]+" => " ")
@@ -1011,7 +1062,9 @@ function extract_text_from_html(html::String)
     text = replace(text, r"[ \t]+\n" => "\n")
     text = replace(text, r"\n{3,}" => "\n\n")
 
-    return String(strip(text))
+    # Defense in depth: never let invalid UTF-8 escape into tool results
+    # (it would corrupt the transcript and downstream API requests).
+    return repair_utf8(strip(text))
 end
 
 """
@@ -1716,9 +1769,10 @@ function create_web_search_tool()
                 println(output, "$i. $title")
                 println(output, "   URL: $url")
                 if !isempty(snippet)
-                    # Truncate long snippets
+                    # Truncate long snippets (char-safe: byte slicing throws on
+                    # multi-byte snippet content)
                     if length(snippet) > 200
-                        snippet = snippet[1:197] * "..."
+                        snippet = first(snippet, 197) * "..."
                     end
                     println(output, "   $snippet")
                 end

--- a/LLMTools/src/worker_tools.jl
+++ b/LLMTools/src/worker_tools.jl
@@ -66,12 +66,45 @@ end
 
 function truncate_description(code::String, max_len::Int = 80)
     s = replace(strip(code), r"\s+" => " ")
-    return length(s) > max_len ? s[1:max_len] * "..." : s
+    # first() is char-safe; s[1:max_len] is byte indexing and throws on
+    # multi-byte code content
+    return length(s) > max_len ? first(s, max_len) * "..." : s
 end
 
-function eval_on_worker(meta::WorkerSessionMetadata, code::String)
+"""
+    WorkerEvalTimeout
+
+Thrown by [`eval_on_worker`](@ref) when an evaluation exceeds its `timeout_s`
+deadline. The wedged worker process is force-terminated before this is thrown.
+"""
+struct WorkerEvalTimeout <: Exception
+    timeout_s::Int
+end
+
+function Base.showerror(io::IO, e::WorkerEvalTimeout)
+    print(io, "worker evaluation timed out after $(e.timeout_s)s; the worker process was terminated")
+end
+
+function eval_on_worker(meta::WorkerSessionMetadata, code::String; timeout_s::Union{Nothing, Int} = nothing)
     expr = Meta.parseall(code)
-    result = remote_fetch(meta.worker, expr)
+    result = if timeout_s === nothing
+        remote_fetch(meta.worker, expr)
+    else
+        fut = remote_eval(meta.worker, expr)
+        # fut.value is ready on success and closed (with the remote exception or
+        # a WorkerTerminatedException) on failure; poll until one or the deadline.
+        status = timedwait(() -> isready(fut.value) || !isopen(fut.value), Float64(max(timeout_s, 0)))
+        if status === :timed_out
+            # A wedged worker (e.g. `while true end`) never processes a graceful
+            # shutdown request, so force-terminate the process.
+            try
+                Workers.terminate!(meta.worker, :eval_timeout)
+            catch
+            end
+            throw(WorkerEvalTimeout(timeout_s))
+        end
+        fetch(fut)
+    end
     # Small yield to let any worker stdout flush through the redirect task
     yield()
     # Read captured stdout (non-destructive peek then take)
@@ -101,7 +134,7 @@ Do NOT call this for follow-up work on an existing worker; use `eval_code` inste
 
 Arguments:
 - `code::String` — Julia code to evaluate. All expressions are executed; stdout and the return value of the last expression are captured.
-- `timeout_s::Union{Nothing, Int}` (default: nothing) — Optional timeout in seconds. `nothing` means no timeout.
+- `timeout_s::Union{Nothing, Int}` (default: nothing) — Optional timeout in seconds. `nothing` means no timeout. On timeout the worker process is terminated and a structured error with `error_kind: "timeout"` is returned.
 
 Behavior:
 - Spawns a new Julia process (~1-2s startup latency). The worker inherits the parent's active Julia project/environment.
@@ -141,7 +174,7 @@ Returns structured JSON with `ok`, `status`, `session_id` (the worker_id), `outp
                 meta = WorkerSessionMetadata(w, output_io, now, now, desc, SESSION_STATUS_RUNNING)
                 register_session!(WORKER_REGISTRY, worker_id, meta)
 
-                combined, result_str = eval_on_worker(meta, code)
+                combined, result_str = eval_on_worker(meta, code; timeout_s = timeout_s)
 
                 is_alive = !Workers.terminated(w)
                 if !is_alive
@@ -175,7 +208,8 @@ Returns structured JSON with `ok`, `status`, `session_id` (the worker_id), `outp
                 bt = catch_backtrace()
                 @warn "exec_code failed" worker_id exception = (err, bt)
                 remove_session!(WORKER_REGISTRY, worker_id; mark_status = SESSION_STATUS_ERROR)
-                errmsg = err isa CapturedException ? sprint(showerror, err.ex) : string(err)
+                errmsg = err isa CapturedException ? sprint(showerror, err.ex) :
+                    err isa WorkerEvalTimeout ? sprint(showerror, err) : string(err)
                 push!(events, make_event(WORKER_REGISTRY, "error"; session_id = worker_id,
                     payload = Dict("message" => errmsg)))
                 return render_process_response("exec_code";
@@ -185,7 +219,7 @@ Returns structured JSON with `ok`, `status`, `session_id` (the worker_id), `outp
                     wall_time_s = time() - start_time,
                     active_sessions = active_session_count(WORKER_REGISTRY),
                     events = events,
-                    error_kind = "eval_failed",
+                    error_kind = err isa WorkerEvalTimeout ? "timeout" : "eval_failed",
                     message = errmsg,
                 )
             end
@@ -200,7 +234,7 @@ Do NOT use this to start a new worker — use `exec_code` instead.
 Arguments:
 - `worker_id::Int` — ID of an existing worker, as returned by `exec_code` in the `session_id` field.
 - `code::String` — Julia code to evaluate. All expressions are executed; stdout and the return value of the last expression are captured.
-- `timeout_s::Union{Nothing, Int}` (default: nothing) — Optional timeout in seconds. `nothing` means no timeout.
+- `timeout_s::Union{Nothing, Int}` (default: nothing) — Optional timeout in seconds. `nothing` means no timeout. On timeout the worker process is terminated (all its state is lost) and a structured error with `error_kind: "timeout"` is returned.
 
 Gotchas:
 - Returns an error if the worker_id does not exist or the worker has exited. Use `list_workers` to check.
@@ -242,7 +276,7 @@ Returns structured JSON with `ok`, `status`, `session_id`, `output`, and `result
                     current === nothing || set_last_used!(current, time())
                 end
 
-                combined, result_str = eval_on_worker(meta, code)
+                combined, result_str = eval_on_worker(meta, code; timeout_s = timeout_s)
 
                 is_alive = !Workers.terminated(meta.worker)
                 if !is_alive
@@ -269,7 +303,8 @@ Returns structured JSON with `ok`, `status`, `session_id`, `output`, and `result
                 bt = catch_backtrace()
                 @warn "eval_code failed" worker_id exception = (err, bt)
                 remove_session!(WORKER_REGISTRY, worker_id; mark_status = SESSION_STATUS_ERROR)
-                errmsg = err isa CapturedException ? sprint(showerror, err.ex) : string(err)
+                errmsg = err isa CapturedException ? sprint(showerror, err.ex) :
+                    err isa WorkerEvalTimeout ? sprint(showerror, err) : string(err)
                 push!(events, make_event(WORKER_REGISTRY, "error"; session_id = worker_id,
                     payload = Dict("message" => errmsg)))
                 return render_process_response("eval_code";
@@ -280,7 +315,7 @@ Returns structured JSON with `ok`, `status`, `session_id`, `output`, and `result
                     wall_time_s = time() - start_time,
                     active_sessions = active_session_count(WORKER_REGISTRY),
                     events = events,
-                    error_kind = "eval_failed",
+                    error_kind = err isa WorkerEvalTimeout ? "timeout" : "eval_failed",
                     message = errmsg,
                 )
             end

--- a/LLMTools/test/file_tools_test.jl
+++ b/LLMTools/test/file_tools_test.jl
@@ -58,3 +58,71 @@ end
         end
     end
 end
+
+@testset "File tools multi-byte safety" begin
+    mktempdir() do tmpdir
+        funcs = file_funcs(tmpdir)
+        read_file = funcs["read"]
+        write_file = funcs["write"]
+        edit_file = funcs["edit"]
+        find_files = funcs["find"]
+
+        @testset "edit: oldText ends with multi-byte char" begin
+            write_file("mb1.txt", "prefix café suffix")
+            msg = edit_file("mb1.txt", "café", "tea")
+            @test occursin("Successfully replaced text", msg)
+            result = read_file("mb1.txt", nothing, nothing)
+            @test isvalid(result)
+            @test result == "prefix tea suffix"
+        end
+
+        @testset "edit: match immediately preceded by multi-byte char" begin
+            write_file("mb2.txt", "héllo world")
+            msg = edit_file("mb2.txt", "llo world", "y planet")
+            @test occursin("Successfully replaced text", msg)
+            result = read_file("mb2.txt", nothing, nothing)
+            @test isvalid(result)
+            @test result == "héy planet"
+        end
+
+        @testset "edit: emoji-terminated oldText at end of file" begin
+            write_file("mb3.txt", "status: done 🎉")
+            msg = edit_file("mb3.txt", "done 🎉", "shipped 🚀")
+            @test occursin("Successfully replaced text", msg)
+            result = read_file("mb3.txt", nothing, nothing)
+            @test isvalid(result)
+            @test result == "status: shipped 🚀"
+        end
+
+        @testset "edit: multi-byte match spans whole file" begin
+            write_file("mb4.txt", "é")
+            msg = edit_file("mb4.txt", "é", "e")
+            @test occursin("Successfully replaced text", msg)
+            result = read_file("mb4.txt", nothing, nothing)
+            @test isvalid(result)
+            @test result == "e"
+        end
+
+        @testset "glob_to_regex with non-ASCII pattern" begin
+            rx = LLMTools.glob_to_regex("café*.jl")
+            @test occursin(rx, "café_test.jl")
+            @test !occursin(rx, "cafe_test.jl")
+            rx2 = LLMTools.glob_to_regex("**/déjà?.txt")
+            @test occursin(rx2, "a/b/déjàX.txt")
+            @test !occursin(rx2, "a/b/déjà.txt")
+        end
+
+        @testset "find with non-ASCII glob" begin
+            write_file("café/menu.txt", "espresso")
+            found = find_files("café/*.txt", nothing, 20)
+            @test occursin("café/menu.txt", found)
+        end
+
+        @testset "strip_dir_suffix multi-byte" begin
+            @test LLMTools.strip_dir_suffix("café/") == "café"
+            @test LLMTools.strip_dir_suffix("café") == "café"
+            @test LLMTools.strip_dir_suffix("ascii/") == "ascii"
+            @test LLMTools.strip_dir_suffix("") == ""
+        end
+    end
+end

--- a/LLMTools/test/web_tools_test.jl
+++ b/LLMTools/test/web_tools_test.jl
@@ -86,4 +86,52 @@ end
     @testset "web_search validates empty query" begin
         @test_throws ArgumentError web_search("   ", 5, 5)
     end
+
+    @testset "Numeric entity decoding is UTF-8 safe" begin
+        # Valid decimal and hex entities still decode
+        @test LLMTools.extract_text_from_html("<p>&#65;&#x42;</p>") == "AB"
+
+        # Overflow-huge, out-of-range, and surrogate values must not throw and
+        # must decode to the replacement character
+        for bad in ("&#99999999999999999999;", "&#99999999;", "&#xD800;", "&#xdfff;", "&#x110000;")
+            out = LLMTools.extract_text_from_html("<p>before " * bad * " after</p>")
+            @test isvalid(out)
+            @test occursin('�', out)
+            @test occursin("before", out)
+            @test occursin("after", out)
+        end
+
+        # Mixed with surrounding multi-byte text and a valid astral-plane entity
+        out = LLMTools.extract_text_from_html("<p>café &#xD800; déjà &#128512;</p>")
+        @test isvalid(out)
+        @test occursin("café", out)
+        @test occursin("déjà", out)
+        @test occursin("😀", out)
+        @test occursin('�', out)
+    end
+
+    @testset "decode_numeric_entity" begin
+        @test LLMTools.decode_numeric_entity("&#65;") == "A"
+        @test LLMTools.decode_numeric_entity("&#x1F600;") == "😀"
+        @test LLMTools.decode_numeric_entity("&#0;") == "\0"
+        @test LLMTools.decode_numeric_entity("&#1114111;") == "\U10FFFF"
+        @test LLMTools.decode_numeric_entity("&#1114112;") == "�"   # scalar range + 1
+        @test LLMTools.decode_numeric_entity("&#xD800;") == "�"     # surrogate low bound
+        @test LLMTools.decode_numeric_entity("&#xDFFF;") == "�"     # surrogate high bound
+        @test LLMTools.decode_numeric_entity("&#55296;") == "�"     # 0xD800 in decimal
+        @test LLMTools.decode_numeric_entity("&#99999999999999999999;") == "�"  # Int overflow
+    end
+
+    @testset "repair_utf8" begin
+        good = "café 😀"
+        @test LLMTools.repair_utf8(good) == good
+        # 'a', an unpaired-surrogate byte sequence, 'b'
+        bad = String(UInt8[0x61, 0xed, 0xa0, 0x80, 0x62])
+        @test !isvalid(bad)
+        repaired = LLMTools.repair_utf8(bad)
+        @test isvalid(repaired)
+        @test startswith(repaired, "a")
+        @test endswith(repaired, "b")
+        @test occursin('�', repaired)
+    end
 end

--- a/LLMTools/test/worker_tools_test.jl
+++ b/LLMTools/test/worker_tools_test.jl
@@ -113,6 +113,63 @@ end
         kill_worker(worker_id)
     end
 
+    @testset "truncate_description is char-safe" begin
+        @test LLMTools.truncate_description("short") == "short"
+        @test LLMTools.truncate_description(repeat("a", 100)) == repeat("a", 80) * "..."
+        out = LLMTools.truncate_description(repeat("α", 100))
+        @test out == repeat("α", 80) * "..."
+        @test isvalid(out)
+    end
+
+    @testset "exec_code timeout terminates wedged worker" begin
+        LLMTools.reset_sessions_for_tests!(LLMTools.WORKER_REGISTRY)
+        result_ref = Ref{Any}(nothing)
+        t = Threads.@spawn begin
+            result_ref[] = exec_code("while true end", 3)
+        end
+        # Guard so a timeout regression fails the test instead of hanging CI
+        # (allow generous margin for worker process startup)
+        status = timedwait(() -> istaskdone(t), 30.0)
+        @test status === :ok
+        if status === :ok
+            parsed = parse_tool_json(result_ref[])
+            @test parsed["ok"] == false
+            @test parsed["error_kind"] == "timeout"
+            @test parsed["status"] == LLMTools.SESSION_STATUS_ERROR
+            @test occursin("timed out after 3s", parsed["message"])
+        end
+        LLMTools.reset_sessions_for_tests!(LLMTools.WORKER_REGISTRY)
+    end
+
+    @testset "eval_code timeout on existing worker" begin
+        LLMTools.reset_sessions_for_tests!(LLMTools.WORKER_REGISTRY)
+        started = parse_tool_json(exec_code("1", nothing))
+        worker_id = started["session_id"]
+        @test worker_id !== nothing
+        result_ref = Ref{Any}(nothing)
+        t = Threads.@spawn begin
+            result_ref[] = eval_code(worker_id, "while true end", 3)
+        end
+        status = timedwait(() -> istaskdone(t), 30.0)
+        @test status === :ok
+        if status === :ok
+            parsed = parse_tool_json(result_ref[])
+            @test parsed["ok"] == false
+            @test parsed["error_kind"] == "timeout"
+        end
+        LLMTools.reset_sessions_for_tests!(LLMTools.WORKER_REGISTRY)
+    end
+
+    @testset "exec_code timeout that does not fire" begin
+        LLMTools.reset_sessions_for_tests!(LLMTools.WORKER_REGISTRY)
+        parsed = parse_tool_json(exec_code("21 * 2", 60))
+        @test parsed["ok"] == true
+        @test parsed["result"] == "42"
+        if parsed["session_id"] !== nothing
+            kill_worker(parsed["session_id"])
+        end
+    end
+
     @testset "stdout capture" begin
         LLMTools.reset_sessions_for_tests!(LLMTools.WORKER_REGISTRY)
         parsed = parse_tool_json(exec_code("println(\"hello from worker\")", nothing))


### PR DESCRIPTION
# Round 1: correctness & security fix pass across the stack

First PR of a systematic review of the monorepo (bugs/correctness/security now; compaction/session cluster, Anthropic thinking+caching, Claw hardening, dual-model watcher, and registry refresh follow as separate PRs). Every fix below was verified against the actual code before changing it; regression tests accompany the behavioral fixes.

## Crashes / hangs (critical)

- **google-gemini-cli was dead**: `stream()` passed an undefined `debug_stream` variable → `UndefVarError` on every request. Now an env flag (`AGENTIF_DEBUG_GEMINI_STREAM`).
- **Infinite loop in the completions message builder**: two `continue`s without advancing the manual loop index — an empty assistant message (routinely created when a request errors mid-turn: `finalize_stream!` still appends the message) or an image-only user message to a text-only model would hang the process at 100% CPU *and permanently poison the session* (every later request rebuilds the same history). Regression test with a timedwait guard.
- **Default input guardrail always rejected**: `input_guardrail = true` read a nonexistent `.text` field on `AssistantMessage`; the `FieldError` was swallowed into `false` → `InvalidInputError` for every input. Now uses `message_text` and logs guardrail failures instead of silently swallowing them.
- **`skill_loader` always errored**: called `truncate_tool_output`, which only exists in LLMTools (not a dependency). Inlined a byte-capped truncation using the existing `MAX_TOOL_RESULT_BYTES` machinery.
- **`calculateCost` unusable with `Agentif.Usage`**: mutated a `cost` field that doesn't exist; the unit test only passed via a bespoke shim struct. Mutation removed; test now mirrors the real Usage field surface.
- **Worker `timeout_s` was documented but never implemented**: `exec_code("while true end")` wedged an evaluation forever. Implemented via `timedwait` + worker termination (SIGTERM→SIGINT→SIGKILL), with `error_kind: "timeout"` results; Claw's `eval_worker` forwards it.

## SSE stream-retry duplication (critical)

HTTP.jl's retry layer sits *above* the layer that feeds `sse_callback`, and `retry_non_idempotent = true` made mid-stream disconnects retryable — the whole response replayed into the same stateful callback closures: doubled text/thinking deltas, corrupted tool-call accumulators (`{"a":1}{"a":1}`). Verified against the pinned HTTP.jl source. All five SSE branches now disable transport retry and use a shared `sse_request_with_retry` that retries transient failures (408/429/5xx, recoverable connection errors, honoring `Retry-After`) **only while zero SSE events have been delivered**; after that, the partial message is kept and the failure surfaces as an `AgentErrorEvent` + `:error` stop reason. The codex custom retry loop got the same events-seen guard (it re-POSTed with the same stateful callback), and `InterruptException` is no longer classified retryable there. Tests: pre-stream 503-then-success still retries; mid-stream disconnect keeps exactly one copy of delivered text and does not re-POST.

Also: both Google branches now handle `HTTP.StatusError` like the other providers (error body parsed into an `AgentErrorEvent`, message finalized, `:error` stop reason) instead of leaking a raw exception and dropping the assistant message.

## Anthropic contract (high)

- **Unknown content blocks/deltas crashed the parser**: `@choosetype` fell through to `Any` → `TypeError` on `redacted_thinking`, `server_tool_use`, `citations_delta` (each verified). Added `RedactedThinkingBlock` as a first-class block plus `UnknownContentBlock`/`UnknownContentBlockDelta` catch-alls (mirroring `OpenAIResponses.UnknownOutput`); unknown types are now ignored with a debug log.
- **`redacted_thinking` round-trips**: captured as `ThinkingContent(redacted = true)` (new field, default `false`, non-breaking for persisted sessions) and replayed as `{"type":"redacted_thinking","data":…}` as the API requires — previously the block vanished, breaking multi-turn continuity after a safety redaction.
- **Signed-but-empty thinking blocks survive replay**: `transform_messages` dropped any ThinkingContent with empty text *before* checking the signature — discarding Responses encrypted-reasoning items when no summary was requested (the gpt-5 "no juice" path) and all redacted blocks. Signed blocks are now kept for same-model replay.
- **Usage accounting**: `message_start` usage (input/cache tokens) is now captured, and `message_delta` usage merges field-wise instead of wholesale — input/cache counts survive backends that only send `output_tokens` in deltas (this silently zeroed the compaction trigger's input).
- **`refusal` now maps to `:error`** instead of masquerading as a normal `:stop` completion (`pause_turn` stays `:stop` with a note; a synthesized `"error"` stop reason now maps to `:error`).
- **Responses: premature `MessageEndEvent`**: with reasoning summaries enabled, `reasoning_summary_text.done` fired the message-end before any text arrived; end is now emitted exactly once on terminal response events.

## UTF-8 boundary crash family (high)

Julia strings are byte-indexed; the repo-wide `length(s) > n … s[1:n]` idiom throws `StringIndexError` whenever a multi-byte char spans the cut — and several of these sites sat in *error-handling and recovery paths*. All audited and fixed (`first`/`prevind`/`nextind`):

- **edit tool splice** (`predefined_tools.jl`) — the flagship editing tool crashed when `oldText` ended in a multi-byte char or the match was preceded by one (verified both sides)
- **compaction** result-text preview — crashed compaction exactly when context is largest
- tool-argument error preview (`agent.jl`), stack-trace truncation (`logging_config.jl`), think-tag stream splitting (completions adapter, incl. the cross-chunk holdback), reasoning-details dedup, DDG snippet truncation, `glob_to_regex` byte-stepping (non-ASCII globs threw), codex text truncations, `toolcall_preview`, worker description, Claw handler-prompt preview

## Web content hardening (high)

- **HTML numeric entities**: the decoder was broken for *every* numeric entity on Julia 1.12 (`replace` passes a `SubString`, not a match object → `FieldError`), and adversarial entities could throw (`OverflowError`, `CodePointError`) or — worse — inject **invalid UTF-8** into tool results via surrogate entities (`&#xD800;`), corrupting the transcript and subsequent API requests. Now `tryparse` + Unicode-scalar validation with U+FFFD substitution, plus a `repair_utf8` defense-in-depth pass on extracted text.

## OAuth (security)

- **Codex token file** was written world-readable (0644) and non-atomically; now temp-file + `chmod 0600` + atomic rename (and `~/.agentif` created 0700), matching the Anthropic path's store.
- **Dead error handling**: the three raw token calls used `status_exception = true`, making their friendly non-2xx branches unreachable; a revoked refresh token (`invalid_grant`) never cleared stored credentials → permanent re-fail loop until manual file deletion. Errors are now classified, `invalid_grant` deletes `codex_auth.json` with a clear "re-run codex_login()" message.
- `codex_login`'s post-exchange save now happens under the same refresh lock as background refreshes (rotation race).
- Credential dir is testable via `AGENTIF_DIR` (default unchanged); tests assert 0600/0700 modes, atomicity leftovers, and the invalid_grant classifier.

## Claw fixes

- **REPL `a"…"` hung forever** when an eval errored before streaming finished (completion event never notified); `close_channel(::ReplChannel)` now notifies.
- **GitHub webhook fails closed**: without a secret, GitHub.jl skips HMAC verification entirely while binding 0.0.0.0 — forged events would be evaluated as trusted input. `start!` now errors without a secret.
- **Telegram group channels survived restarts only for positive ids**: the re-seed regex rejected negative (group/supergroup) chat ids, silently routing persisted group handlers to a sink.
- Handler upsert is crash-resistant: the replacement row is inserted before the old row is deleted (crash between DELETE and re-INSERT left automations that never fire again); `init!` re-seeds Tempus job event types after the purge (they'd vanish from `list_event_types` and break handler validation); the five `ext/*_run.jl` scripts no longer exit immediately (Claw.run is non-blocking); `Claw.run(; db_path=…)` now works as the README documents.

## Testing

Full monorepo suite green (`julia --project=. test/runtests.jl`), including ~40 new testsets: SSE retry unit + integration (local servers: pre-stream 503, mid-stream disconnect, codex no-re-POST, Google 400), Anthropic redacted/unknown-block/usage-merge/refusal round-trips, Responses single-end-event, builder termination, edit-tool multi-byte splices, entity-decode adversarial cases, non-ASCII globs, worker timeouts (hang-guarded), OAuth file modes/atomicity/invalid_grant.


## Maintainer review follow-up

- Made Codex credential replacement secure before any token bytes are written. Existing credential directories are also tightened to mode 0700. A 401 now clears credentials only when the response identifies a rejected refresh token; `invalid_client` keeps valid user credentials.
- Made SSE failure handling work with both HTTP 1.x and HTTP 2.x exception APIs. HTTP 2 failed-task wrappers and nested parse errors are classified without replaying a partial stream.
- Fixed remaining UTF-8 index hazards in compound tool-call IDs, OpenAI ID limits, and skill metadata unquoting.
- Made Anthropic stream error events produce a complete message lifecycle and an `:error` stop reason.
- Applied worker timeouts to the initial Claw worker evaluation and to later evaluations. Timed-out workers are removed from the shared registry and their Claw session is marked as failed.

Validation completed on the final branch: the full monorepo suite passed under the normal HTTP 1 dependency set; the complete Agentif suite passed with HTTP 2.6; the LLMOAuth suite passed with HTTP 2.6 and OAuth 3.0; and a trimmed Agentif build loaded successfully.

Co-authored by Codex

🤖 Generated with [Claude Code](https://claude.com/claude-code)
