### PR TITLE
Anthropic: thinking/effort, prompt caching, and pause_turn resubmit

### DIFF
--- a/Agentif/src/providers/anthropic_messages_adapter.jl
+++ b/Agentif/src/providers/anthropic_messages_adapter.jl
@@ -121,8 +121,15 @@ end
 function anthropic_cache_control(base_url::AbstractString, cache_retention)
     retention = resolve_openai_cache_retention(cache_retention)
     retention == "none" && return nothing
-    # The 1h beta TTL only exists on Anthropic's own endpoint; proxies reject it.
-    ttl = (retention == "long" && occursin("api.anthropic.com", lowercase(String(base_url)))) ? "1h" : nothing
+    # The 1h TTL is only enabled for Anthropic's own endpoint. Compare the parsed
+    # host exactly; a substring check also matches proxy or attacker-controlled hosts
+    # such as `api.anthropic.com.example.test`.
+    native_host = try
+        rstrip(lowercase(HTTP.URI(String(base_url)).host), '.') == "api.anthropic.com"
+    catch
+        false
+    end
+    ttl = retention == "long" && native_host ? "1h" : nothing
     return AnthropicMessages.CacheControl(; type = "ephemeral", ttl)
 end
 
@@ -159,38 +166,32 @@ function anthropic_apply_cache_control!(messages::Vector{AnthropicMessages.Messa
 end
 
 # --- Per-model thinking/effort capabilities -----------------------------------------
-# Source: Anthropic docs fetched 2026-07-30 —
-#   /docs/en/build-with-claude/thinking  and  /docs/en/build-with-claude/effort.
-# There are two distinct thinking mechanisms and the newest models only support the
-# newer one, so selection is capability-driven rather than a single global mapping.
+# Prefer the registry's `compat` and `thinkingLevelMap` metadata. The model-name
+# fallbacks keep manually constructed models and older snapshots working.
 
 anthropic_model_matches(model_id::AbstractString, patterns) =
     any(p -> occursin(p, lowercase(String(model_id))), patterns)
 
-# Adaptive-only: extended thinking (`budget_tokens`) returns a 400 here. These are also
-# the models that reject non-default temperature/top_p/top_k on *every* request.
+# Mythos Preview is intentionally absent. It supports both adaptive thinking and
+# manual `budget_tokens`; classifying it as adaptive-only corrupts explicit requests.
 const ANTHROPIC_ADAPTIVE_ONLY_MODELS = (
     "opus-4-7", "opus-4.7", "opus-4-8", "opus-4.8",
-    "opus-5", "sonnet-5", "fable-5", "mythos-5", "mythos-preview",
+    "opus-5", "sonnet-5", "fable-5", "mythos-5",
 )
 
-# The 4.6 family supports both mechanisms (extended thinking deprecated there).
 const ANTHROPIC_ADAPTIVE_THINKING_MODELS = (
-    ANTHROPIC_ADAPTIVE_ONLY_MODELS..., "opus-4-6", "opus-4.6", "sonnet-4-6", "sonnet-4.6",
+    ANTHROPIC_ADAPTIVE_ONLY_MODELS..., "mythos-preview",
+    "opus-4-6", "opus-4.6", "sonnet-4-6", "sonnet-4.6",
 )
 
-# Thinking cannot be turned off at all on these; `{type: "disabled"}` is rejected.
 const ANTHROPIC_ALWAYS_THINKING_MODELS = ("fable-5", "mythos-5", "mythos-preview")
-
-# `effort` also works on Opus 4.5, the one extended-thinking-only model that supports it
-# (there it composes with `budget_tokens`).
 const ANTHROPIC_EFFORT_MODELS = (ANTHROPIC_ADAPTIVE_THINKING_MODELS..., "opus-4-5", "opus-4.5")
-
-# `max` is available on the 4.6 family and newer; `xhigh` arrived with Opus 4.7 and is
-# not available on Mythos Preview or the 4.6 family.
 const ANTHROPIC_MAX_EFFORT_MODELS = ANTHROPIC_ADAPTIVE_THINKING_MODELS
 const ANTHROPIC_XHIGH_EFFORT_MODELS = (
     "opus-4-7", "opus-4.7", "opus-4-8", "opus-4.8", "opus-5", "sonnet-5", "fable-5", "mythos-5",
+)
+const ANTHROPIC_REJECTS_SAMPLING_MODELS = (
+    ANTHROPIC_ADAPTIVE_ONLY_MODELS..., "mythos-preview",
 )
 
 anthropic_supports_adaptive_thinking(model_id::AbstractString) = anthropic_model_matches(model_id, ANTHROPIC_ADAPTIVE_THINKING_MODELS)
@@ -199,16 +200,51 @@ anthropic_thinking_always_on(model_id::AbstractString) = anthropic_model_matches
 anthropic_supports_effort(model_id::AbstractString) = anthropic_model_matches(model_id, ANTHROPIC_EFFORT_MODELS)
 anthropic_supports_max_effort(model_id::AbstractString) = anthropic_model_matches(model_id, ANTHROPIC_MAX_EFFORT_MODELS)
 anthropic_supports_xhigh_effort(model_id::AbstractString) = anthropic_model_matches(model_id, ANTHROPIC_XHIGH_EFFORT_MODELS)
-# Non-default temperature/top_p/top_k are rejected outright on the adaptive-only models;
-# on older models they only conflict while thinking is on.
-anthropic_rejects_sampling_params(model_id::AbstractString) = anthropic_model_matches(model_id, ANTHROPIC_ADAPTIVE_ONLY_MODELS)
-# Interleaved thinking is automatic under adaptive thinking (no header); under extended
-# thinking it needs a beta header, and Claude Haiku 4.5 does not support it at all.
-anthropic_needs_interleaved_thinking_beta(model_id::AbstractString) =
-    !anthropic_supports_adaptive_thinking(model_id) && !anthropic_model_matches(model_id, ("haiku-4-5", "haiku-4.5"))
+anthropic_rejects_sampling_params(model_id::AbstractString) = anthropic_model_matches(model_id, ANTHROPIC_REJECTS_SAMPLING_MODELS)
 
-# pi-mono's mapThinkingLevelToEffort, made capability-driven: a level the model does not
-# support steps down to the highest rung it does support.
+function anthropic_compat_flag(model::Model, key::AbstractString)
+    model.compat === nothing && return nothing
+    value = get(() -> nothing, model.compat, String(key))
+    return value isa Bool ? value : nothing
+end
+
+function anthropic_supports_adaptive_thinking(model::Model)
+    override = anthropic_compat_flag(model, "forceAdaptiveThinking")
+    return override === nothing ? anthropic_supports_adaptive_thinking(model.id) : override
+end
+function anthropic_supports_extended_thinking(model::Model)
+    override = anthropic_compat_flag(model, "forceAdaptiveThinking")
+    override === false && return true
+    return anthropic_supports_extended_thinking(model.id)
+end
+function anthropic_thinking_always_on(model::Model)
+    level_map = model.thinkingLevelMap
+    if level_map !== nothing && haskey(level_map, "off")
+        return level_map["off"] === nothing
+    end
+    return anthropic_thinking_always_on(model.id)
+end
+function anthropic_supports_effort(model::Model)
+    override = anthropic_compat_flag(model, "forceAdaptiveThinking")
+    override !== nothing && return override
+    return anthropic_supports_effort(model.id)
+end
+function anthropic_rejects_sampling_params(model::Model)
+    supports_temperature = anthropic_compat_flag(model, "supportsTemperature")
+    return supports_temperature === nothing ?
+        anthropic_rejects_sampling_params(model.id) : !supports_temperature
+end
+
+# Interleaved thinking is automatic in adaptive mode. In manual mode it needs a
+# beta header except on Haiku 4.5 (unsupported) and Opus 4.6 (no manual-mode
+# interleaving). Sonnet 4.6 still accepts the header in manual mode.
+function anthropic_needs_interleaved_thinking_beta(model::Model, thinking)
+    anthropic_thinking_type(thinking) == "enabled" || return false
+    anthropic_model_matches(model.id, ("haiku-4-5", "haiku-4.5")) && return false
+    anthropic_model_matches(model.id, ("opus-4-6", "opus-4.6")) && return false
+    return true
+end
+
 function anthropic_effort_for_level(level::AbstractString, model_id::AbstractString)
     lvl = lowercase(strip(String(level)))
     lvl == "minimal" && (lvl = "low")
@@ -221,6 +257,21 @@ function anthropic_effort_for_level(level::AbstractString, model_id::AbstractStr
     return "high"
 end
 
+function anthropic_effort_for_level(level::AbstractString, model::Model)
+    lvl = lowercase(strip(String(level)))
+    lvl == "minimal" && (lvl = "low")
+    level_map = model.thinkingLevelMap
+    if level_map !== nothing
+        mapped = get(() -> nothing, level_map, lvl)
+        mapped isa AbstractString && return String(mapped)
+        if lvl == "xhigh"
+            max_mapped = get(() -> nothing, level_map, "max")
+            max_mapped isa AbstractString && return String(max_mapped)
+        end
+    end
+    return anthropic_effort_for_level(lvl, model.id)
+end
+
 const ANTHROPIC_DEFAULT_THINKING_BUDGETS = Dict("minimal" => 1024, "low" => 2048, "medium" => 8192, "high" => 16384)
 const ANTHROPIC_MIN_OUTPUT_TOKENS = 1024
 
@@ -228,14 +279,18 @@ const ANTHROPIC_MIN_OUTPUT_TOKENS = 1024
 # budget, clamp to the model ceiling, and keep budget_tokens strictly below max_tokens
 # (the API rejects budget_tokens >= max_tokens).
 function anthropic_adjust_max_tokens_for_thinking(base_max_tokens::Int, model_max_tokens::Int, level::AbstractString)
+    base_max_tokens > 0 || throw(ArgumentError("max_tokens must be positive"))
+    model_max_tokens > ANTHROPIC_MIN_OUTPUT_TOKENS ||
+        throw(ArgumentError("model maxTokens must exceed $ANTHROPIC_MIN_OUTPUT_TOKENS for extended thinking"))
     lvl = lowercase(strip(String(level)))
-    # Budget-based models have no rung above "high".
     lvl in ("xhigh", "max") && (lvl = "high")
     budget = get(() -> ANTHROPIC_DEFAULT_THINKING_BUDGETS["high"], ANTHROPIC_DEFAULT_THINKING_BUDGETS, lvl)
     max_tokens = min(base_max_tokens + budget, model_max_tokens)
     if max_tokens <= budget
-        budget = max(0, max_tokens - ANTHROPIC_MIN_OUTPUT_TOKENS)
+        budget = max_tokens - ANTHROPIC_MIN_OUTPUT_TOKENS
     end
+    budget >= 1024 ||
+        throw(ArgumentError("max_tokens is too small for the minimum 1,024-token thinking budget"))
     return (; max_tokens, thinking_budget = budget)
 end
 
@@ -246,9 +301,9 @@ end
 function anthropic_thinking_request(model::Model, level, base_max_tokens::Int)
     (level === nothing || !model.reasoning) && return (; thinking = nothing, output_config = nothing, max_tokens = base_max_tokens)
     lvl = string(level)
-    output_config = anthropic_supports_effort(model.id) ?
-        AnthropicMessages.OutputConfig(; effort = anthropic_effort_for_level(lvl, model.id)) : nothing
-    if anthropic_supports_adaptive_thinking(model.id)
+    output_config = anthropic_supports_effort(model) ?
+        AnthropicMessages.OutputConfig(; effort = anthropic_effort_for_level(lvl, model)) : nothing
+    if anthropic_supports_adaptive_thinking(model)
         # `display` defaults to "omitted" on the 5-generation models, which would stream
         # empty thinking blocks; Agentif surfaces reasoning, so ask for summaries.
         return (;
@@ -272,6 +327,43 @@ function anthropic_thinking_type(thinking)
     return nothing
 end
 
+function anthropic_thinking_field(thinking, key::Symbol)
+    thinking isa AnthropicMessages.ThinkingConfig && return getproperty(thinking, key)
+    if thinking isa AbstractDict
+        value = get(() -> nothing, thinking, String(key))
+        return value === nothing ? get(() -> nothing, thinking, key) : value
+    end
+    thinking isa NamedTuple && return get(() -> nothing, thinking, key)
+    return nothing
+end
+
+function anthropic_output_effort(output_config)
+    output_config isa AnthropicMessages.OutputConfig && return output_config.effort
+    if output_config isa AbstractDict
+        value = get(() -> nothing, output_config, "effort")
+        return value === nothing ? get(() -> nothing, output_config, :effort) : value
+    end
+    output_config isa NamedTuple && return get(() -> nothing, output_config, :effort)
+    return nothing
+end
+
+function anthropic_disabled_effort_conflict(model::Model, thinking, output_config)
+    anthropic_thinking_type(thinking) == "disabled" || return false
+    anthropic_model_matches(model.id, ("opus-5",)) || return false
+    effort = anthropic_output_effort(output_config)
+    return effort !== nothing && lowercase(String(effort)) in ("xhigh", "max")
+end
+
+function anthropic_tool_choice_type(tool_choice)
+    if tool_choice isa AbstractDict
+        value = get(() -> nothing, tool_choice, "type")
+        return value === nothing ? get(() -> nothing, tool_choice, :type) : value
+    end
+    tool_choice isa NamedTuple && return get(() -> nothing, tool_choice, :type)
+    tool_choice isa AbstractString && return tool_choice
+    return nothing
+end
+
 # Caller-supplied `thinking` kwargs win over the derived config; we still need to know
 # whether thinking ends up on so the sampling guard and beta header stay correct.
 function anthropic_thinking_is_enabled(thinking)
@@ -281,24 +373,79 @@ function anthropic_thinking_is_enabled(thinking)
     return String(type) != "disabled"
 end
 
-# Reconcile a caller-supplied thinking config with the model's capabilities so an
-# unsupported shape degrades to the supported mechanism instead of returning a 400.
+function anthropic_normalize_extended_thinking(thinking, model::Model, base_max_tokens::Int)
+    raw_budget = anthropic_thinking_field(thinking, :budget_tokens)
+    budget = raw_budget === nothing ? 1024 : try
+        Int(raw_budget)
+    catch
+        throw(ArgumentError("thinking.budget_tokens must be an integer"))
+    end
+    if budget < 1024
+        @warn "Anthropic requires a minimum 1,024-token thinking budget; clamping" requested = budget
+        budget = 1024
+    end
+    model.maxTokens > ANTHROPIC_MIN_OUTPUT_TOKENS ||
+        throw(ArgumentError("model maxTokens must exceed $ANTHROPIC_MIN_OUTPUT_TOKENS for extended thinking"))
+    max_tokens = min(max(base_max_tokens, budget + ANTHROPIC_MIN_OUTPUT_TOKENS), model.maxTokens)
+    if budget >= max_tokens
+        clamped = max_tokens - ANTHROPIC_MIN_OUTPUT_TOKENS
+        clamped >= 1024 ||
+            throw(ArgumentError("max_tokens is too small for the minimum 1,024-token thinking budget"))
+        @warn "thinking.budget_tokens must be below max_tokens; clamping" requested = budget clamped max_tokens
+        budget = clamped
+    end
+    display = anthropic_thinking_field(thinking, :display)
+    if display !== nothing && !(String(display) in ("omitted", "summarized"))
+        @warn "Ignoring unsupported Anthropic thinking display" display
+        display = nothing
+    end
+    config = AnthropicMessages.ThinkingConfig(;
+        type = "enabled",
+        budget_tokens = budget,
+        display = display === nothing ? nothing : String(display),
+    )
+    return (; thinking = config, max_tokens)
+end
+
+# Reconcile a caller-supplied thinking config with model capabilities. Invalid
+# configurations are normalized before they reach the API.
 function anthropic_normalize_thinking(thinking, model::Model, base_max_tokens::Int)
     thinking === nothing && return (; thinking = nothing, max_tokens = base_max_tokens)
     type = anthropic_thinking_type(thinking)
-    type = type === nothing ? nothing : String(type)
-    if type == "disabled" && anthropic_thinking_always_on(model.id)
+    type === nothing && throw(ArgumentError("thinking.type is required"))
+    type = lowercase(String(type))
+    type in ("adaptive", "enabled", "disabled") ||
+        throw(ArgumentError("unsupported thinking.type: $type"))
+    if type == "disabled" && anthropic_thinking_always_on(model)
         @warn "Thinking cannot be disabled on this model; ignoring thinking=disabled" model = model.id
         return (; thinking = nothing, max_tokens = base_max_tokens)
-    elseif type == "enabled" && !anthropic_supports_extended_thinking(model.id)
+    elseif type == "enabled" && !anthropic_supports_extended_thinking(model)
         @warn "Extended thinking (budget_tokens) is not supported on this model; falling back to adaptive thinking" model = model.id
         return (; thinking = AnthropicMessages.ThinkingConfig(; type = "adaptive", display = "summarized"), max_tokens = base_max_tokens)
-    elseif type == "adaptive" && !anthropic_supports_adaptive_thinking(model.id)
+    elseif type == "enabled"
+        return anthropic_normalize_extended_thinking(thinking, model, base_max_tokens)
+    elseif type == "adaptive" && !anthropic_supports_adaptive_thinking(model)
         @warn "Adaptive thinking is not supported on this model; falling back to extended thinking" model = model.id
         adjusted = anthropic_adjust_max_tokens_for_thinking(base_max_tokens, model.maxTokens, "high")
         return (; thinking = AnthropicMessages.ThinkingConfig(; type = "enabled", budget_tokens = adjusted.thinking_budget), max_tokens = adjusted.max_tokens)
+    elseif type == "adaptive"
+        display = anthropic_thinking_field(thinking, :display)
+        if display !== nothing && !(String(display) in ("omitted", "summarized"))
+            @warn "Ignoring unsupported Anthropic thinking display" display
+            display = nothing
+        end
+        return (;
+            thinking = AnthropicMessages.ThinkingConfig(;
+                type = "adaptive",
+                display = display === nothing ? nothing : String(display),
+            ),
+            max_tokens = base_max_tokens,
+        )
     end
-    return (; thinking, max_tokens = base_max_tokens)
+    return (;
+        thinking = AnthropicMessages.ThinkingConfig(; type = "disabled"),
+        max_tokens = base_max_tokens,
+    )
 end
 
 function anthropic_message_from_agent(msg::AgentMessage, tool_name_map::Dict{String, String}, model::Model)
@@ -448,7 +595,7 @@ function anthropic_stop_reason(reason::Union{Nothing, String}, tool_calls::Vecto
     end
     if reason == "tool_use"
         return :tool_calls
-    elseif reason == "max_tokens"
+    elseif reason == "max_tokens" || reason == "model_context_window_exceeded"
         return :length
     elseif reason == "stop_sequence"
         return :stop
@@ -457,9 +604,9 @@ function anthropic_stop_reason(reason::Union{Nothing, String}, tool_calls::Vecto
     elseif reason == "refusal"
         return :error
     elseif reason == "pause_turn"
-        # The stream driver resubmits paused turns (bounded); reaching here means the
-        # resubmit budget ran out, so the turn is reported as a normal stop.
-        return :stop
+        # The stream driver resubmits paused turns (bounded). Reaching here means the
+        # turn is still incomplete, so never report it as a successful stop.
+        return :length
     elseif reason == "error"
         # Synthesized by the stream driver on HTTP errors.
         return :error
@@ -477,16 +624,22 @@ function anthropic_event_callback(
         latest_usage::Base.RefValue{Union{Nothing, AnthropicMessages.Usage}},
         blocks_by_index::Dict{Int, AssistantContentBlock},
         partial_json_by_index::Dict{Int, String},
+        wire_blocks_by_index::Dict{Int, Dict{String, Any}},
+        wire_partial_json_by_index::Dict{Int, String},
+        wire_replay_safe::Base.RefValue{Bool},
         tool_name_reverse_map::Dict{String, String},
         abort::Abort,
     ) where {F <: Function}
     stop_on_tool_call = get(ENV, "AGENTIF_STOP_ON_TOOL_CALL", "") != ""
     return function (stream, event)
         maybe_abort!(abort, stream)
-        local parsed
+        local parsed, wire_event
         try
-            parsed = JSON.parse(String(event.data), AnthropicMessages.StreamEvent)
+            data = String(event.data)
+            wire_event = JSON.parse(data)
+            parsed = JSON.parse(data, AnthropicMessages.StreamEvent)
         catch e
+            wire_replay_safe[] = false
             f(AgentErrorEvent(ErrorException(sprint(showerror, e))))
             return
         end
@@ -502,6 +655,13 @@ function anthropic_event_callback(
                 f(MessageStartEvent(:assistant, assistant_message))
             end
         elseif parsed isa AnthropicMessages.StreamContentBlockStartEvent
+            wire_block = get(() -> nothing, wire_event, "content_block")
+            if wire_block isa AbstractDict
+                wire_blocks_by_index[parsed.index] =
+                    Dict{String, Any}(String(key) => value for (key, value) in wire_block)
+            else
+                wire_replay_safe[] = false
+            end
             if parsed.content_block isa AnthropicMessages.TextBlock
                 block = TextContent(; text = parsed.content_block.text)
                 push!(assistant_message.content, block)
@@ -537,6 +697,32 @@ function anthropic_event_callback(
                 @debug "Ignoring unknown Anthropic content block" type = parsed.content_block.type index = parsed.index
             end
         elseif parsed isa AnthropicMessages.StreamContentBlockDeltaEvent
+            wire_delta = get(() -> nothing, wire_event, "delta")
+            wire_block = get(() -> nothing, wire_blocks_by_index, parsed.index)
+            if wire_delta isa AbstractDict && wire_block isa AbstractDict
+                delta_type = get(() -> nothing, wire_delta, "type")
+                if delta_type == "text_delta"
+                    wire_block["text"] = string(get(() -> "", wire_block, "text"),
+                        get(() -> "", wire_delta, "text"))
+                elseif delta_type == "thinking_delta"
+                    wire_block["thinking"] = string(get(() -> "", wire_block, "thinking"),
+                        get(() -> "", wire_delta, "thinking"))
+                elseif delta_type == "signature_delta"
+                    wire_block["signature"] = string(get(() -> "", wire_block, "signature"),
+                        get(() -> "", wire_delta, "signature"))
+                elseif delta_type == "input_json_delta"
+                    partial = get(() -> "", wire_partial_json_by_index, parsed.index)
+                    wire_partial_json_by_index[parsed.index] =
+                        partial * string(get(() -> "", wire_delta, "partial_json"))
+                else
+                    # Unknown deltas cannot be applied to a final content block
+                    # without knowing their merge semantics. Do not replay a
+                    # potentially corrupted paused turn.
+                    wire_replay_safe[] = false
+                end
+            else
+                wire_replay_safe[] = false
+            end
             if parsed.delta isa AnthropicMessages.TextDelta
                 block = get(() -> nothing, blocks_by_index, parsed.index)
                 block isa TextContent || return
@@ -571,6 +757,21 @@ function anthropic_event_callback(
                 @debug "Ignoring unknown Anthropic content block delta" type = parsed.delta.type index = parsed.index
             end
         elseif parsed isa AnthropicMessages.StreamContentBlockStopEvent
+            wire_partial = get(() -> nothing, wire_partial_json_by_index, parsed.index)
+            if wire_partial !== nothing
+                wire_block = get(() -> nothing, wire_blocks_by_index, parsed.index)
+                if wire_block isa AbstractDict
+                    try
+                        wire_block["input"] = isempty(wire_partial) ?
+                            get(() -> Dict{String, Any}(), wire_block, "input") :
+                            JSON.parse(wire_partial)
+                    catch
+                        wire_replay_safe[] = false
+                    end
+                else
+                    wire_replay_safe[] = false
+                end
+            end
             block = get(() -> nothing, blocks_by_index, parsed.index)
             if block isa ToolCallContent
                 partial = get(() -> "", partial_json_by_index, parsed.index)

--- a/Agentif/src/providers/anthropic_messages_adapter.jl
+++ b/Agentif/src/providers/anthropic_messages_adapter.jl
@@ -113,12 +113,192 @@ function anthropic_internal_tool_name(tool_name_reverse_map::Dict{String, String
     return get(() -> name, tool_name_reverse_map, name)
 end
 
-function anthropic_oauth_system_blocks(prompt::String)
+# Prompt caching, mirroring pi-mono's anthropic provider (getCacheControl,
+# packages/ai/src/providers/anthropic.ts): a breakpoint on the system prompt and one
+# on the last user message, so the whole conversation prefix is served from cache
+# instead of being re-billed at uncached rates every turn.
+# `resolve_openai_cache_retention` is the shared none/short/long resolver.
+function anthropic_cache_control(base_url::AbstractString, cache_retention)
+    retention = resolve_openai_cache_retention(cache_retention)
+    retention == "none" && return nothing
+    # The 1h beta TTL only exists on Anthropic's own endpoint; proxies reject it.
+    ttl = (retention == "long" && occursin("api.anthropic.com", lowercase(String(base_url)))) ? "1h" : nothing
+    return AnthropicMessages.CacheControl(; type = "ephemeral", ttl)
+end
+
+function anthropic_system_blocks(prompt::String, cache_control::Union{Nothing, AnthropicMessages.CacheControl})
+    isempty(strip(prompt)) && return nothing
+    return AnthropicMessages.TextBlock[AnthropicMessages.TextBlock(; text = prompt, cache_control)]
+end
+
+function anthropic_oauth_system_blocks(prompt::String, cache_control::Union{Nothing, AnthropicMessages.CacheControl} = AnthropicMessages.CacheControl(; type = "ephemeral"))
     blocks = AnthropicMessages.TextBlock[]
-    cache_control = AnthropicMessages.CacheControl(; type = "ephemeral")
     push!(blocks, AnthropicMessages.TextBlock(; text = "You are Claude Code, Anthropic's official CLI for Claude.", cache_control))
     isempty(prompt) || push!(blocks, AnthropicMessages.TextBlock(; text = prompt, cache_control))
     return blocks
+end
+
+# Breakpoint on the last block of the trailing user message. Anthropic allows at most
+# four; the OAuth spoof path already spends two on its system blocks, so this one is
+# additive rather than a second pass over the system prompt.
+function anthropic_apply_cache_control!(messages::Vector{AnthropicMessages.Message}, cache_control::Union{Nothing, AnthropicMessages.CacheControl})
+    (cache_control === nothing || isempty(messages)) && return messages
+    last_message = messages[end]
+    last_message.role == "user" || return messages
+    content = last_message.content
+    if content isa AbstractString
+        block = AnthropicMessages.TextBlock(; text = content, cache_control)
+        messages[end] = AnthropicMessages.Message(; role = "user", content = AnthropicMessages.ContentBlock[block])
+    elseif content isa AbstractVector && !isempty(content)
+        block = content[end]
+        if block isa AnthropicMessages.TextBlock || block isa AnthropicMessages.ImageBlock || block isa AnthropicMessages.ToolResultBlock
+            block.cache_control = cache_control
+        end
+    end
+    return messages
+end
+
+# --- Per-model thinking/effort capabilities -----------------------------------------
+# Source: Anthropic docs fetched 2026-07-30 —
+#   /docs/en/build-with-claude/thinking  and  /docs/en/build-with-claude/effort.
+# There are two distinct thinking mechanisms and the newest models only support the
+# newer one, so selection is capability-driven rather than a single global mapping.
+
+anthropic_model_matches(model_id::AbstractString, patterns) =
+    any(p -> occursin(p, lowercase(String(model_id))), patterns)
+
+# Adaptive-only: extended thinking (`budget_tokens`) returns a 400 here. These are also
+# the models that reject non-default temperature/top_p/top_k on *every* request.
+const ANTHROPIC_ADAPTIVE_ONLY_MODELS = (
+    "opus-4-7", "opus-4.7", "opus-4-8", "opus-4.8",
+    "opus-5", "sonnet-5", "fable-5", "mythos-5", "mythos-preview",
+)
+
+# The 4.6 family supports both mechanisms (extended thinking deprecated there).
+const ANTHROPIC_ADAPTIVE_THINKING_MODELS = (
+    ANTHROPIC_ADAPTIVE_ONLY_MODELS..., "opus-4-6", "opus-4.6", "sonnet-4-6", "sonnet-4.6",
+)
+
+# Thinking cannot be turned off at all on these; `{type: "disabled"}` is rejected.
+const ANTHROPIC_ALWAYS_THINKING_MODELS = ("fable-5", "mythos-5", "mythos-preview")
+
+# `effort` also works on Opus 4.5, the one extended-thinking-only model that supports it
+# (there it composes with `budget_tokens`).
+const ANTHROPIC_EFFORT_MODELS = (ANTHROPIC_ADAPTIVE_THINKING_MODELS..., "opus-4-5", "opus-4.5")
+
+# `max` is available on the 4.6 family and newer; `xhigh` arrived with Opus 4.7 and is
+# not available on Mythos Preview or the 4.6 family.
+const ANTHROPIC_MAX_EFFORT_MODELS = ANTHROPIC_ADAPTIVE_THINKING_MODELS
+const ANTHROPIC_XHIGH_EFFORT_MODELS = (
+    "opus-4-7", "opus-4.7", "opus-4-8", "opus-4.8", "opus-5", "sonnet-5", "fable-5", "mythos-5",
+)
+
+anthropic_supports_adaptive_thinking(model_id::AbstractString) = anthropic_model_matches(model_id, ANTHROPIC_ADAPTIVE_THINKING_MODELS)
+anthropic_supports_extended_thinking(model_id::AbstractString) = !anthropic_model_matches(model_id, ANTHROPIC_ADAPTIVE_ONLY_MODELS)
+anthropic_thinking_always_on(model_id::AbstractString) = anthropic_model_matches(model_id, ANTHROPIC_ALWAYS_THINKING_MODELS)
+anthropic_supports_effort(model_id::AbstractString) = anthropic_model_matches(model_id, ANTHROPIC_EFFORT_MODELS)
+anthropic_supports_max_effort(model_id::AbstractString) = anthropic_model_matches(model_id, ANTHROPIC_MAX_EFFORT_MODELS)
+anthropic_supports_xhigh_effort(model_id::AbstractString) = anthropic_model_matches(model_id, ANTHROPIC_XHIGH_EFFORT_MODELS)
+# Non-default temperature/top_p/top_k are rejected outright on the adaptive-only models;
+# on older models they only conflict while thinking is on.
+anthropic_rejects_sampling_params(model_id::AbstractString) = anthropic_model_matches(model_id, ANTHROPIC_ADAPTIVE_ONLY_MODELS)
+# Interleaved thinking is automatic under adaptive thinking (no header); under extended
+# thinking it needs a beta header, and Claude Haiku 4.5 does not support it at all.
+anthropic_needs_interleaved_thinking_beta(model_id::AbstractString) =
+    !anthropic_supports_adaptive_thinking(model_id) && !anthropic_model_matches(model_id, ("haiku-4-5", "haiku-4.5"))
+
+# pi-mono's mapThinkingLevelToEffort, made capability-driven: a level the model does not
+# support steps down to the highest rung it does support.
+function anthropic_effort_for_level(level::AbstractString, model_id::AbstractString)
+    lvl = lowercase(strip(String(level)))
+    lvl == "minimal" && (lvl = "low")
+    lvl in ("low", "medium", "high") && return lvl
+    if lvl in ("xhigh", "max")
+        lvl == "xhigh" && anthropic_supports_xhigh_effort(model_id) && return "xhigh"
+        anthropic_supports_max_effort(model_id) && return "max"
+        return "high"
+    end
+    return "high"
+end
+
+const ANTHROPIC_DEFAULT_THINKING_BUDGETS = Dict("minimal" => 1024, "low" => 2048, "medium" => 8192, "high" => 16384)
+const ANTHROPIC_MIN_OUTPUT_TOKENS = 1024
+
+# pi-mono's adjustMaxTokensForThinking: grow max_tokens to make room for the thinking
+# budget, clamp to the model ceiling, and keep budget_tokens strictly below max_tokens
+# (the API rejects budget_tokens >= max_tokens).
+function anthropic_adjust_max_tokens_for_thinking(base_max_tokens::Int, model_max_tokens::Int, level::AbstractString)
+    lvl = lowercase(strip(String(level)))
+    # Budget-based models have no rung above "high".
+    lvl in ("xhigh", "max") && (lvl = "high")
+    budget = get(() -> ANTHROPIC_DEFAULT_THINKING_BUDGETS["high"], ANTHROPIC_DEFAULT_THINKING_BUDGETS, lvl)
+    max_tokens = min(base_max_tokens + budget, model_max_tokens)
+    if max_tokens <= budget
+        budget = max(0, max_tokens - ANTHROPIC_MIN_OUTPUT_TOKENS)
+    end
+    return (; max_tokens, thinking_budget = budget)
+end
+
+# Maps a reasoning-effort level onto the request fields, picking the mechanism the model
+# actually supports: adaptive thinking where available, extended thinking (budget_tokens)
+# otherwise. `output_config.effort` rides along on every model that supports effort,
+# including Opus 4.5 where it composes with a token budget.
+function anthropic_thinking_request(model::Model, level, base_max_tokens::Int)
+    (level === nothing || !model.reasoning) && return (; thinking = nothing, output_config = nothing, max_tokens = base_max_tokens)
+    lvl = string(level)
+    output_config = anthropic_supports_effort(model.id) ?
+        AnthropicMessages.OutputConfig(; effort = anthropic_effort_for_level(lvl, model.id)) : nothing
+    if anthropic_supports_adaptive_thinking(model.id)
+        # `display` defaults to "omitted" on the 5-generation models, which would stream
+        # empty thinking blocks; Agentif surfaces reasoning, so ask for summaries.
+        return (;
+            thinking = AnthropicMessages.ThinkingConfig(; type = "adaptive", display = "summarized"),
+            output_config,
+            max_tokens = base_max_tokens,
+        )
+    end
+    adjusted = anthropic_adjust_max_tokens_for_thinking(base_max_tokens, model.maxTokens, lvl)
+    return (;
+        thinking = AnthropicMessages.ThinkingConfig(; type = "enabled", budget_tokens = adjusted.thinking_budget),
+        output_config,
+        max_tokens = adjusted.max_tokens,
+    )
+end
+
+function anthropic_thinking_type(thinking)
+    thinking isa AnthropicMessages.ThinkingConfig && return thinking.type
+    thinking isa AbstractDict && return get(() -> get(() -> nothing, thinking, :type), thinking, "type")
+    thinking isa NamedTuple && return get(() -> nothing, thinking, :type)
+    return nothing
+end
+
+# Caller-supplied `thinking` kwargs win over the derived config; we still need to know
+# whether thinking ends up on so the sampling guard and beta header stay correct.
+function anthropic_thinking_is_enabled(thinking)
+    thinking === nothing && return false
+    type = anthropic_thinking_type(thinking)
+    type === nothing && return true
+    return String(type) != "disabled"
+end
+
+# Reconcile a caller-supplied thinking config with the model's capabilities so an
+# unsupported shape degrades to the supported mechanism instead of returning a 400.
+function anthropic_normalize_thinking(thinking, model::Model, base_max_tokens::Int)
+    thinking === nothing && return (; thinking = nothing, max_tokens = base_max_tokens)
+    type = anthropic_thinking_type(thinking)
+    type = type === nothing ? nothing : String(type)
+    if type == "disabled" && anthropic_thinking_always_on(model.id)
+        @warn "Thinking cannot be disabled on this model; ignoring thinking=disabled" model = model.id
+        return (; thinking = nothing, max_tokens = base_max_tokens)
+    elseif type == "enabled" && !anthropic_supports_extended_thinking(model.id)
+        @warn "Extended thinking (budget_tokens) is not supported on this model; falling back to adaptive thinking" model = model.id
+        return (; thinking = AnthropicMessages.ThinkingConfig(; type = "adaptive", display = "summarized"), max_tokens = base_max_tokens)
+    elseif type == "adaptive" && !anthropic_supports_adaptive_thinking(model.id)
+        @warn "Adaptive thinking is not supported on this model; falling back to extended thinking" model = model.id
+        adjusted = anthropic_adjust_max_tokens_for_thinking(base_max_tokens, model.maxTokens, "high")
+        return (; thinking = AnthropicMessages.ThinkingConfig(; type = "enabled", budget_tokens = adjusted.thinking_budget), max_tokens = adjusted.max_tokens)
+    end
+    return (; thinking, max_tokens = base_max_tokens)
 end
 
 function anthropic_message_from_agent(msg::AgentMessage, tool_name_map::Dict{String, String}, model::Model)
@@ -248,6 +428,20 @@ function anthropic_merge_usage(base::Union{Nothing, AnthropicMessages.Usage}, de
     )
 end
 
+# Anthropic pauses long-running turns with stop_reason "pause_turn". The documented
+# continuation is to re-send the same request with the paused assistant content
+# appended verbatim and *no* extra user turn; the server resumes where it left off.
+# https://platform.claude.com/docs/en/build-with-claude/handling-stop-reasons
+const ANTHROPIC_MAX_PAUSE_TURN_RESUBMITS = 3
+
+function anthropic_should_resubmit_paused(reason::Union{Nothing, String}, attempt::Int, assistant_message::AssistantMessage)
+    reason == "pause_turn" || return false
+    attempt <= ANTHROPIC_MAX_PAUSE_TURN_RESUBMITS || return false
+    # A pending client tool call outranks the pause: the caller owes us a tool result
+    # before the turn can continue.
+    return isempty(assistant_message.tool_calls)
+end
+
 function anthropic_stop_reason(reason::Union{Nothing, String}, tool_calls::Vector{AgentToolCall})
     if !isempty(tool_calls)
         return :tool_calls
@@ -263,7 +457,8 @@ function anthropic_stop_reason(reason::Union{Nothing, String}, tool_calls::Vecto
     elseif reason == "refusal"
         return :error
     elseif reason == "pause_turn"
-        # The server paused a long-running turn; auto-resubmitting to continue is future work.
+        # The stream driver resubmits paused turns (bounded); reaching here means the
+        # resubmit budget ran out, so the turn is reported as a normal stop.
         return :stop
     elseif reason == "error"
         # Synthesized by the stream driver on HTTP errors.
@@ -396,7 +591,9 @@ function anthropic_event_callback(
                 sr isa AbstractString && !isempty(sr) && (stop_reason[] = sr)
             end
         elseif parsed isa AnthropicMessages.StreamMessageStopEvent
-            if started[] && !ended[]
+            # A paused turn is resumed by the driver into this same assistant message,
+            # so hold the end event back until the continuation finishes.
+            if started[] && !ended[] && stop_reason[] != "pause_turn"
                 ended[] = true
                 f(MessageEndEvent(:assistant, assistant_message))
             end

--- a/Agentif/src/stream.jl
+++ b/Agentif/src/stream.jl
@@ -811,11 +811,25 @@ function stream(
         blocks_by_index = Dict{Int, AssistantContentBlock}()
         partial_json_by_index = Dict{Int, String}()
 
-        max_tokens = haskey(kw_nt, :max_tokens) ? kw_nt[:max_tokens] : model.maxTokens
+        base_max_tokens = haskey(kw_nt, :max_tokens) ? kw_nt[:max_tokens] : model.maxTokens
         stream_kw = haskey(kw_nt, :max_tokens) ? Base.structdiff(kw_nt, (; max_tokens = 0)) : kw_nt
         stream_kw = haskey(stream_kw, :system) ? Base.structdiff(stream_kw, (; system = nothing)) : stream_kw
+
+        # Reasoning effort uses the same kwarg surface as the openai/codex branches.
+        reasoning_effort = get(() -> nothing, stream_kw, :reasoning_effort)
+        reasoning_effort === nothing && (reasoning_effort = get(() -> nothing, stream_kw, :reasoningEffort))
+        reasoning_effort === nothing && (reasoning_effort = get(() -> nothing, stream_kw, :reasoning))
+        stream_kw = Base.structdiff(stream_kw, (; reasoning_effort = nothing, reasoningEffort = nothing, reasoning = nothing))
+
+        cache_retention = get(() -> nothing, stream_kw, :cache_retention)
+        cache_retention === nothing && (cache_retention = get(() -> nothing, stream_kw, :cacheRetention))
+        stream_kw = Base.structdiff(stream_kw, (; cache_retention = nothing, cacheRetention = nothing))
+        cache_control = anthropic_cache_control(model.baseUrl, cache_retention)
+        anthropic_apply_cache_control!(messages, cache_control)
+
         system_prompt = agent_system_prompt(agent)
-        system_value = is_oauth ? anthropic_oauth_system_blocks(system_prompt) : system_prompt
+        system_value = is_oauth ? anthropic_oauth_system_blocks(system_prompt, cache_control) :
+            anthropic_system_blocks(system_prompt, cache_control)
         if haskey(stream_kw, :tool_choice)
             tool_choice = stream_kw[:tool_choice]
             if tool_choice isa AbstractDict
@@ -840,10 +854,39 @@ function stream(
             stream_kw = merge(Base.structdiff(stream_kw, (; tool_choice = nothing)), (; tool_choice))
         end
         request_kw = merge((; tools, system = system_value), stream_kw)
+
+        # Thinking: a caller-supplied `thinking` kwarg wins, but is still clamped to what
+        # the model supports; otherwise derive the config from the reasoning-effort level.
+        max_tokens = base_max_tokens
+        if haskey(stream_kw, :thinking)
+            normalized = anthropic_normalize_thinking(stream_kw[:thinking], model, base_max_tokens)
+            max_tokens = normalized.max_tokens
+            thinking_enabled = anthropic_thinking_is_enabled(normalized.thinking)
+            request_kw = merge(request_kw, (; thinking = normalized.thinking))
+        else
+            thinking_request = anthropic_thinking_request(model, reasoning_effort, base_max_tokens)
+            thinking_enabled = thinking_request.thinking !== nothing
+            if thinking_enabled
+                max_tokens = thinking_request.max_tokens
+                request_kw = merge(request_kw, (; thinking = thinking_request.thinking))
+                if thinking_request.output_config !== nothing && !haskey(stream_kw, :output_config)
+                    request_kw = merge(request_kw, (; output_config = thinking_request.output_config))
+                end
+            end
+        end
+        # Sampling parameters: the adaptive-only models reject non-default temperature /
+        # top_p / top_k on every request; older models reject temperature only while
+        # thinking is on. Drop them rather than letting the request 400.
+        if anthropic_rejects_sampling_params(model.id)
+            request_kw = merge(request_kw, (; temperature = nothing, top_p = nothing))
+        elseif thinking_enabled
+            request_kw = merge(request_kw, (; temperature = nothing))
+        end
+
         disable_streaming = get(ENV, "AGENTIF_DISABLE_STREAMING", "") != ""
-        req = AnthropicMessages.Request(
+        anthropic_request(msgs) = AnthropicMessages.Request(
             ; model = model.id,
-            messages,
+            messages = msgs,
             max_tokens,
             stream = !disable_streaming,
             model_request_kw(model)...,
@@ -857,6 +900,11 @@ function stream(
         )
         # Add beta features for tool streaming
         beta_features = ["fine-grained-tool-streaming-2025-05-14"]
+        # Interleaved thinking only does anything when the model reasons between tool
+        # calls, and it is automatic (no header) under adaptive thinking.
+        if thinking_enabled && !isempty(agent.tools) && anthropic_needs_interleaved_thinking_beta(model.id)
+            push!(beta_features, "interleaved-thinking-2025-05-14")
+        end
 
         if is_oauth
             headers["Authorization"] = "Bearer $apikey"
@@ -868,40 +916,56 @@ function stream(
         model.headers !== nothing && merge!(headers, model.headers)
         url = joinpath(model.baseUrl, "v1", "messages")
         if disable_streaming
-            response = JSON.parse(HTTP.post(url, headers; body = JSON.json(req), merged_http_kw...).body, AnthropicMessages.Response)
-            response.id !== nothing && (assistant_message.response_id = response.id)
-            response.stop_reason !== nothing && (stop_reason[] = response.stop_reason)
+            request_messages = messages
+            total_usage = Usage()
+            attempt = 0
+            while true
+                attempt += 1
+                stop_reason[] = nothing
+                req = anthropic_request(request_messages)
+                response = JSON.parse(HTTP.post(url, headers; body = JSON.json(req), merged_http_kw...).body, AnthropicMessages.Response)
+                response.id !== nothing && (assistant_message.response_id = response.id)
+                response.stop_reason !== nothing && (stop_reason[] = response.stop_reason)
 
-            for block in response.content
-                if block isa AnthropicMessages.TextBlock
-                    append_text!(assistant_message, block.text)
-                elseif block isa AnthropicMessages.ThinkingBlock
-                    thinking = ThinkingContent(;
-                        thinking = block.thinking,
-                        thinkingSignature = block.signature,
-                    )
-                    push!(assistant_message.content, thinking)
-                elseif block isa AnthropicMessages.RedactedThinkingBlock
-                    push!(assistant_message.content, ThinkingContent(;
-                        thinking = "",
-                        thinkingSignature = block.data,
-                        redacted = true,
-                    ))
-                elseif block isa AnthropicMessages.ToolUseBlock
-                    tool_name = anthropic_internal_tool_name(tool_name_reverse_map, block.name)
-                    args = block.input isa AbstractDict ? Dict{String, Any}(block.input) : Dict{String, Any}()
-                    tool_block = ToolCallContent(;
-                        id = block.id,
-                        name = tool_name,
-                        arguments = args,
-                    )
-                    push!(assistant_message.content, tool_block)
-                    call = AgentToolCall(; call_id = block.id, name = tool_name, arguments = JSON.json(args))
-                    push!(assistant_message.tool_calls, call)
-                    findtool(agent.tools, call.name)
-                    ptc = PendingToolCall(; call_id = call.call_id, name = call.name, arguments = call.arguments)
-                    f(ToolCallRequestEvent(ptc))
+                for block in response.content
+                    if block isa AnthropicMessages.TextBlock
+                        append_text!(assistant_message, block.text)
+                    elseif block isa AnthropicMessages.ThinkingBlock
+                        thinking = ThinkingContent(;
+                            thinking = block.thinking,
+                            thinkingSignature = block.signature,
+                        )
+                        push!(assistant_message.content, thinking)
+                    elseif block isa AnthropicMessages.RedactedThinkingBlock
+                        push!(assistant_message.content, ThinkingContent(;
+                            thinking = "",
+                            thinkingSignature = block.data,
+                            redacted = true,
+                        ))
+                    elseif block isa AnthropicMessages.ToolUseBlock
+                        tool_name = anthropic_internal_tool_name(tool_name_reverse_map, block.name)
+                        args = block.input isa AbstractDict ? Dict{String, Any}(block.input) : Dict{String, Any}()
+                        tool_block = ToolCallContent(;
+                            id = block.id,
+                            name = tool_name,
+                            arguments = args,
+                        )
+                        push!(assistant_message.content, tool_block)
+                        call = AgentToolCall(; call_id = block.id, name = tool_name, arguments = JSON.json(args))
+                        push!(assistant_message.tool_calls, call)
+                        findtool(agent.tools, call.name)
+                        ptc = PendingToolCall(; call_id = call.call_id, name = call.name, arguments = call.arguments)
+                        f(ToolCallRequestEvent(ptc))
+                    end
                 end
+
+                latest_usage[] = response.usage
+                add_usage!(total_usage, anthropic_usage_from_response(response.usage))
+                anthropic_should_resubmit_paused(stop_reason[], attempt, assistant_message) || break
+                paused = anthropic_message_from_agent(assistant_message, tool_name_map, model)
+                paused === nothing && break
+                # Docs: replace the message list with [original turns..., paused assistant].
+                request_messages = vcat(messages, AnthropicMessages.Message[paused])
             end
 
             text = message_text(assistant_message)
@@ -911,67 +975,88 @@ function stream(
                 f(MessageEndEvent(:assistant, assistant_message))
             end
 
-            latest_usage[] = response.usage
-            usage = anthropic_usage_from_response(latest_usage[])
             final_stop = anthropic_stop_reason(stop_reason[], assistant_message.tool_calls)
-            return finalize_stream!(state, input, assistant_message, usage, final_stop)
+            return finalize_stream!(state, input, assistant_message, total_usage, final_stop)
         else
             events_seen = Ref(false)
             stream_failed = Ref(false)
-            sse_cb = sse_tracking_callback(
-                anthropic_event_callback(
-                    f,
-                    agent,
-                    assistant_message,
-                    started,
-                    ended,
-                    stop_reason,
-                    latest_usage,
-                    blocks_by_index,
-                    partial_json_by_index,
-                    tool_name_reverse_map,
-                    abort,
-                ),
-                events_seen,
-            )
             request_http_kw = merge(merged_http_kw, (; retry = false))
-            try
-                sse_request_with_retry(events_seen, abort; max_attempts = sse_retry_attempts(merged_http_kw)) do
-                    HTTP.post(
-                        url,
-                        headers;
-                        body = JSON.json(req),
-                        sse_callback = sse_cb,
-                        request_http_kw...,
-                    )
+            request_messages = messages
+            total_usage = Usage()
+            attempt = 0
+            while true
+                attempt += 1
+                # Fresh accumulator state per attempt (stream indices restart at 0), while
+                # `assistant_message` and the started/ended refs persist so a resumed turn
+                # keeps appending to the same message and emits one start/end pair.
+                stop_reason[] = nothing
+                latest_usage[] = nothing
+                empty!(blocks_by_index)
+                empty!(partial_json_by_index)
+                events_seen[] = false
+                sse_cb = sse_tracking_callback(
+                    anthropic_event_callback(
+                        f,
+                        agent,
+                        assistant_message,
+                        started,
+                        ended,
+                        stop_reason,
+                        latest_usage,
+                        blocks_by_index,
+                        partial_json_by_index,
+                        tool_name_reverse_map,
+                        abort,
+                    ),
+                    events_seen,
+                )
+                req = anthropic_request(request_messages)
+                try
+                    sse_request_with_retry(events_seen, abort; max_attempts = sse_retry_attempts(merged_http_kw)) do
+                        HTTP.post(
+                            url,
+                            headers;
+                            body = JSON.json(req),
+                            sse_callback = sse_cb,
+                            request_http_kw...,
+                        )
+                    end
+                catch e
+                    if e isa StopStreaming
+                    elseif e isa HTTP.StatusError
+                        if !started[]
+                            started[] = true
+                            f(MessageStartEvent(:assistant, assistant_message))
+                        end
+                        if !ended[]
+                            ended[] = true
+                            f(MessageEndEvent(:assistant, assistant_message))
+                        end
+                        error_body = String(e.response.body)
+                        error_msg = try
+                            err_json = JSON.parse(error_body)
+                            err_obj = get(() -> Dict(), err_json, "error")
+                            get(() -> "HTTP $(e.status)", err_obj, "message")
+                        catch
+                            "HTTP $(e.status): $error_body"
+                        end
+                        f(AgentErrorEvent(ErrorException(error_msg)))
+                        stop_reason[] = "error"
+                    elseif events_seen[] && sse_recoverable_connection_error(e)
+                        sse_emit_stream_interrupted!(f, assistant_message, started, ended, e)
+                        stream_failed[] = true
+                    else
+                        rethrow()
+                    end
                 end
-            catch e
-                if e isa StopStreaming
-                elseif e isa HTTP.StatusError
-                    if !started[]
-                        started[] = true
-                        f(MessageStartEvent(:assistant, assistant_message))
-                    end
-                    if !ended[]
-                        ended[] = true
-                        f(MessageEndEvent(:assistant, assistant_message))
-                    end
-                    error_body = String(e.response.body)
-                    error_msg = try
-                        err_json = JSON.parse(error_body)
-                        err_obj = get(() -> Dict(), err_json, "error")
-                        get(() -> "HTTP $(e.status)", err_obj, "message")
-                    catch
-                        "HTTP $(e.status): $error_body"
-                    end
-                    f(AgentErrorEvent(ErrorException(error_msg)))
-                    stop_reason[] = "error"
-                elseif events_seen[] && sse_recoverable_connection_error(e)
-                    sse_emit_stream_interrupted!(f, assistant_message, started, ended, e)
-                    stream_failed[] = true
-                else
-                    rethrow()
-                end
+
+                add_usage!(total_usage, anthropic_usage_from_response(latest_usage[]))
+                (stream_failed[] || isaborted(abort)) && break
+                anthropic_should_resubmit_paused(stop_reason[], attempt, assistant_message) || break
+                paused = anthropic_message_from_agent(assistant_message, tool_name_map, model)
+                paused === nothing && break
+                # Docs: replace the message list with [original turns..., paused assistant].
+                request_messages = vcat(messages, AnthropicMessages.Message[paused])
             end
 
             if started[] && !ended[]
@@ -979,11 +1064,10 @@ function stream(
                 f(MessageEndEvent(:assistant, assistant_message))
             end
 
-            usage = anthropic_usage_from_response(latest_usage[])
             final_stop = anthropic_stop_reason(stop_reason[], assistant_message.tool_calls)
             stream_failed[] && (final_stop = :error)
             isaborted(abort) && (final_stop = :aborted)
-            return finalize_stream!(state, input, assistant_message, usage, final_stop)
+            return finalize_stream!(state, input, assistant_message, total_usage, final_stop)
         end
     elseif api isa Val{Symbol("google-generative-ai")}
         apikey isa AbstractString || throw(ArgumentError("apikey must be a String for provider $(model.provider)"))

--- a/Agentif/src/stream.jl
+++ b/Agentif/src/stream.jl
@@ -858,6 +858,7 @@ function stream(
         # Thinking: a caller-supplied `thinking` kwarg wins, but is still clamped to what
         # the model supports; otherwise derive the config from the reasoning-effort level.
         max_tokens = base_max_tokens
+        thinking_enabled = false
         if haskey(stream_kw, :thinking)
             normalized = anthropic_normalize_thinking(stream_kw[:thinking], model, base_max_tokens)
             max_tokens = normalized.max_tokens
@@ -874,24 +875,61 @@ function stream(
                 end
             end
         end
-        # Sampling parameters: the adaptive-only models reject non-default temperature /
-        # top_p / top_k on every request; older models reject temperature only while
-        # thinking is on. Drop them rather than letting the request 400.
-        if anthropic_rejects_sampling_params(model.id)
-            request_kw = merge(request_kw, (; temperature = nothing, top_p = nothing))
+
+        thinking_value = get(() -> nothing, request_kw, :thinking)
+        output_config = get(() -> nothing, request_kw, :output_config)
+        if anthropic_disabled_effort_conflict(model, thinking_value, output_config)
+            @warn "Anthropic rejects xhigh/max effort with thinking disabled; enabling adaptive thinking" model = model.id
+            thinking_value = AnthropicMessages.ThinkingConfig(; type = "adaptive", display = "summarized")
+            thinking_enabled = true
+            request_kw = merge(request_kw, (; thinking = thinking_value))
+        end
+
+        # Manual extended thinking rejects forced tool selection. Keep the tools,
+        # but let Anthropic select them with its default `auto` behavior.
+        tool_choice = get(() -> nothing, request_kw, :tool_choice)
+        tool_choice_type = anthropic_tool_choice_type(tool_choice)
+        if anthropic_thinking_type(thinking_value) == "enabled" &&
+                tool_choice_type !== nothing &&
+                lowercase(String(tool_choice_type)) in ("any", "tool")
+            @warn "Anthropic extended thinking does not support forced tool choice; using auto" model = model.id
+            request_kw = merge(request_kw, (; tool_choice = nothing))
+        end
+
+        # The newest models reject all sampling controls. Older models reject
+        # temperature and top_k while thinking is enabled. Their top_p value, when
+        # supplied, must stay in the documented 0.95–1.0 interval.
+        if anthropic_rejects_sampling_params(model)
+            request_kw = merge(request_kw, (; temperature = nothing, top_p = nothing, top_k = nothing))
         elseif thinking_enabled
-            request_kw = merge(request_kw, (; temperature = nothing))
+            request_kw = merge(request_kw, (; temperature = nothing, top_k = nothing))
+            model_kw = model_request_kw(model)
+            top_p = get(() -> get(() -> nothing, model_kw, :top_p), request_kw, :top_p)
+            if top_p !== nothing && (!(top_p isa Real) || !(0.95 <= top_p <= 1.0))
+                @warn "Anthropic thinking requires top_p between 0.95 and 1.0; omitting top_p" requested = top_p
+                request_kw = merge(request_kw, (; top_p = nothing))
+            end
         end
 
         disable_streaming = get(ENV, "AGENTIF_DISABLE_STREAMING", "") != ""
-        anthropic_request(msgs) = AnthropicMessages.Request(
+        typed_request = AnthropicMessages.Request(
             ; model = model.id,
-            messages = msgs,
+            messages,
             max_tokens,
             stream = !disable_streaming,
             model_request_kw(model)...,
             request_kw...,
         )
+        # A raw request template is required for `pause_turn`. Server-tool blocks
+        # are intentionally unknown to the typed public content model, but Anthropic
+        # requires every response field to be sent back unchanged.
+        request_template = JSON.parse(JSON.json(typed_request))
+        original_request_messages = deepcopy(request_template["messages"])
+        function anthropic_request(msgs)
+            req = deepcopy(request_template)
+            req["messages"] = deepcopy(msgs)
+            return req
+        end
         headers = Dict(
             "anthropic-version" => "2023-06-01",
             "Content-Type" => "application/json",
@@ -902,7 +940,8 @@ function stream(
         beta_features = ["fine-grained-tool-streaming-2025-05-14"]
         # Interleaved thinking only does anything when the model reasons between tool
         # calls, and it is automatic (no header) under adaptive thinking.
-        if thinking_enabled && !isempty(agent.tools) && anthropic_needs_interleaved_thinking_beta(model.id)
+        if thinking_enabled && !isempty(agent.tools) &&
+                anthropic_needs_interleaved_thinking_beta(model, thinking_value)
             push!(beta_features, "interleaved-thinking-2025-05-14")
         end
 
@@ -916,14 +955,21 @@ function stream(
         model.headers !== nothing && merge!(headers, model.headers)
         url = joinpath(model.baseUrl, "v1", "messages")
         if disable_streaming
-            request_messages = messages
+            request_messages = original_request_messages
             total_usage = Usage()
             attempt = 0
             while true
                 attempt += 1
                 stop_reason[] = nothing
                 req = anthropic_request(request_messages)
-                response = JSON.parse(HTTP.post(url, headers; body = JSON.json(req), merged_http_kw...).body, AnthropicMessages.Response)
+                response_body = String(HTTP.post(
+                    url,
+                    headers;
+                    body = JSON.json(req),
+                    merged_http_kw...,
+                ).body)
+                wire_response = JSON.parse(response_body)
+                response = JSON.parse(response_body, AnthropicMessages.Response)
                 response.id !== nothing && (assistant_message.response_id = response.id)
                 response.stop_reason !== nothing && (stop_reason[] = response.stop_reason)
 
@@ -962,10 +1008,20 @@ function stream(
                 latest_usage[] = response.usage
                 add_usage!(total_usage, anthropic_usage_from_response(response.usage))
                 anthropic_should_resubmit_paused(stop_reason[], attempt, assistant_message) || break
-                paused = anthropic_message_from_agent(assistant_message, tool_name_map, model)
-                paused === nothing && break
-                # Docs: replace the message list with [original turns..., paused assistant].
-                request_messages = vcat(messages, AnthropicMessages.Message[paused])
+                wire_content = get(() -> nothing, wire_response, "content")
+                if !(wire_content isa AbstractVector) || isempty(wire_content)
+                    @warn "Cannot safely replay an Anthropic pause_turn response without raw content"
+                    break
+                end
+                # Docs: on every continuation, replace the message list with the
+                # original turns plus the current paused response.
+                request_messages = vcat(
+                    deepcopy(original_request_messages),
+                    Any[Dict{String, Any}(
+                        "role" => "assistant",
+                        "content" => deepcopy(wire_content),
+                    )],
+                )
             end
 
             text = message_text(assistant_message)
@@ -981,7 +1037,10 @@ function stream(
             events_seen = Ref(false)
             stream_failed = Ref(false)
             request_http_kw = merge(merged_http_kw, (; retry = false))
-            request_messages = messages
+            request_messages = original_request_messages
+            wire_blocks_by_index = Dict{Int, Dict{String, Any}}()
+            wire_partial_json_by_index = Dict{Int, String}()
+            wire_replay_safe = Ref(true)
             total_usage = Usage()
             attempt = 0
             while true
@@ -993,6 +1052,9 @@ function stream(
                 latest_usage[] = nothing
                 empty!(blocks_by_index)
                 empty!(partial_json_by_index)
+                empty!(wire_blocks_by_index)
+                empty!(wire_partial_json_by_index)
+                wire_replay_safe[] = true
                 events_seen[] = false
                 sse_cb = sse_tracking_callback(
                     anthropic_event_callback(
@@ -1005,6 +1067,9 @@ function stream(
                         latest_usage,
                         blocks_by_index,
                         partial_json_by_index,
+                        wire_blocks_by_index,
+                        wire_partial_json_by_index,
+                        wire_replay_safe,
                         tool_name_reverse_map,
                         abort,
                     ),
@@ -1053,10 +1118,23 @@ function stream(
                 add_usage!(total_usage, anthropic_usage_from_response(latest_usage[]))
                 (stream_failed[] || isaborted(abort)) && break
                 anthropic_should_resubmit_paused(stop_reason[], attempt, assistant_message) || break
-                paused = anthropic_message_from_agent(assistant_message, tool_name_map, model)
-                paused === nothing && break
-                # Docs: replace the message list with [original turns..., paused assistant].
-                request_messages = vcat(messages, AnthropicMessages.Message[paused])
+                attempt_wire_content = [
+                    deepcopy(wire_blocks_by_index[index])
+                    for index in sort!(collect(keys(wire_blocks_by_index)))
+                ]
+                if !wire_replay_safe[] || isempty(attempt_wire_content)
+                    @warn "Cannot safely replay an Anthropic pause_turn stream with incomplete raw content"
+                    break
+                end
+                # Docs: on every continuation, replace the message list with the
+                # original turns plus the current paused response.
+                request_messages = vcat(
+                    deepcopy(original_request_messages),
+                    Any[Dict{String, Any}(
+                        "role" => "assistant",
+                        "content" => attempt_wire_content,
+                    )],
+                )
             end
 
             if started[] && !ended[]

--- a/Agentif/test/runtests.jl
+++ b/Agentif/test/runtests.jl
@@ -1554,6 +1554,479 @@ end
     end
 end
 
+function anthropic_test_model(; id = "claude-opus-5", reasoning = true, maxTokens = 32000, baseUrl = "http://127.0.0.1:1", kw = (;))
+    return Model(
+        id = id,
+        name = id,
+        api = "anthropic-messages",
+        provider = "anthropic",
+        baseUrl = baseUrl,
+        reasoning = reasoning,
+        input = ["text"],
+        cost = Dict("input" => 0.0, "output" => 0.0, "cacheRead" => 0.0, "cacheWrite" => 0.0),
+        contextWindow = 200000,
+        maxTokens = maxTokens,
+        kw = kw,
+    )
+end
+
+@testset "anthropic per-model thinking capabilities" begin
+    # Adaptive thinking: 4.6 family and newer
+    @test Agentif.anthropic_supports_adaptive_thinking("claude-opus-4-6")
+    @test Agentif.anthropic_supports_adaptive_thinking("claude-sonnet-4-6")
+    @test Agentif.anthropic_supports_adaptive_thinking("claude-opus-5")
+    @test Agentif.anthropic_supports_adaptive_thinking("claude-sonnet-5")
+    @test Agentif.anthropic_supports_adaptive_thinking("claude-fable-5")
+    @test !Agentif.anthropic_supports_adaptive_thinking("claude-opus-4-5")
+    @test !Agentif.anthropic_supports_adaptive_thinking("claude-haiku-4-5-20251001")
+
+    # Extended thinking (budget_tokens): everything except the adaptive-only models
+    @test Agentif.anthropic_supports_extended_thinking("claude-haiku-4-5-20251001")
+    @test Agentif.anthropic_supports_extended_thinking("claude-sonnet-4-5")
+    @test Agentif.anthropic_supports_extended_thinking("claude-opus-4-6")   # deprecated but accepted
+    @test !Agentif.anthropic_supports_extended_thinking("claude-opus-4-7")
+    @test !Agentif.anthropic_supports_extended_thinking("claude-opus-5")
+    @test !Agentif.anthropic_supports_extended_thinking("claude-sonnet-5")
+    @test !Agentif.anthropic_supports_extended_thinking("claude-fable-5")
+
+    # Thinking cannot be turned off on the always-thinking models
+    @test Agentif.anthropic_thinking_always_on("claude-fable-5")
+    @test Agentif.anthropic_thinking_always_on("claude-mythos-5")
+    @test !Agentif.anthropic_thinking_always_on("claude-opus-5")
+
+    # effort: 4.6 family and newer, plus Opus 4.5 (the one extended-only model with effort)
+    @test Agentif.anthropic_supports_effort("claude-opus-4-5")
+    @test Agentif.anthropic_supports_effort("claude-sonnet-4-6")
+    @test !Agentif.anthropic_supports_effort("claude-haiku-4-5-20251001")
+    @test !Agentif.anthropic_supports_effort("claude-sonnet-4-5")
+    # max: 4.6 family and newer; xhigh: Opus 4.7+ / Sonnet 5 / Fable 5 only
+    @test Agentif.anthropic_supports_max_effort("claude-sonnet-4-6")
+    @test !Agentif.anthropic_supports_max_effort("claude-opus-4-5")
+    @test Agentif.anthropic_supports_xhigh_effort("claude-opus-4-7")
+    @test Agentif.anthropic_supports_xhigh_effort("claude-sonnet-5")
+    @test !Agentif.anthropic_supports_xhigh_effort("claude-opus-4-6")
+    @test !Agentif.anthropic_supports_xhigh_effort("claude-sonnet-4-6")
+
+    # Sampling params are rejected outright on the adaptive-only models
+    @test Agentif.anthropic_rejects_sampling_params("claude-opus-5")
+    @test Agentif.anthropic_rejects_sampling_params("claude-sonnet-5")
+    @test !Agentif.anthropic_rejects_sampling_params("claude-opus-4-6")
+    @test !Agentif.anthropic_rejects_sampling_params("claude-haiku-4-5-20251001")
+
+    # Interleaved thinking: automatic under adaptive, header under extended, absent on Haiku
+    @test !Agentif.anthropic_needs_interleaved_thinking_beta("claude-opus-5")
+    @test !Agentif.anthropic_needs_interleaved_thinking_beta("claude-haiku-4-5-20251001")
+    @test Agentif.anthropic_needs_interleaved_thinking_beta("claude-sonnet-4-5")
+end
+
+@testset "anthropic thinking config, effort mapping, and budget clamping" begin
+    # Effort levels step down to the highest rung the model actually supports
+    @test Agentif.anthropic_effort_for_level("minimal", "claude-opus-5") == "low"
+    @test Agentif.anthropic_effort_for_level("low", "claude-opus-5") == "low"
+    @test Agentif.anthropic_effort_for_level("medium", "claude-opus-5") == "medium"
+    @test Agentif.anthropic_effort_for_level("high", "claude-opus-5") == "high"
+    @test Agentif.anthropic_effort_for_level("max", "claude-sonnet-5") == "max"
+    @test Agentif.anthropic_effort_for_level("xhigh", "claude-opus-5") == "xhigh"
+    @test Agentif.anthropic_effort_for_level("xhigh", "claude-opus-4-7") == "xhigh"
+    # 4.6 family has max but not xhigh
+    @test Agentif.anthropic_effort_for_level("xhigh", "claude-opus-4-6") == "max"
+    @test Agentif.anthropic_effort_for_level("xhigh", "claude-sonnet-4-6") == "max"
+    # Opus 4.5 has neither xhigh nor max
+    @test Agentif.anthropic_effort_for_level("xhigh", "claude-opus-4-5") == "high"
+    @test Agentif.anthropic_effort_for_level("max", "claude-opus-4-5") == "high"
+    @test Agentif.anthropic_effort_for_level("bogus", "claude-opus-5") == "high"
+
+    # budget_tokens must stay strictly below max_tokens (pi's adjustMaxTokensForThinking)
+    grown = Agentif.anthropic_adjust_max_tokens_for_thinking(4096, 64000, "medium")
+    @test grown.max_tokens == 12288
+    @test grown.thinking_budget == 8192
+    @test grown.thinking_budget < grown.max_tokens
+    clamped = Agentif.anthropic_adjust_max_tokens_for_thinking(1000, 8192, "high")
+    @test clamped.max_tokens == 8192
+    @test clamped.thinking_budget == 8192 - 1024
+    @test clamped.thinking_budget < clamped.max_tokens
+    @test Agentif.anthropic_adjust_max_tokens_for_thinking(4096, 64000, "xhigh") ==
+        Agentif.anthropic_adjust_max_tokens_for_thinking(4096, 64000, "high")
+
+    # Adaptive path: {type: adaptive} + output_config.effort, max_tokens untouched
+    adaptive_model = anthropic_test_model()
+    cfg = Agentif.anthropic_thinking_request(adaptive_model, "xhigh", 8192)
+    @test cfg.thinking.type == "adaptive"
+    @test cfg.thinking.budget_tokens === nothing
+    @test cfg.thinking.display == "summarized"
+    @test cfg.output_config.effort == "xhigh"
+    @test cfg.max_tokens == 8192
+
+    # Extended path: {type: enabled, budget_tokens} and a grown max_tokens, no effort
+    # (Haiku 4.5 has a 64k output ceiling and does not support the effort parameter)
+    budget_model = anthropic_test_model(id = "claude-haiku-4-5-20251001", maxTokens = 64000)
+    bcfg = Agentif.anthropic_thinking_request(budget_model, "medium", 4096)
+    @test bcfg.thinking.type == "enabled"
+    @test bcfg.thinking.budget_tokens == 8192
+    @test bcfg.thinking.display === nothing
+    @test bcfg.output_config === nothing
+    @test bcfg.max_tokens == 12288
+    @test bcfg.thinking.budget_tokens < bcfg.max_tokens
+
+    # Opus 4.5 is extended-thinking-only but supports effort: both ride along
+    both_model = anthropic_test_model(id = "claude-opus-4-5", maxTokens = 64000)
+    both = Agentif.anthropic_thinking_request(both_model, "high", 8192)
+    @test both.thinking.type == "enabled"
+    @test both.thinking.budget_tokens == 16384
+    @test both.output_config.effort == "high"
+
+    # No effort requested, or a non-reasoning model: no thinking config at all
+    @test Agentif.anthropic_thinking_request(adaptive_model, nothing, 8192).thinking === nothing
+    @test Agentif.anthropic_thinking_request(anthropic_test_model(reasoning = false), "high", 8192).thinking === nothing
+
+    @test Agentif.anthropic_thinking_is_enabled(nothing) == false
+    @test Agentif.anthropic_thinking_is_enabled(Dict("type" => "disabled")) == false
+    @test Agentif.anthropic_thinking_is_enabled(Dict("type" => "adaptive")) == true
+    @test Agentif.anthropic_thinking_is_enabled((; type = "enabled")) == true
+    @test Agentif.anthropic_thinking_is_enabled(LLMProviders.AnthropicMessages.ThinkingConfig(; type = "disabled")) == false
+end
+
+@testset "anthropic clamps unsupported thinking configs to model capability" begin
+    # Extended thinking on an adaptive-only model would 400: fall back to adaptive
+    opus5 = anthropic_test_model(id = "claude-opus-5", maxTokens = 128000)
+    fallback = @test_logs (:warn,) match_mode = :any Agentif.anthropic_normalize_thinking(
+        Dict("type" => "enabled", "budget_tokens" => 8192), opus5, 32000,
+    )
+    @test fallback.thinking.type == "adaptive"
+    @test fallback.thinking.budget_tokens === nothing
+    @test fallback.max_tokens == 32000
+
+    # Adaptive on an extended-only model: fall back to a token budget below max_tokens
+    haiku = anthropic_test_model(id = "claude-haiku-4-5-20251001", maxTokens = 64000)
+    downgraded = @test_logs (:warn,) match_mode = :any Agentif.anthropic_normalize_thinking(
+        Dict("type" => "adaptive"), haiku, 4096,
+    )
+    @test downgraded.thinking.type == "enabled"
+    @test downgraded.thinking.budget_tokens == 16384
+    @test downgraded.thinking.budget_tokens < downgraded.max_tokens
+
+    # Thinking cannot be disabled on Fable 5: drop the field instead of sending a 400
+    fable = anthropic_test_model(id = "claude-fable-5", maxTokens = 128000)
+    dropped = @test_logs (:warn,) match_mode = :any Agentif.anthropic_normalize_thinking(
+        Dict("type" => "disabled"), fable, 32000,
+    )
+    @test dropped.thinking === nothing
+
+    # Supported configs pass through untouched
+    supported = Agentif.anthropic_normalize_thinking(Dict("type" => "adaptive"), opus5, 32000)
+    @test supported.thinking["type"] == "adaptive"
+    @test Agentif.anthropic_normalize_thinking(Dict("type" => "disabled"), opus5, 32000).thinking["type"] == "disabled"
+    @test Agentif.anthropic_normalize_thinking(Dict("type" => "enabled", "budget_tokens" => 2048), haiku, 32000).thinking["budget_tokens"] == 2048
+    @test Agentif.anthropic_normalize_thinking(nothing, opus5, 32000).thinking === nothing
+end
+
+@testset "anthropic cache_control placement" begin
+    A = LLMProviders.AnthropicMessages
+    ephemeral = A.CacheControl(; type = "ephemeral")
+
+    # retention resolution: none disables breakpoints, long only gets 1h on Anthropic's host
+    @test Agentif.anthropic_cache_control("https://api.anthropic.com", "none") === nothing
+    @test Agentif.anthropic_cache_control("https://api.anthropic.com", "short").ttl === nothing
+    @test Agentif.anthropic_cache_control("https://api.anthropic.com", "long").ttl == "1h"
+    @test Agentif.anthropic_cache_control("http://127.0.0.1:8080", "long").ttl === nothing
+
+    # a string user turn is promoted to a block array carrying the breakpoint
+    msgs = A.Message[A.Message(; role = "user", content = "hello")]
+    Agentif.anthropic_apply_cache_control!(msgs, ephemeral)
+    @test msgs[end].content isa AbstractVector
+    @test msgs[end].content[end].cache_control !== nothing
+
+    # the breakpoint lands on the last block of the last user message
+    blocks = A.ContentBlock[A.TextBlock(; text = "a"), A.TextBlock(; text = "b")]
+    msgs2 = A.Message[A.Message(; role = "user", content = blocks)]
+    Agentif.anthropic_apply_cache_control!(msgs2, ephemeral)
+    @test msgs2[end].content[1].cache_control === nothing
+    @test msgs2[end].content[2].cache_control !== nothing
+
+    # tool results are cacheable blocks too
+    msgs3 = A.Message[A.Message(; role = "user", content = A.ContentBlock[A.ToolResultBlock(; tool_use_id = "t1", content = "ok")])]
+    Agentif.anthropic_apply_cache_control!(msgs3, ephemeral)
+    @test msgs3[end].content[end].cache_control !== nothing
+
+    # trailing assistant turns and retention=none are left untouched
+    msgs4 = A.Message[A.Message(; role = "assistant", content = A.ContentBlock[A.TextBlock(; text = "a")])]
+    Agentif.anthropic_apply_cache_control!(msgs4, ephemeral)
+    @test msgs4[end].content[end].cache_control === nothing
+    msgs5 = A.Message[A.Message(; role = "user", content = A.ContentBlock[A.TextBlock(; text = "a")])]
+    Agentif.anthropic_apply_cache_control!(msgs5, nothing)
+    @test msgs5[end].content[end].cache_control === nothing
+
+    # system blocks: plain API key gets one breakpoint, the OAuth spoof keeps its two
+    system_blocks = Agentif.anthropic_system_blocks("You are helpful.", ephemeral)
+    @test length(system_blocks) == 1
+    @test system_blocks[1].cache_control !== nothing
+    @test Agentif.anthropic_system_blocks("", ephemeral) === nothing
+    @test Agentif.anthropic_system_blocks("You are helpful.", nothing)[1].cache_control === nothing
+    oauth_blocks = Agentif.anthropic_oauth_system_blocks("You are helpful.", ephemeral)
+    @test length(oauth_blocks) == 2
+    @test all(b -> b.cache_control !== nothing, oauth_blocks)
+    @test all(b -> b.cache_control === nothing, Agentif.anthropic_oauth_system_blocks("You are helpful.", nothing))
+end
+
+@testset "anthropic request shaping: thinking, effort, cache_control, temperature guard" begin
+    bodies = Vector{Any}()
+
+    server = HTTP.serve!("127.0.0.1", 0) do req
+        push!(bodies, JSON.parse(String(req.body)))
+        sse = join([
+            "data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_s\",\"role\":\"assistant\",\"content\":[],\"usage\":{\"input_tokens\":5,\"output_tokens\":1}}}",
+            "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}",
+            "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"ok\"}}",
+            "data: {\"type\":\"content_block_stop\",\"index\":0}",
+            "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":2}}",
+            "data: {\"type\":\"message_stop\"}",
+        ], "\n\n") * "\n\n"
+        return HTTP.Response(200, ["Content-Type" => "text/event-stream"], sse)
+    end
+
+    try
+        port = HTTP.Sockets.getsockname(server.listener.server)[2]
+        base_url = "http://127.0.0.1:$port"
+        # temperature comes from model.kw; the sampling guard has to strip it
+        model = anthropic_test_model(baseUrl = base_url, maxTokens = 128000, kw = (; temperature = 0.7))
+        agent = Agent(id = "anthropic-shape-test", prompt = "You are helpful.", model = model, apikey = "test-key", tools = AgentTool[])
+
+        stream(ev -> ev, agent, AgentState(), "Say hello", Abort(); reasoning_effort = "xhigh")
+        body = bodies[end]
+        @test body["thinking"]["type"] == "adaptive"
+        @test !haskey(body["thinking"], "budget_tokens")
+        @test body["thinking"]["display"] == "summarized"
+        @test body["output_config"]["effort"] == "xhigh"
+        # Claude Opus 5 rejects non-default sampling params outright
+        @test !haskey(body, "temperature")
+        # the effort kwarg is consumed, never forwarded as an unknown request field
+        @test !haskey(body, "reasoning_effort")
+        @test body["max_tokens"] == 128000
+        @test body["system"][1]["cache_control"]["type"] == "ephemeral"
+        @test !haskey(body["system"][1]["cache_control"], "ttl")
+        last_msg = body["messages"][end]
+        @test last_msg["role"] == "user"
+        @test last_msg["content"][end]["cache_control"]["type"] == "ephemeral"
+
+        # ...even with no thinking at all, since the restriction is unconditional there
+        stream(ev -> ev, agent, AgentState(), "Say hello", Abort())
+        plain = bodies[end]
+        @test !haskey(plain, "thinking")
+        @test !haskey(plain, "output_config")
+        @test !haskey(plain, "temperature")
+
+        # On older models temperature is only dropped while thinking is on
+        legacy_agent = Agent(
+            id = "anthropic-legacy-test", prompt = "You are helpful.",
+            model = anthropic_test_model(id = "claude-opus-4-6", baseUrl = base_url, kw = (; temperature = 0.7)),
+            apikey = "test-key", tools = AgentTool[],
+        )
+        stream(ev -> ev, legacy_agent, AgentState(), "Say hello", Abort())
+        @test bodies[end]["temperature"] == 0.7
+        stream(ev -> ev, legacy_agent, AgentState(), "Say hello", Abort(); reasoning_effort = "xhigh")
+        legacy_thinking = bodies[end]
+        @test !haskey(legacy_thinking, "temperature")
+        @test legacy_thinking["thinking"]["type"] == "adaptive"
+        # Opus 4.6 has max but not xhigh
+        @test legacy_thinking["output_config"]["effort"] == "max"
+
+        # extended-thinking models get {type: enabled, budget_tokens} and a grown max_tokens
+        budget_agent = Agent(
+            id = "anthropic-budget-test", prompt = "You are helpful.",
+            model = anthropic_test_model(id = "claude-haiku-4-5-20251001", maxTokens = 64000, baseUrl = base_url),
+            apikey = "test-key", tools = AgentTool[],
+        )
+        stream(ev -> ev, budget_agent, AgentState(), "Say hello", Abort(); reasoning_effort = "medium", max_tokens = 4096)
+        budget_body = bodies[end]
+        @test budget_body["thinking"]["type"] == "enabled"
+        @test budget_body["thinking"]["budget_tokens"] == 8192
+        @test budget_body["thinking"]["budget_tokens"] < budget_body["max_tokens"]
+        @test budget_body["max_tokens"] == 12288
+        # Haiku 4.5 does not support the effort parameter
+        @test !haskey(budget_body, "output_config")
+
+        # cache_retention="none" drops every breakpoint
+        stream(ev -> ev, agent, AgentState(), "Say hello", Abort(); cache_retention = "none")
+        uncached = bodies[end]
+        @test !haskey(uncached["system"][1], "cache_control")
+        @test !haskey(uncached, "cache_retention")
+        uncached_last = uncached["messages"][end]
+        @test uncached_last["content"] == "Say hello" || !haskey(uncached_last["content"][end], "cache_control")
+
+        # an explicit thinking kwarg wins over the derived config
+        stream(ev -> ev, legacy_agent, AgentState(), "Say hello", Abort(); reasoning_effort = "high", thinking = Dict("type" => "disabled"))
+        explicit = bodies[end]
+        @test explicit["thinking"]["type"] == "disabled"
+        @test !haskey(explicit, "output_config")
+        # thinking disabled => the temperature guard stays out of the way
+        @test explicit["temperature"] == 0.7
+
+        # ...but an unsupported explicit config is clamped instead of 400ing
+        stream(ev -> ev, agent, AgentState(), "Say hello", Abort(); thinking = Dict("type" => "enabled", "budget_tokens" => 4096))
+        clamped = bodies[end]
+        @test clamped["thinking"]["type"] == "adaptive"
+        @test !haskey(clamped["thinking"], "budget_tokens")
+
+        # OAuth keeps its two system breakpoints and still caches the conversation tail
+        oauth_agent = Agent(
+            id = "anthropic-oauth-test", prompt = "You are helpful.",
+            model = anthropic_test_model(baseUrl = base_url), apikey = "sk-ant-oat01-test", tools = AgentTool[],
+        )
+        stream(ev -> ev, oauth_agent, AgentState(), "Say hello", Abort())
+        oauth_body = bodies[end]
+        @test length(oauth_body["system"]) == 2
+        @test all(b -> b["cache_control"]["type"] == "ephemeral", oauth_body["system"])
+        @test oauth_body["messages"][end]["content"][end]["cache_control"]["type"] == "ephemeral"
+        # Anthropic allows at most four breakpoints per request
+        @test length(oauth_body["system"]) + 1 <= 4
+    finally
+        close(server)
+    end
+end
+
+@testset "anthropic stream captures thinking blocks with signatures" begin
+    seen_events = Agentif.AgentEvent[]
+    bodies = Vector{Any}()
+
+    server = HTTP.serve!("127.0.0.1", 0) do req
+        push!(bodies, JSON.parse(String(req.body)))
+        sse = join([
+            "data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_t\",\"role\":\"assistant\",\"content\":[],\"usage\":{\"input_tokens\":11,\"output_tokens\":1}}}",
+            "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"thinking\",\"thinking\":\"\"}}",
+            "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"step one \"}}",
+            "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"step two\"}}",
+            "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"signature_delta\",\"signature\":\"sig-\"}}",
+            "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"signature_delta\",\"signature\":\"abc\"}}",
+            "data: {\"type\":\"content_block_stop\",\"index\":0}",
+            "data: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}",
+            "data: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"text_delta\",\"text\":\"Answer\"}}",
+            "data: {\"type\":\"content_block_stop\",\"index\":1}",
+            "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":13}}",
+            "data: {\"type\":\"message_stop\"}",
+        ], "\n\n") * "\n\n"
+        return HTTP.Response(200, ["Content-Type" => "text/event-stream"], sse)
+    end
+
+    try
+        port = HTTP.Sockets.getsockname(server.listener.server)[2]
+        model = anthropic_test_model(baseUrl = "http://127.0.0.1:$port")
+        agent = Agent(id = "anthropic-thinking-test", prompt = "You are helpful.", model = model, apikey = "test-key", tools = AgentTool[])
+
+        result = stream(ev -> (push!(seen_events, ev); ev), agent, AgentState(), "Think it through", Abort(); reasoning_effort = "high")
+        @test result.most_recent_stop_reason == :stop
+        @test !any(ev -> ev isa Agentif.AgentErrorEvent, seen_events)
+        @test bodies[end]["thinking"]["type"] == "adaptive"
+        @test bodies[end]["output_config"]["effort"] == "high"
+
+        assistant = result.messages[end]
+        thinking_blocks = [b for b in assistant.content if b isa Agentif.ThinkingContent]
+        @test length(thinking_blocks) == 1
+        @test thinking_blocks[1].thinking == "step one step two"
+        @test thinking_blocks[1].thinkingSignature == "sig-abc"
+        @test !thinking_blocks[1].redacted
+        @test Agentif.message_thinking(assistant) == "step one step two"
+        @test Agentif.message_text(assistant) == "Answer"
+        @test any(ev -> ev isa Agentif.MessageUpdateEvent && ev.kind == :reasoning, seen_events)
+
+        # signed thinking replays as a thinking block rather than being downgraded to text
+        replayed = Agentif.anthropic_message_from_agent(assistant, Dict{String, String}(), model)
+        lowered = JSON.parse(JSON.json(replayed))
+        @test lowered["content"][1]["type"] == "thinking"
+        @test lowered["content"][1]["signature"] == "sig-abc"
+    finally
+        close(server)
+    end
+end
+
+@testset "anthropic stream resubmits paused turns" begin
+    seen_events = Agentif.AgentEvent[]
+    bodies = Vector{Any}()
+
+    function pause_sse(text, stop_reason, id)
+        return join([
+            "data: {\"type\":\"message_start\",\"message\":{\"id\":\"$id\",\"role\":\"assistant\",\"content\":[],\"usage\":{\"input_tokens\":100,\"output_tokens\":1}}}",
+            "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}",
+            "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"$text\"}}",
+            "data: {\"type\":\"content_block_stop\",\"index\":0}",
+            "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"$stop_reason\"},\"usage\":{\"output_tokens\":5}}",
+            "data: {\"type\":\"message_stop\"}",
+        ], "\n\n") * "\n\n"
+    end
+
+    server = HTTP.serve!("127.0.0.1", 0) do req
+        push!(bodies, JSON.parse(String(req.body)))
+        sse = length(bodies) == 1 ? pause_sse("Part one ", "pause_turn", "msg_p1") : pause_sse("Part two", "end_turn", "msg_p2")
+        return HTTP.Response(200, ["Content-Type" => "text/event-stream"], sse)
+    end
+
+    try
+        port = HTTP.Sockets.getsockname(server.listener.server)[2]
+        model = anthropic_test_model(baseUrl = "http://127.0.0.1:$port")
+        agent = Agent(id = "anthropic-pause-test", prompt = "You are helpful.", model = model, apikey = "test-key", tools = AgentTool[])
+
+        result = stream(ev -> (push!(seen_events, ev); ev), agent, AgentState(), "Do the long thing", Abort())
+        @test result.most_recent_stop_reason == :stop
+        @test !any(ev -> ev isa Agentif.AgentErrorEvent, seen_events)
+        # exactly one resubmit
+        @test length(bodies) == 2
+
+        assistant = result.messages[end]
+        @test Agentif.message_text(assistant) == "Part one Part two"
+        # the paused turn is one logical assistant message: one start, one end
+        @test count(ev -> ev isa Agentif.MessageStartEvent, seen_events) == 1
+        @test count(ev -> ev isa Agentif.MessageEndEvent, seen_events) == 1
+        @test findlast(ev -> ev isa Agentif.MessageEndEvent, seen_events) >
+            findlast(ev -> ev isa Agentif.MessageUpdateEvent, seen_events)
+
+        # the continuation replays the paused assistant content verbatim, with no extra user turn
+        @test length(bodies[2]["messages"]) == length(bodies[1]["messages"]) + 1
+        resumed = bodies[2]["messages"][end]
+        @test resumed["role"] == "assistant"
+        @test resumed["content"][1]["type"] == "text"
+        @test resumed["content"][1]["text"] == "Part one "
+        @test bodies[2]["messages"][end - 1]["role"] == "user"
+
+        # usage is summed across both requests
+        @test result.usage.input == 200
+        @test result.usage.output == 10
+    finally
+        close(server)
+    end
+end
+
+@testset "anthropic pause_turn resubmits are bounded" begin
+    bodies = Vector{Any}()
+
+    server = HTTP.serve!("127.0.0.1", 0) do req
+        push!(bodies, JSON.parse(String(req.body)))
+        sse = join([
+            "data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_b\",\"role\":\"assistant\",\"content\":[],\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}",
+            "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}",
+            "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"x\"}}",
+            "data: {\"type\":\"content_block_stop\",\"index\":0}",
+            "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"pause_turn\"},\"usage\":{\"output_tokens\":1}}",
+            "data: {\"type\":\"message_stop\"}",
+        ], "\n\n") * "\n\n"
+        return HTTP.Response(200, ["Content-Type" => "text/event-stream"], sse)
+    end
+
+    try
+        port = HTTP.Sockets.getsockname(server.listener.server)[2]
+        model = anthropic_test_model(baseUrl = "http://127.0.0.1:$port")
+        agent = Agent(id = "anthropic-pause-bound-test", prompt = "You are helpful.", model = model, apikey = "test-key", tools = AgentTool[])
+
+        seen_events = Agentif.AgentEvent[]
+        result = stream(ev -> (push!(seen_events, ev); ev), agent, AgentState(), "Loop forever", Abort())
+        # one original request plus ANTHROPIC_MAX_PAUSE_TURN_RESUBMITS continuations
+        @test length(bodies) == 1 + Agentif.ANTHROPIC_MAX_PAUSE_TURN_RESUBMITS
+        @test result.most_recent_stop_reason == :stop
+        @test Agentif.message_text(result.messages[end]) == "xxxx"
+        @test count(ev -> ev isa Agentif.MessageEndEvent, seen_events) == 1
+    finally
+        close(server)
+    end
+end
+
 @testset "openai_codex stream keeps incomplete as length" begin
     seen_events = Agentif.AgentEvent[]
 

--- a/Agentif/test/runtests.jl
+++ b/Agentif/test/runtests.jl
@@ -1554,7 +1554,15 @@ end
     end
 end
 
-function anthropic_test_model(; id = "claude-opus-5", reasoning = true, maxTokens = 32000, baseUrl = "http://127.0.0.1:1", kw = (;))
+function anthropic_test_model(;
+        id = "claude-opus-5",
+        reasoning = true,
+        maxTokens = 32000,
+        baseUrl = "http://127.0.0.1:1",
+        compat = nothing,
+        thinkingLevelMap = nothing,
+        kw = (;),
+    )
     return Model(
         id = id,
         name = id,
@@ -1566,17 +1574,23 @@ function anthropic_test_model(; id = "claude-opus-5", reasoning = true, maxToken
         cost = Dict("input" => 0.0, "output" => 0.0, "cacheRead" => 0.0, "cacheWrite" => 0.0),
         contextWindow = 200000,
         maxTokens = maxTokens,
+        compat = compat,
+        thinkingLevelMap = thinkingLevelMap,
         kw = kw,
     )
 end
 
 @testset "anthropic per-model thinking capabilities" begin
+    @test Agentif.anthropic_stop_reason(
+        "model_context_window_exceeded", Agentif.AgentToolCall[]) == :length
+
     # Adaptive thinking: 4.6 family and newer
     @test Agentif.anthropic_supports_adaptive_thinking("claude-opus-4-6")
     @test Agentif.anthropic_supports_adaptive_thinking("claude-sonnet-4-6")
     @test Agentif.anthropic_supports_adaptive_thinking("claude-opus-5")
     @test Agentif.anthropic_supports_adaptive_thinking("claude-sonnet-5")
     @test Agentif.anthropic_supports_adaptive_thinking("claude-fable-5")
+    @test Agentif.anthropic_supports_adaptive_thinking("claude-mythos-preview")
     @test !Agentif.anthropic_supports_adaptive_thinking("claude-opus-4-5")
     @test !Agentif.anthropic_supports_adaptive_thinking("claude-haiku-4-5-20251001")
 
@@ -1588,10 +1602,12 @@ end
     @test !Agentif.anthropic_supports_extended_thinking("claude-opus-5")
     @test !Agentif.anthropic_supports_extended_thinking("claude-sonnet-5")
     @test !Agentif.anthropic_supports_extended_thinking("claude-fable-5")
+    @test Agentif.anthropic_supports_extended_thinking("claude-mythos-preview")
 
     # Thinking cannot be turned off on the always-thinking models
     @test Agentif.anthropic_thinking_always_on("claude-fable-5")
     @test Agentif.anthropic_thinking_always_on("claude-mythos-5")
+    @test Agentif.anthropic_thinking_always_on("claude-mythos-preview")
     @test !Agentif.anthropic_thinking_always_on("claude-opus-5")
 
     # effort: 4.6 family and newer, plus Opus 4.5 (the one extended-only model with effort)
@@ -1610,13 +1626,23 @@ end
     # Sampling params are rejected outright on the adaptive-only models
     @test Agentif.anthropic_rejects_sampling_params("claude-opus-5")
     @test Agentif.anthropic_rejects_sampling_params("claude-sonnet-5")
+    @test Agentif.anthropic_rejects_sampling_params("claude-mythos-preview")
     @test !Agentif.anthropic_rejects_sampling_params("claude-opus-4-6")
     @test !Agentif.anthropic_rejects_sampling_params("claude-haiku-4-5-20251001")
 
-    # Interleaved thinking: automatic under adaptive, header under extended, absent on Haiku
-    @test !Agentif.anthropic_needs_interleaved_thinking_beta("claude-opus-5")
-    @test !Agentif.anthropic_needs_interleaved_thinking_beta("claude-haiku-4-5-20251001")
-    @test Agentif.anthropic_needs_interleaved_thinking_beta("claude-sonnet-4-5")
+    # Interleaved thinking depends on the selected mode, not only model capability.
+    adaptive = LLMProviders.AnthropicMessages.ThinkingConfig(; type = "adaptive")
+    enabled = LLMProviders.AnthropicMessages.ThinkingConfig(; type = "enabled", budget_tokens = 2048)
+    @test !Agentif.anthropic_needs_interleaved_thinking_beta(
+        anthropic_test_model(id = "claude-opus-5"), adaptive)
+    @test !Agentif.anthropic_needs_interleaved_thinking_beta(
+        anthropic_test_model(id = "claude-haiku-4-5-20251001"), enabled)
+    @test Agentif.anthropic_needs_interleaved_thinking_beta(
+        anthropic_test_model(id = "claude-sonnet-4-5"), enabled)
+    @test Agentif.anthropic_needs_interleaved_thinking_beta(
+        anthropic_test_model(id = "claude-sonnet-4-6"), enabled)
+    @test !Agentif.anthropic_needs_interleaved_thinking_beta(
+        anthropic_test_model(id = "claude-opus-4-6"), enabled)
 end
 
 @testset "anthropic thinking config, effort mapping, and budget clamping" begin
@@ -1679,6 +1705,34 @@ end
     @test Agentif.anthropic_thinking_request(adaptive_model, nothing, 8192).thinking === nothing
     @test Agentif.anthropic_thinking_request(anthropic_test_model(reasoning = false), "high", 8192).thinking === nothing
 
+    # Registry metadata wins over model-name inference.
+    metadata_model = anthropic_test_model(
+        id = "custom-anthropic-model",
+        compat = Dict{String, Any}("forceAdaptiveThinking" => true),
+        thinkingLevelMap = Dict{String, Any}(
+            "off" => "disabled",
+            "high" => "medium",
+            "max" => "high",
+        ),
+    )
+    metadata_cfg = Agentif.anthropic_thinking_request(metadata_model, "max", 8192)
+    @test metadata_cfg.thinking.type == "adaptive"
+    @test metadata_cfg.output_config.effort == "high"
+
+    opt_out_model = anthropic_test_model(
+        id = "claude-opus-4-8",
+        maxTokens = 64000,
+        compat = Dict{String, Any}(
+            "forceAdaptiveThinking" => false,
+            "supportsTemperature" => true,
+        ),
+    )
+    opt_out_cfg = Agentif.anthropic_thinking_request(opt_out_model, "medium", 4096)
+    @test opt_out_cfg.thinking.type == "enabled"
+    @test opt_out_cfg.output_config === nothing
+    @test Agentif.anthropic_supports_extended_thinking(opt_out_model)
+    @test !Agentif.anthropic_rejects_sampling_params(opt_out_model)
+
     @test Agentif.anthropic_thinking_is_enabled(nothing) == false
     @test Agentif.anthropic_thinking_is_enabled(Dict("type" => "disabled")) == false
     @test Agentif.anthropic_thinking_is_enabled(Dict("type" => "adaptive")) == true
@@ -1712,11 +1766,25 @@ end
     )
     @test dropped.thinking === nothing
 
-    # Supported configs pass through untouched
+    # Supported configs are converted to validated typed values.
     supported = Agentif.anthropic_normalize_thinking(Dict("type" => "adaptive"), opus5, 32000)
-    @test supported.thinking["type"] == "adaptive"
-    @test Agentif.anthropic_normalize_thinking(Dict("type" => "disabled"), opus5, 32000).thinking["type"] == "disabled"
-    @test Agentif.anthropic_normalize_thinking(Dict("type" => "enabled", "budget_tokens" => 2048), haiku, 32000).thinking["budget_tokens"] == 2048
+    @test supported.thinking.type == "adaptive"
+    @test Agentif.anthropic_normalize_thinking(
+        Dict("type" => "disabled"), opus5, 32000).thinking.type == "disabled"
+    @test Agentif.anthropic_normalize_thinking(
+        Dict("type" => "enabled", "budget_tokens" => 2048), haiku, 32000,
+    ).thinking.budget_tokens == 2048
+    minimum = @test_logs (:warn,) match_mode = :any Agentif.anthropic_normalize_thinking(
+        Dict("type" => "enabled", "budget_tokens" => 10), haiku, 32000,
+    )
+    @test minimum.thinking.budget_tokens == 1024
+    below_max = @test_logs (:warn,) match_mode = :any Agentif.anthropic_normalize_thinking(
+        Dict("type" => "enabled", "budget_tokens" => 64000), haiku, 32000,
+    )
+    @test below_max.thinking.budget_tokens < below_max.max_tokens
+    @test_throws ArgumentError Agentif.anthropic_normalize_thinking(
+        Dict("type" => "enabled", "budget_tokens" => "many"), haiku, 32000,
+    )
     @test Agentif.anthropic_normalize_thinking(nothing, opus5, 32000).thinking === nothing
 end
 
@@ -1728,6 +1796,7 @@ end
     @test Agentif.anthropic_cache_control("https://api.anthropic.com", "none") === nothing
     @test Agentif.anthropic_cache_control("https://api.anthropic.com", "short").ttl === nothing
     @test Agentif.anthropic_cache_control("https://api.anthropic.com", "long").ttl == "1h"
+    @test Agentif.anthropic_cache_control("https://api.anthropic.com.example.test", "long").ttl === nothing
     @test Agentif.anthropic_cache_control("http://127.0.0.1:8080", "long").ttl === nothing
 
     # a string user turn is promoted to a block array carrying the breakpoint
@@ -1768,11 +1837,13 @@ end
     @test all(b -> b.cache_control === nothing, Agentif.anthropic_oauth_system_blocks("You are helpful.", nothing))
 end
 
-@testset "anthropic request shaping: thinking, effort, cache_control, temperature guard" begin
+@testset "anthropic request shaping: thinking, effort, caching, and API guards" begin
     bodies = Vector{Any}()
+    beta_headers = String[]
 
     server = HTTP.serve!("127.0.0.1", 0) do req
         push!(bodies, JSON.parse(String(req.body)))
+        push!(beta_headers, something(HTTP.header(req, "anthropic-beta"), ""))
         sse = join([
             "data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_s\",\"role\":\"assistant\",\"content\":[],\"usage\":{\"input_tokens\":5,\"output_tokens\":1}}}",
             "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}",
@@ -1787,8 +1858,12 @@ end
     try
         port = HTTP.Sockets.getsockname(server.listener.server)[2]
         base_url = "http://127.0.0.1:$port"
-        # temperature comes from model.kw; the sampling guard has to strip it
-        model = anthropic_test_model(baseUrl = base_url, maxTokens = 128000, kw = (; temperature = 0.7))
+        # Sampling controls come from model.kw; the newest-model guard strips all three.
+        model = anthropic_test_model(
+            baseUrl = base_url,
+            maxTokens = 128000,
+            kw = (; temperature = 0.7, top_p = 0.8, top_k = 20),
+        )
         agent = Agent(id = "anthropic-shape-test", prompt = "You are helpful.", model = model, apikey = "test-key", tools = AgentTool[])
 
         stream(ev -> ev, agent, AgentState(), "Say hello", Abort(); reasoning_effort = "xhigh")
@@ -1799,6 +1874,8 @@ end
         @test body["output_config"]["effort"] == "xhigh"
         # Claude Opus 5 rejects non-default sampling params outright
         @test !haskey(body, "temperature")
+        @test !haskey(body, "top_p")
+        @test !haskey(body, "top_k")
         # the effort kwarg is consumed, never forwarded as an unknown request field
         @test !haskey(body, "reasoning_effort")
         @test body["max_tokens"] == 128000
@@ -1814,18 +1891,29 @@ end
         @test !haskey(plain, "thinking")
         @test !haskey(plain, "output_config")
         @test !haskey(plain, "temperature")
+        @test !haskey(plain, "top_p")
+        @test !haskey(plain, "top_k")
 
-        # On older models temperature is only dropped while thinking is on
+        # Older models only reject temperature/top_k while thinking is on. Their
+        # top_p value must be in the 0.95–1.0 interval.
         legacy_agent = Agent(
             id = "anthropic-legacy-test", prompt = "You are helpful.",
-            model = anthropic_test_model(id = "claude-opus-4-6", baseUrl = base_url, kw = (; temperature = 0.7)),
+            model = anthropic_test_model(
+                id = "claude-opus-4-6",
+                baseUrl = base_url,
+                kw = (; temperature = 0.7, top_p = 0.8, top_k = 20),
+            ),
             apikey = "test-key", tools = AgentTool[],
         )
         stream(ev -> ev, legacy_agent, AgentState(), "Say hello", Abort())
         @test bodies[end]["temperature"] == 0.7
+        @test bodies[end]["top_p"] == 0.8
+        @test bodies[end]["top_k"] == 20
         stream(ev -> ev, legacy_agent, AgentState(), "Say hello", Abort(); reasoning_effort = "xhigh")
         legacy_thinking = bodies[end]
         @test !haskey(legacy_thinking, "temperature")
+        @test !haskey(legacy_thinking, "top_p")
+        @test !haskey(legacy_thinking, "top_k")
         @test legacy_thinking["thinking"]["type"] == "adaptive"
         # Opus 4.6 has max but not xhigh
         @test legacy_thinking["output_config"]["effort"] == "max"
@@ -1844,6 +1932,20 @@ end
         @test budget_body["max_tokens"] == 12288
         # Haiku 4.5 does not support the effort parameter
         @test !haskey(budget_body, "output_config")
+
+        valid_top_p_agent = Agent(
+            id = "anthropic-valid-top-p-test", prompt = "You are helpful.",
+            model = anthropic_test_model(
+                id = "claude-haiku-4-5-20251001",
+                maxTokens = 64000,
+                baseUrl = base_url,
+                kw = (; top_p = 0.97),
+            ),
+            apikey = "test-key", tools = AgentTool[],
+        )
+        stream(ev -> ev, valid_top_p_agent, AgentState(), "Say hello", Abort();
+            reasoning_effort = "medium", max_tokens = 4096)
+        @test bodies[end]["top_p"] == 0.97
 
         # cache_retention="none" drops every breakpoint
         stream(ev -> ev, agent, AgentState(), "Say hello", Abort(); cache_retention = "none")
@@ -1866,6 +1968,33 @@ end
         clamped = bodies[end]
         @test clamped["thinking"]["type"] == "adaptive"
         @test !haskey(clamped["thinking"], "budget_tokens")
+
+        # Opus 5 rejects disabled thinking with xhigh/max effort.
+        stream(ev -> ev, agent, AgentState(), "Say hello", Abort();
+            thinking = Dict("type" => "disabled"),
+            output_config = Dict("effort" => "max"))
+        effort_conflict = bodies[end]
+        @test effort_conflict["thinking"]["type"] == "adaptive"
+        @test effort_conflict["thinking"]["display"] == "summarized"
+
+        # Manual thinking rejects forced tool selection. Sonnet 4.6 still needs
+        # the interleaved-thinking beta when manual thinking is selected.
+        shape_tool = @tool "Echo text." anthropic_shape_echo(text::String) = text
+        manual_agent = Agent(
+            id = "anthropic-manual-tool-test", prompt = "You are helpful.",
+            model = anthropic_test_model(
+                id = "claude-sonnet-4-6",
+                maxTokens = 64000,
+                baseUrl = base_url,
+            ),
+            apikey = "test-key", tools = [shape_tool],
+        )
+        stream(ev -> ev, manual_agent, AgentState(), "Say hello", Abort();
+            thinking = Dict("type" => "enabled", "budget_tokens" => 2048),
+            tool_choice = Dict("type" => "tool", "name" => "anthropic_shape_echo"))
+        manual = bodies[end]
+        @test !haskey(manual, "tool_choice")
+        @test occursin("interleaved-thinking-2025-05-14", beta_headers[end])
 
         # OAuth keeps its two system breakpoints and still caches the conversation tail
         oauth_agent = Agent(
@@ -1994,6 +2123,157 @@ end
     end
 end
 
+@testset "anthropic pause_turn preserves raw server-tool state" begin
+    seen_events = Agentif.AgentEvent[]
+    bodies = Vector{Any}()
+    expected_server_tool = Dict{String, Any}(
+        "type" => "server_tool_use",
+        "id" => "srvtoolu_01",
+        "name" => "web_search",
+        "input" => Dict{String, Any}("query" => "Julia language"),
+    )
+    expected_server_result = Dict{String, Any}(
+        "type" => "web_search_tool_result",
+        "tool_use_id" => "srvtoolu_01",
+        "content" => Any[
+            Dict{String, Any}(
+                "type" => "web_search_result",
+                "url" => "https://julialang.org",
+                "title" => "The Julia Programming Language",
+                "encrypted_content" => "opaque-result",
+            ),
+        ],
+    )
+
+    server = HTTP.serve!("127.0.0.1", 0) do req
+        push!(bodies, JSON.parse(String(req.body)))
+        sse = if length(bodies) == 1
+            join([
+                "data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_srv_1\",\"role\":\"assistant\",\"content\":[],\"usage\":{\"input_tokens\":20,\"output_tokens\":1}}}",
+                "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"server_tool_use\",\"id\":\"srvtoolu_01\",\"name\":\"web_search\",\"input\":{}}}",
+                "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"query\\\":\\\"Julia language\\\"}\"}}",
+                "data: {\"type\":\"content_block_stop\",\"index\":0}",
+                "data: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"web_search_tool_result\",\"tool_use_id\":\"srvtoolu_01\",\"content\":[{\"type\":\"web_search_result\",\"url\":\"https://julialang.org\",\"title\":\"The Julia Programming Language\",\"encrypted_content\":\"opaque-result\"}]}}",
+                "data: {\"type\":\"content_block_stop\",\"index\":1}",
+                "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"pause_turn\"},\"usage\":{\"output_tokens\":8}}",
+                "data: {\"type\":\"message_stop\"}",
+            ], "\n\n") * "\n\n"
+        else
+            join([
+                "data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_srv_2\",\"role\":\"assistant\",\"content\":[],\"usage\":{\"input_tokens\":30,\"output_tokens\":1}}}",
+                "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}",
+                "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Julia found.\"}}",
+                "data: {\"type\":\"content_block_stop\",\"index\":0}",
+                "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":3}}",
+                "data: {\"type\":\"message_stop\"}",
+            ], "\n\n") * "\n\n"
+        end
+        return HTTP.Response(200, ["Content-Type" => "text/event-stream"], sse)
+    end
+
+    try
+        port = HTTP.Sockets.getsockname(server.listener.server)[2]
+        model = anthropic_test_model(baseUrl = "http://127.0.0.1:$port")
+        agent = Agent(
+            id = "anthropic-server-pause-test",
+            prompt = "You are helpful.",
+            model = model,
+            apikey = "test-key",
+            tools = AgentTool[],
+        )
+
+        result = stream(
+            ev -> (push!(seen_events, ev); ev),
+            agent,
+            AgentState(),
+            "Search the web",
+            Abort(),
+        )
+        @test result.most_recent_stop_reason == :stop
+        @test length(bodies) == 2
+        @test !any(ev -> ev isa Agentif.AgentErrorEvent, seen_events)
+        resumed = bodies[2]["messages"][end]
+        @test resumed["role"] == "assistant"
+        @test resumed["content"] == Any[expected_server_tool, expected_server_result]
+        @test Agentif.message_text(result.messages[end]) == "Julia found."
+    finally
+        close(server)
+    end
+end
+
+@testset "anthropic non-streaming pause_turn preserves raw content" begin
+    bodies = Vector{Any}()
+    paused_content = Any[
+        Dict{String, Any}(
+            "type" => "server_tool_use",
+            "id" => "srvtoolu_nonstream",
+            "name" => "web_fetch",
+            "input" => Dict{String, Any}("url" => "https://julialang.org"),
+        ),
+        Dict{String, Any}(
+            "type" => "web_fetch_tool_result",
+            "tool_use_id" => "srvtoolu_nonstream",
+            "content" => Dict{String, Any}(
+                "type" => "web_fetch_result",
+                "url" => "https://julialang.org",
+                "content" => "opaque",
+            ),
+        ),
+    ]
+
+    server = HTTP.serve!("127.0.0.1", 0) do req
+        push!(bodies, JSON.parse(String(req.body)))
+        response = if length(bodies) == 1
+            Dict{String, Any}(
+                "id" => "msg_ns_1",
+                "model" => "claude-opus-5",
+                "role" => "assistant",
+                "content" => paused_content,
+                "stop_reason" => "pause_turn",
+                "usage" => Dict("input_tokens" => 4, "output_tokens" => 2),
+            )
+        else
+            Dict{String, Any}(
+                "id" => "msg_ns_2",
+                "model" => "claude-opus-5",
+                "role" => "assistant",
+                "content" => Any[Dict("type" => "text", "text" => "Done.")],
+                "stop_reason" => "end_turn",
+                "usage" => Dict("input_tokens" => 6, "output_tokens" => 1),
+            )
+        end
+        return HTTP.Response(
+            200,
+            ["Content-Type" => "application/json"],
+            JSON.json(response),
+        )
+    end
+
+    try
+        port = HTTP.Sockets.getsockname(server.listener.server)[2]
+        model = anthropic_test_model(baseUrl = "http://127.0.0.1:$port")
+        agent = Agent(
+            id = "anthropic-nonstream-pause-test",
+            prompt = "You are helpful.",
+            model = model,
+            apikey = "test-key",
+            tools = AgentTool[],
+        )
+        result = withenv("AGENTIF_DISABLE_STREAMING" => "1") do
+            stream(identity, agent, AgentState(), "Fetch the page", Abort())
+        end
+
+        @test length(bodies) == 2
+        @test bodies[2]["messages"][end]["content"] == paused_content
+        @test Agentif.message_text(result.messages[end]) == "Done."
+        @test result.most_recent_stop_reason == :stop
+        @test result.usage.input == 10
+        @test result.usage.output == 3
+    finally
+        close(server)
+    end
+end
+
 @testset "anthropic pause_turn resubmits are bounded" begin
     bodies = Vector{Any}()
 
@@ -2019,8 +2299,12 @@ end
         result = stream(ev -> (push!(seen_events, ev); ev), agent, AgentState(), "Loop forever", Abort())
         # one original request plus ANTHROPIC_MAX_PAUSE_TURN_RESUBMITS continuations
         @test length(bodies) == 1 + Agentif.ANTHROPIC_MAX_PAUSE_TURN_RESUBMITS
-        @test result.most_recent_stop_reason == :stop
+        @test result.most_recent_stop_reason == :length
         @test Agentif.message_text(result.messages[end]) == "xxxx"
+        @test all(body -> begin
+            replay = body["messages"][end]["content"]
+            length(replay) == 1 && replay[1]["text"] == "x"
+        end, bodies[2:end])
         @test count(ev -> ev isa Agentif.MessageEndEvent, seen_events) == 1
     finally
         close(server)

--- a/LLMProviders/src/providers/anthropic_messages.jl
+++ b/LLMProviders/src/providers/anthropic_messages.jl
@@ -273,6 +273,7 @@ end
     stream::Union{Nothing, Bool} = nothing
     temperature::Union{Nothing, Float64} = nothing
     top_p::Union{Nothing, Float64} = nothing
+    top_k::Union{Nothing, Int} = nothing
     stop_sequences::Union{Nothing, Vector{String}} = nothing
     # `Any` (like tool_choice) so callers can pass a raw Dict/NamedTuple through
     # `model.kw`/stream kwargs while the adapter builds the typed structs above.

--- a/LLMProviders/src/providers/anthropic_messages.jl
+++ b/LLMProviders/src/providers/anthropic_messages.jl
@@ -13,6 +13,8 @@ schema(::Type{T}) where {T} = JSONSchema.schema(
 
 @omit_null @kwarg struct CacheControl
     type::String
+    # "1h" opts into the extended-TTL cache; omitted means the default 5m ephemeral cache.
+    ttl::Union{Nothing, String} = nothing
 end
 
 @omit_null @kwarg mutable struct TextBlock
@@ -38,9 +40,10 @@ end
     data::String
 end
 
-@omit_null @kwarg struct ImageBlock
+@omit_null @kwarg mutable struct ImageBlock
     type::String = "image"
     source::ImageSource
+    cache_control::Union{Nothing, CacheControl} = nothing
 end
 
 @omit_null @kwarg mutable struct ToolUseBlock
@@ -52,11 +55,12 @@ end
 
 const ToolResultContentBlock = Union{TextBlock, ImageBlock}
 
-@omit_null @kwarg struct ToolResultBlock
+@omit_null @kwarg mutable struct ToolResultBlock
     type::String = "tool_result"
     tool_use_id::String
     content::Union{String, Vector{ToolResultContentBlock}}
     is_error::Union{Nothing, Bool} = nothing
+    cache_control::Union{Nothing, CacheControl} = nothing
 end
 
 # Catch-all so unrecognized content block types (e.g. server_tool_use) parse
@@ -243,6 +247,22 @@ JSON.@choosetype StreamEvent x -> begin
     end
 end
 
+# Two distinct mechanisms:
+#   adaptive thinking  -> {"type": "adaptive"} (+ optional "display")
+#   extended thinking  -> {"type": "enabled", "budget_tokens": N}
+#   off                -> {"type": "disabled"} (rejected on always-thinking models)
+# `display` is "omitted" | "summarized"; it is invalid with type "disabled".
+@omit_null @kwarg struct ThinkingConfig
+    type::String = "adaptive"
+    budget_tokens::Union{Nothing, Int} = nothing
+    display::Union{Nothing, String} = nothing
+end
+
+# Carries the effort level: low | medium | high | xhigh | max (model dependent).
+@omit_null @kwarg struct OutputConfig
+    effort::Union{Nothing, String} = nothing
+end
+
 @omit_null @kwarg struct Request
     model::String
     messages::Vector{Message}
@@ -254,6 +274,11 @@ end
     temperature::Union{Nothing, Float64} = nothing
     top_p::Union{Nothing, Float64} = nothing
     stop_sequences::Union{Nothing, Vector{String}} = nothing
+    # `Any` (like tool_choice) so callers can pass a raw Dict/NamedTuple through
+    # `model.kw`/stream kwargs while the adapter builds the typed structs above.
+    thinking::Union{Nothing, Any} = nothing
+    output_config::Union{Nothing, Any} = nothing
+    metadata::Union{Nothing, Any} = nothing
 end
 
 end # module AnthropicMessages

--- a/LLMProviders/test/runtests.jl
+++ b/LLMProviders/test/runtests.jl
@@ -190,6 +190,73 @@ end
     @test response.content[2].data == "opaque"
     @test response.content[3] isa AnthropicMessages.TextBlock
     @test response.content[3].text == "done"
+
+    # adaptive thinking + effort serialize to the documented wire shapes
+    adaptive = AnthropicMessages.Request(
+        ; model = "claude-opus-5",
+        messages = AnthropicMessages.Message[AnthropicMessages.Message(; role = "user", content = "hi")],
+        max_tokens = 4096,
+        thinking = AnthropicMessages.ThinkingConfig(; type = "adaptive", display = "summarized"),
+        output_config = AnthropicMessages.OutputConfig(; effort = "xhigh"),
+        metadata = Dict("user_id" => "u-1"),
+    )
+    adaptive_body = JSON.parse(JSON.json(adaptive))
+    @test adaptive_body["thinking"]["type"] == "adaptive"
+    @test adaptive_body["thinking"]["display"] == "summarized"
+    @test !haskey(adaptive_body["thinking"], "budget_tokens")
+    @test adaptive_body["output_config"]["effort"] == "xhigh"
+    @test adaptive_body["metadata"]["user_id"] == "u-1"
+    @test !haskey(adaptive_body, "temperature")
+
+    # budget-based thinking keeps budget_tokens strictly below max_tokens
+    budgeted = AnthropicMessages.Request(
+        ; model = "claude-haiku-4-5",
+        messages = AnthropicMessages.Message[],
+        max_tokens = 12288,
+        thinking = AnthropicMessages.ThinkingConfig(; type = "enabled", budget_tokens = 8192),
+    )
+    budget_body = JSON.parse(JSON.json(budgeted))
+    @test budget_body["thinking"]["type"] == "enabled"
+    @test !haskey(budget_body["thinking"], "display")
+    @test budget_body["thinking"]["budget_tokens"] == 8192
+    @test budget_body["thinking"]["budget_tokens"] < budget_body["max_tokens"]
+    @test !haskey(budget_body, "output_config")
+
+    # cache_control breakpoints ride on system blocks and on user content blocks
+    cached = AnthropicMessages.Request(
+        ; model = "claude-opus-5",
+        messages = AnthropicMessages.Message[
+            AnthropicMessages.Message(
+                ; role = "user",
+                content = AnthropicMessages.ContentBlock[
+                    AnthropicMessages.ToolResultBlock(
+                        ; tool_use_id = "t1",
+                        content = "ok",
+                        cache_control = AnthropicMessages.CacheControl(; type = "ephemeral"),
+                    ),
+                ],
+            ),
+        ],
+        max_tokens = 1024,
+        system = AnthropicMessages.TextBlock[
+            AnthropicMessages.TextBlock(
+                ; text = "sys",
+                cache_control = AnthropicMessages.CacheControl(; type = "ephemeral", ttl = "1h"),
+            ),
+        ],
+    )
+    cached_body = JSON.parse(JSON.json(cached))
+    @test cached_body["system"][1]["cache_control"]["type"] == "ephemeral"
+    @test cached_body["system"][1]["cache_control"]["ttl"] == "1h"
+    tool_result_body = cached_body["messages"][1]["content"][1]
+    @test tool_result_body["cache_control"]["type"] == "ephemeral"
+    # the default 5m ephemeral cache omits the ttl field entirely
+    @test !haskey(tool_result_body["cache_control"], "ttl")
+
+    image_block = AnthropicMessages.ImageBlock(; source = AnthropicMessages.ImageSource(; media_type = "image/png", data = "AAA"))
+    @test JSON.parse(JSON.json(image_block)) |> b -> !haskey(b, "cache_control")
+    image_block.cache_control = AnthropicMessages.CacheControl(; type = "ephemeral")
+    @test JSON.parse(JSON.json(image_block))["cache_control"]["type"] == "ephemeral"
 end
 
 @testset "GoogleGenerativeAI" begin

--- a/LLMProviders/test/runtests.jl
+++ b/LLMProviders/test/runtests.jl
@@ -208,6 +208,14 @@ end
     @test adaptive_body["metadata"]["user_id"] == "u-1"
     @test !haskey(adaptive_body, "temperature")
 
+    sampled = AnthropicMessages.Request(
+        ; model = "claude-3-5-haiku-latest",
+        messages = AnthropicMessages.Message[],
+        max_tokens = 1024,
+        top_k = 40,
+    )
+    @test JSON.parse(JSON.json(sampled))["top_k"] == 40
+
     # budget-based thinking keeps budget_tokens strictly below max_tokens
     budgeted = AnthropicMessages.Request(
         ; model = "claude-haiku-4-5",


### PR DESCRIPTION
## Summary

This PR completes the Anthropic Messages path in three areas:

- Adds adaptive and manual thinking, model-aware effort, and request validation.
- Adds explicit prompt-cache breakpoints for the system prompt and conversation tail.
- Continues `pause_turn` responses in both streaming and non-streaming modes.

## Review fixes

The review found and fixed several API-level correctness problems:

- Preserve raw `server_tool_use` and server-tool result blocks when a paused response is sent back. The typed Agentif content model can still ignore unknown blocks for display.
- Replace the continuation message with the current paused response on each retry, as required by Anthropic's documented loop.
- Keep Mythos Preview compatible with both adaptive and manual thinking.
- Prefer registry `compat` and `thinkingLevelMap` metadata. An explicit `forceAdaptiveThinking = false` now overrides model-name inference.
- Validate manual thinking budgets. Clamp them to the 1,024-token minimum and below `max_tokens`.
- Remove `temperature`, `top_p`, and `top_k` where the selected model or thinking mode rejects them.
- Normalize the Opus 5 disabled-thinking plus `xhigh`/`max` conflict.
- Remove forced tool choice during manual thinking.
- Select the interleaved-thinking beta from the active thinking mode.
- Restrict the 1-hour cache TTL to the exact `api.anthropic.com` host.
- Report exhausted `pause_turn` and `model_context_window_exceeded` responses as incomplete.

The behavior follows Anthropic's current [extended thinking](https://platform.claude.com/docs/en/build-with-claude/extended-thinking), [effort](https://platform.claude.com/docs/en/build-with-claude/effort), [prompt caching](https://platform.claude.com/docs/en/build-with-claude/prompt-caching), and [stop reason](https://platform.claude.com/docs/en/build-with-claude/handling-stop-reasons) documentation.

## Validation

- Full local monorepo suite passed.
- Packages: `LLMProviders`, `LLMOAuth`, `Agentif`, `LLMTools`, and `Claw`.
- Tests cover request wire shapes, capability overrides, invalid parameter guards, prompt-cache placement, streaming and non-streaming continuation, exact server-tool replay, retry bounds, event counts, and accumulated usage.

Co-authored by Codex
