### PR TITLE
Compaction & session persistence: fix the data-loss cluster

### DIFF
--- a/Agentif/ext/AgentifSQLiteExt/AgentifSQLiteExt.jl
+++ b/Agentif/ext/AgentifSQLiteExt/AgentifSQLiteExt.jl
@@ -6,6 +6,14 @@ using JSON
 using LocalSearch
 using SQLite
 
+function _ensure_column!(db::SQLite.DB, table::String, column::String, declaration::String)
+    for row in SQLite.DBInterface.execute(db, "PRAGMA table_info($table)")
+        String(row.name) == column && return false
+    end
+    SQLite.execute(db, "ALTER TABLE $table ADD COLUMN $declaration")
+    return true
+end
+
 function Agentif.init_sqlite_session_schema!(db::SQLite.DB)
     SQLite.execute(db, "PRAGMA journal_mode=WAL")
     SQLite.execute(db, "PRAGMA synchronous=NORMAL")
@@ -28,6 +36,8 @@ function Agentif.init_sqlite_session_schema!(db::SQLite.DB)
             channel_flags INTEGER
         )
     """)
+    # Added after the initial schema: existing databases need the column too.
+    _ensure_column!(db, "session_entries", "post_id", "post_id TEXT")
     SQLite.execute(db, """
         CREATE INDEX IF NOT EXISTS idx_entries_parent
         ON session_entries(parent_id)
@@ -35,6 +45,10 @@ function Agentif.init_sqlite_session_schema!(db::SQLite.DB)
     SQLite.execute(db, """
         CREATE INDEX IF NOT EXISTS idx_entries_entry_id
         ON session_entries(entry_id)
+    """)
+    SQLite.execute(db, """
+        CREATE INDEX IF NOT EXISTS idx_entries_post_id
+        ON session_entries(post_id)
     """)
     SQLite.execute(db, """
         CREATE TABLE IF NOT EXISTS session_branches (
@@ -83,8 +97,8 @@ function Agentif.append_entry!(store::SQLiteSessionStore, entry::Agentif.Session
         store.db,
         """INSERT INTO session_entries
            (entry_id, parent_id, created_at, entry, is_compaction, first_kept_entry_id,
-            is_deleted, user_id, channel_id, search_channel_id, channel_flags)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            is_deleted, user_id, channel_id, search_channel_id, channel_flags, post_id)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (
             entry.id,
             entry.parent_id,
@@ -97,6 +111,7 @@ function Agentif.append_entry!(store::SQLiteSessionStore, entry::Agentif.Session
             entry.channel_id,
             entry.search_channel_id,
             entry.channel_flags,
+            entry.post_id,
         ),
     )
     doc_id = "session:entry:$(entry.id)"
@@ -148,88 +163,13 @@ function Agentif.lock_branch(f::Function, store::SQLiteSessionStore, branch_id::
     end
 end
 
-# ─── Lineage walk via recursive CTE ───
-
-function Agentif.load_branch(store::SQLiteSessionStore, branch_id::String)
-    leaf_id = Agentif.get_branch_leaf(store, branch_id)
-    leaf_id === nothing && return Agentif.AgentState()
-    return _load_lineage(store, leaf_id)
-end
-
-function Agentif.load_branch_with_boundaries(store::SQLiteSessionStore, branch_id::String)
-    leaf_id = Agentif.get_branch_leaf(store, branch_id)
-    if leaf_id === nothing
-        return Agentif.AgentState(), Agentif.EntryBoundary[]
-    end
-    return _load_lineage_with_boundaries(store, leaf_id)
-end
-
-const LINEAGE_CTE_SQL = """
-    WITH RECURSIVE lineage AS (
-        SELECT entry_id, parent_id, is_compaction, first_kept_entry_id, entry,
-               0 as depth, 0 as stop_after_this
-        FROM session_entries WHERE entry_id = ?
-
-        UNION ALL
-
-        SELECT e.entry_id, e.parent_id, e.is_compaction, e.first_kept_entry_id, e.entry,
-               l.depth + 1,
-               CASE WHEN e.is_compaction THEN 1 ELSE 0 END
-        FROM session_entries e
-        JOIN lineage l ON e.entry_id = l.parent_id
-        WHERE l.stop_after_this = 0
-    )
-    SELECT entry_id, is_compaction, first_kept_entry_id, entry
-    FROM lineage ORDER BY depth DESC
-"""
-
-function _parse_lineage_rows(store::SQLiteSessionStore, leaf_id::String)
-    rows = SQLite.DBInterface.execute(store.db, LINEAGE_CTE_SQL, (leaf_id,))
-    entries = Agentif.SessionEntry[]
-    compaction_idx = 0
-    for row in rows
-        entry = JSON.parse(String(row.entry), Agentif.SessionEntry)
-        push!(entries, entry)
-        if row.is_compaction == 1 && compaction_idx == 0
-            compaction_idx = length(entries)
-        end
-    end
-
-    # CTE returns root→leaf order. If compaction found, reorder:
-    # compaction entry FIRST, then kept entries, then post-compaction entries
-    if compaction_idx > 0
-        compaction_entry = entries[compaction_idx]
-        kept = entries[1:compaction_idx-1]
-        post_compaction = entries[compaction_idx+1:end]
-        entries = vcat([compaction_entry], kept, post_compaction)
-    end
-
-    return entries
-end
-
-function _load_lineage(store::SQLiteSessionStore, leaf_id::String)
-    entries = _parse_lineage_rows(store, leaf_id)
-    state = Agentif.AgentState()
-    for entry in entries
-        Agentif.apply_session_entry!(state, entry)
-    end
-    return state
-end
-
-function _load_lineage_with_boundaries(store::SQLiteSessionStore, leaf_id::String)
-    entries = _parse_lineage_rows(store, leaf_id)
-    state = Agentif.AgentState()
-    boundaries = Agentif.EntryBoundary[]
-    for entry in entries
-        start_idx = length(state.messages) + 1
-        Agentif.apply_session_entry!(state, entry)
-        end_idx = length(state.messages)
-        if end_idx >= start_idx
-            push!(boundaries, Agentif.EntryBoundary(entry.id, start_idx, end_idx))
-        end
-    end
-    return state, boundaries
-end
+# ─── Lineage walk ───
+#
+# `Agentif.load_branch` / `load_branch_with_boundaries` walk parents through
+# `get_entry`, which this store implements, so the SQLite store inherits exactly
+# the in-memory lineage semantics (stop at the first compaction ancestor, but
+# keep walking to `first_kept_entry_id`). A recursive CTE cannot express the
+# `first_kept_entry_id` hand-off, so the walk stays in Julia.
 
 # ─── Search ───
 
@@ -253,22 +193,31 @@ end
 # ─── Scrub ───
 
 function Agentif.scrub_post!(store::SQLiteSessionStore, post_id::String)
-    # entry_id IS the platform message ID, so look up by entry_id
-    entries = SQLite.DBInterface.execute(store.db,
-        "SELECT entry_id FROM session_entries WHERE entry_id = ? AND is_deleted = 0",
-        (post_id,)) |> SQLite.rowtable
-    isempty(entries) && return nothing
-    for row in entries
-        doc_id = "session:entry:$(row.entry_id)"
+    # `post_id` is the platform message id. Entries written before the column
+    # existed used it as the entry id, so match either.
+    rows = SQLite.DBInterface.execute(
+        store.db,
+        """SELECT entry_id, entry FROM session_entries
+           WHERE (post_id = ? OR (post_id IS NULL AND entry_id = ?)) AND is_deleted = 0""",
+        (post_id, post_id),
+    ) |> SQLite.rowtable
+    isempty(rows) && return nothing
+    for row in rows
+        entry = JSON.parse(String(row.entry), Agentif.SessionEntry)
+        # Rewrite the stored entry without its messages: flagging is_deleted is
+        # not enough, the lineage walk replays whatever the entry JSON holds.
+        scrubbed = Agentif.scrubbed_entry(entry)
+        SQLite.execute(
+            store.db,
+            "UPDATE session_entries SET entry = ?, is_deleted = 1, user_id = NULL WHERE entry_id = ?",
+            (JSON.json(scrubbed), row.entry_id),
+        )
         try
-            Base.delete!(store.search_store, doc_id)
+            Base.delete!(store.search_store, "session:entry:$(row.entry_id)")
         catch
         end
     end
-    SQLite.execute(store.db,
-        "UPDATE session_entries SET is_deleted = 1 WHERE entry_id = ?",
-        (post_id,))
-    @info "scrub_post!: marked session entry as deleted" entry_id=post_id
+    @info "scrub_post!: scrubbed session entries" post_id count = length(rows)
     return nothing
 end
 

--- a/Agentif/ext/AgentifSQLiteExt/AgentifSQLiteExt.jl
+++ b/Agentif/ext/AgentifSQLiteExt/AgentifSQLiteExt.jl
@@ -206,16 +206,15 @@ function Agentif.scrub_post!(store::SQLiteSessionStore, post_id::String)
         entry = JSON.parse(String(row.entry), Agentif.SessionEntry)
         # Rewrite the stored entry without its messages: flagging is_deleted is
         # not enough, the lineage walk replays whatever the entry JSON holds.
+        # Delete the search document first. If that fails, leave the row active
+        # so the caller can retry instead of silently retaining searchable text.
         scrubbed = Agentif.scrubbed_entry(entry)
+        Base.delete!(store.search_store, "session:entry:$(row.entry_id)")
         SQLite.execute(
             store.db,
             "UPDATE session_entries SET entry = ?, is_deleted = 1, user_id = NULL WHERE entry_id = ?",
             (JSON.json(scrubbed), row.entry_id),
         )
-        try
-            Base.delete!(store.search_store, "session:entry:$(row.entry_id)")
-        catch
-        end
     end
     @info "scrub_post!: scrubbed session entries" post_id count = length(rows)
     return nothing

--- a/Agentif/src/compaction.jl
+++ b/Agentif/src/compaction.jl
@@ -170,14 +170,17 @@ format_messages_for_summary(messages::Vector{AgentMessage}) =
     format_messages_for_summary(stored_agent_messages(messages))
 
 """
-    generate_summary(agent, to_discard, existing_summary, config, model) -> String
+    generate_summary(agent, to_discard, existing_summary, config, model, abort) -> Union{Nothing, String}
 
 Use the agent's model to generate a structured summary of discarded messages.
+Returns `nothing` when the summarization call failed (provider error, abort, or
+an empty response) so callers can skip compaction instead of trading real
+history for an empty summary.
 """
 function generate_summary(
         agent::Agent, to_discard::Vector{StoredAgentMessage},
         existing_summary::Union{Nothing, CompactionSummaryMessage},
-        config::CompactionConfig, model::Model,
+        config::CompactionConfig, model::Model, abort::Abort = Abort(),
     )
     prompt = if existing_summary !== nothing
         replace(COMPACTION_UPDATE_PROMPT, "%s" => existing_summary.summary)
@@ -196,38 +199,55 @@ function generate_summary(
         http_kw = agent.http_kw,
         api = Val(Symbol(model.api)),
     )
-    result = stream(identity, summary_agent, AgentState(), summary_input, Abort())
-    return message_text(last_assistant_message(result))
+    result = stream(identity, summary_agent, AgentState(), summary_input, abort)
+    stop_reason = result.most_recent_stop_reason
+    if stop_reason === :error || stop_reason === :aborted
+        @warn "Compaction summary call did not complete, skipping compaction" stop_reason
+        return nothing
+    end
+    msg = last_assistant_message(result)
+    summary_text = msg === nothing ? "" : message_text(msg)
+    if isempty(strip(summary_text))
+        @warn "Compaction summary was empty, skipping compaction" stop_reason
+        return nothing
+    end
+    return summary_text
 end
 
 """
-    compact!(agent, state, config, model)
+    compact!(agent, state, config, model; abort) -> Bool
 
 Perform compaction on the agent state: summarize old messages and replace them
 with a CompactionSummaryMessage. Sets `state.last_compaction` to signal
-session_middleware to write a compaction entry.
+session_middleware to write a compaction entry, and updates the persisted-prefix
+provenance so persistence knows which kept messages the store already holds.
+
+Returns `true` when the state was compacted, `false` when compaction was skipped
+(nothing to compact, or summarization failed) — in which case `state` is
+untouched.
 """
-function compact!(agent::Agent, state::AgentState, config::CompactionConfig, model::Model)
+function compact!(agent::Agent, state::AgentState, config::CompactionConfig, model::Model; abort::Abort = Abort())
     messages = state.messages
 
     cut_idx = find_cut_point(messages, config.keep_recent_tokens)
-    cut_idx <= 1 && return
+    cut_idx <= 1 && return false
 
     # Check for existing compaction summary at the front
     existing_summary = !isempty(messages) && messages[1] isa CompactionSummaryMessage ? messages[1] : nothing
     discard_start = existing_summary !== nothing ? 2 : 1
 
     to_discard = messages[discard_start:cut_idx-1]
-    isempty(to_discard) && return
+    isempty(to_discard) && return false
 
     to_keep = messages[cut_idx:end]
 
     summary_text = try
-        generate_summary(agent, to_discard, existing_summary, config, model)
+        generate_summary(agent, to_discard, existing_summary, config, model, abort)
     catch e
         @warn "Compaction summary generation failed, skipping compaction" exception = (e, catch_backtrace())
-        return
+        nothing
     end
+    summary_text === nothing && return false
 
     tokens_before = 0
     for message in to_discard
@@ -243,6 +263,14 @@ function compact!(agent::Agent, state::AgentState, config::CompactionConfig, mod
         compacted_at = time(),
     )
 
+    # The already-persisted prefix occupies positions
+    # discard_start .. discard_start + persisted_prefix_count - 1; whatever part
+    # of it survives the cut stays persisted, the rest is now summarized.
+    prefix_end = discard_start + state.persisted_prefix_count - 1
+    surviving_prefix = max(0, prefix_end - max(cut_idx, discard_start) + 1)
+    state.persisted_prefix_start += max(0, min(cut_idx, discard_start + state.persisted_prefix_count) - discard_start)
+    state.persisted_prefix_count = surviving_prefix
+
     # Replace state.messages in-place
     empty!(state.messages)
     push!(state.messages, compaction_msg)
@@ -250,9 +278,8 @@ function compact!(agent::Agent, state::AgentState, config::CompactionConfig, mod
 
     # Signal to session_middleware
     state.last_compaction = compaction_msg
-    state.compaction_kept_count = length(to_keep)
 
-    return
+    return true
 end
 
 function compaction_threshold(context_window::Int, reserve_tokens::Int)
@@ -268,6 +295,78 @@ end
 compaction_threshold(config::CompactionConfig, model::Model) = compaction_threshold(model.contextWindow, config.reserve_tokens)
 
 """
+    estimate_context_tokens(messages) -> Int
+
+Rough token estimate for a whole conversation. Used as the compaction trigger
+when no measured token count is available (e.g. the first call of an evaluation
+whose state was just restored from a session store).
+"""
+function estimate_context_tokens(messages::Vector{AgentMessage})
+    total = 0
+    for msg in messages
+        total += estimate_message_tokens(msg)
+    end
+    return total
+end
+
+"""
+    current_context_tokens(state) -> Int
+
+Best available estimate of how many input tokens the next API call will carry:
+the measured input tokens of the most recent call (`state.context_tokens`), or
+the message estimate when that is larger or unknown. Taking the larger of the
+two catches context that grew after the last measurement (a long tool-call loop)
+and restored sessions that were already over the limit.
+"""
+function current_context_tokens(state::AgentState)
+    return max(state.context_tokens, estimate_context_tokens(state.messages))
+end
+
+const CONTEXT_OVERFLOW_PATTERNS = [
+    "context length",
+    "context_length",
+    "context window",
+    "maximum context",
+    "too many tokens",
+    "prompt is too long",
+    "input is too long",
+    "reduce the length of the messages",
+]
+
+"""
+    is_context_overflow_error(text) -> Bool
+
+Whether a provider error message looks like "the request exceeded the model's
+context window". Matching is textual because providers report overflow as a
+generic 400 with a prose message.
+"""
+function is_context_overflow_error(text::AbstractString)
+    lowered = lowercase(text)
+    return any(pat -> occursin(pat, lowered), CONTEXT_OVERFLOW_PATTERNS)
+end
+
+is_context_overflow_error(e::Exception) = is_context_overflow_error(sprint(showerror, e))
+
+function is_context_overflow_error(e::HTTP.StatusError)
+    400 <= e.status < 500 || return false
+    body = try
+        String(copy(e.response.body))
+    catch
+        ""
+    end
+    return is_context_overflow_error(body) || is_context_overflow_error(sprint(showerror, e))
+end
+
+function _record_context_tokens!(state::AgentState, total_before::Int)
+    # Track full input token count (including cached) for accurate context
+    # window utilization. usage.input has cached tokens subtracted, so we add
+    # cacheRead back.
+    total_after = state.usage.input + state.usage.cacheRead
+    state.context_tokens = max(0, total_after - total_before)
+    return state
+end
+
+"""
     compaction_middleware(agent_handler, config) -> middleware
 
 Middleware that checks if context is approaching the model's context window
@@ -276,12 +375,14 @@ and compacts old messages into a summary before calling the LLM.
 Sits directly above `stream` in the middleware stack so it runs before each
 individual LLM API call (including within tool-call loops).
 
-Uses `state.usage.input` from the previous API call to determine if compaction
-is needed. On the first call (no previous usage data), compaction is skipped.
+The trigger comes from the state itself — the measured input tokens of the most
+recent API call, or an estimate over `state.messages` — so a session restored
+over the limit compacts before its first call rather than failing forever.
+
+If the provider still rejects the request as a context overflow, the middleware
+compacts once and retries the call once.
 """
 function compaction_middleware(agent_handler::AgentHandler, config::CompactionConfig)
-    last_input_tokens = Ref(0)
-
     return function (f::F, agent::Agent, state::AgentState, current_input::AgentTurnInput, abort::Abort;
             model::Union{Nothing, Model} = nothing, kw...) where {F <: Function}
         if !config.enabled
@@ -296,19 +397,59 @@ function compaction_middleware(agent_handler::AgentHandler, config::CompactionCo
         threshold = compaction_threshold(config, resolved_model)
         threshold <= 0 && return agent_handler(f, agent, state, current_input, abort; model, kw...)
 
-        # Compact if previous call's total input tokens (including cached)
-        # exceeded the context window threshold.
-        if last_input_tokens[] > 0 && last_input_tokens[] > threshold
-            compact!(agent, state, config, resolved_model)
+        if current_context_tokens(state) > threshold
+            compact!(agent, state, config, resolved_model; abort) && (state.context_tokens = 0)
         end
 
-        # Track full input token count (including cached) for accurate
-        # context window utilization. usage.input has cached tokens
-        # subtracted, so we add cacheRead back.
+        # Hold back a context-overflow error: if compaction can rescue the call
+        # we retry instead of surfacing it, otherwise we forward it unchanged.
+        overflow_event = Ref{Union{Nothing, AgentErrorEvent}}(nothing)
+        guarded_f = function (event)
+            if overflow_event[] === nothing && event isa AgentErrorEvent && is_context_overflow_error(event.error)
+                overflow_event[] = event
+                return nothing
+            end
+            return f(event)
+        end
+
+        msg_count_before = length(state.messages)
         total_before = state.usage.input + state.usage.cacheRead
-        result = agent_handler(f, agent, state, current_input, abort; model, kw...)
-        total_after = result.usage.input + result.usage.cacheRead
-        last_input_tokens[] = total_after - total_before
+        overflow_thrown = Ref{Union{Nothing, Exception}}(nothing)
+        result = try
+            agent_handler(guarded_f, agent, state, current_input, abort; model, kw...)
+        catch e
+            (e isa Exception && !isaborted(abort) && is_context_overflow_error(e)) || rethrow()
+            overflow_event[] = AgentErrorEvent(e)
+            overflow_thrown[] = e
+            state
+        end
+        _record_context_tokens!(result, total_before)
+
+        if overflow_event[] !== nothing
+            compacted = false
+            if !isaborted(abort)
+                # Drop the messages the rejected call appended so the retry does
+                # not duplicate the turn, and put them back if compaction fails.
+                failed_tail = AgentMessage[]
+                if length(result.messages) > msg_count_before
+                    append!(failed_tail, result.messages[msg_count_before + 1:end])
+                    Base.resize!(result.messages, msg_count_before)
+                end
+                compacted = compact!(agent, result, config, resolved_model; abort)
+                compacted || append!(result.messages, failed_tail)
+            end
+            if compacted
+                result.context_tokens = 0
+                total_before = result.usage.input + result.usage.cacheRead
+                result = agent_handler(f, agent, result, current_input, abort; model, kw...)
+                _record_context_tokens!(result, total_before)
+            else
+                # Compaction cannot help: leave the failed call exactly as it
+                # was, error and all.
+                overflow_thrown[] === nothing || throw(overflow_thrown[])
+                f(overflow_event[])
+            end
+        end
 
         return result
     end

--- a/Agentif/src/compaction.jl
+++ b/Agentif/src/compaction.jl
@@ -301,7 +301,7 @@ Rough token estimate for a whole conversation. Used as the compaction trigger
 when no measured token count is available (e.g. the first call of an evaluation
 whose state was just restored from a session store).
 """
-function estimate_context_tokens(messages::Vector{AgentMessage})
+function estimate_context_tokens(messages::AbstractVector{<:AgentMessage})
     total = 0
     for msg in messages
         total += estimate_message_tokens(msg)
@@ -357,11 +357,12 @@ function is_context_overflow_error(e::HTTP.StatusError)
     return is_context_overflow_error(body) || is_context_overflow_error(sprint(showerror, e))
 end
 
+_context_input_tokens(usage::Usage) = usage.input + usage.cacheRead + usage.cacheWrite
+
 function _record_context_tokens!(state::AgentState, total_before::Int)
-    # Track full input token count (including cached) for accurate context
-    # window utilization. usage.input has cached tokens subtracted, so we add
-    # cacheRead back.
-    total_after = state.usage.input + state.usage.cacheRead
+    # Track every input token that occupies the context window. Providers can
+    # report uncached, cache-read, and newly cache-written tokens separately.
+    total_after = _context_input_tokens(state.usage)
     state.context_tokens = max(0, total_after - total_before)
     return state
 end
@@ -401,28 +402,60 @@ function compaction_middleware(agent_handler::AgentHandler, config::CompactionCo
             compact!(agent, state, config, resolved_model; abort) && (state.context_tokens = 0)
         end
 
-        # Hold back a context-overflow error: if compaction can rescue the call
-        # we retry instead of surfacing it, otherwise we forward it unchanged.
+        # Hold back an empty response lifecycle and a context-overflow error. A
+        # rejected HTTP call can emit start/end before its error; those events
+        # must not close the consumer's stream before a successful retry.
+        # Once substantive output is visible, retrying would duplicate it, so
+        # an overflow after progress is forwarded without a retry.
         overflow_event = Ref{Union{Nothing, AgentErrorEvent}}(nothing)
-        guarded_f = function (event)
-            if overflow_event[] === nothing && event isa AgentErrorEvent && is_context_overflow_error(event.error)
-                overflow_event[] = event
-                return nothing
+        pending_lifecycle = AgentEvent[]
+        stream_progressed = Ref(false)
+        flush_pending! = function ()
+            for pending_event in pending_lifecycle
+                f(pending_event)
             end
-            return f(event)
+            empty!(pending_lifecycle)
+            return nothing
+        end
+        guarded_f = function (event)
+            overflow_event[] === nothing || return nothing
+            if event isa MessageStartEvent ||
+                    (event isa MessageEndEvent && !stream_progressed[])
+                if !stream_progressed[]
+                    push!(pending_lifecycle, event)
+                    return nothing
+                end
+                return f(event)
+            elseif event isa AgentErrorEvent
+                if !stream_progressed[] && is_context_overflow_error(event.error)
+                    overflow_event[] = event
+                    return nothing
+                end
+                flush_pending!()
+                return f(event)
+            else
+                flush_pending!()
+                stream_progressed[] = true
+                return f(event)
+            end
         end
 
         msg_count_before = length(state.messages)
-        total_before = state.usage.input + state.usage.cacheRead
+        total_before = _context_input_tokens(state.usage)
         overflow_thrown = Ref{Union{Nothing, Exception}}(nothing)
         result = try
             agent_handler(guarded_f, agent, state, current_input, abort; model, kw...)
         catch e
-            (e isa Exception && !isaborted(abort) && is_context_overflow_error(e)) || rethrow()
+            if !(e isa Exception && !isaborted(abort) &&
+                    !stream_progressed[] && is_context_overflow_error(e))
+                flush_pending!()
+                rethrow()
+            end
             overflow_event[] = AgentErrorEvent(e)
             overflow_thrown[] = e
             state
         end
+        overflow_event[] === nothing && flush_pending!()
         _record_context_tokens!(result, total_before)
 
         if overflow_event[] !== nothing
@@ -439,13 +472,15 @@ function compaction_middleware(agent_handler::AgentHandler, config::CompactionCo
                 compacted || append!(result.messages, failed_tail)
             end
             if compacted
+                empty!(pending_lifecycle)
                 result.context_tokens = 0
-                total_before = result.usage.input + result.usage.cacheRead
+                total_before = _context_input_tokens(result.usage)
                 result = agent_handler(f, agent, result, current_input, abort; model, kw...)
                 _record_context_tokens!(result, total_before)
             else
                 # Compaction cannot help: leave the failed call exactly as it
                 # was, error and all.
+                flush_pending!()
                 overflow_thrown[] === nothing || throw(overflow_thrown[])
                 f(overflow_event[])
             end

--- a/Agentif/src/messages.jl
+++ b/Agentif/src/messages.jl
@@ -291,9 +291,9 @@ end
     pending_tool_calls::Vector{PendingToolCall} = PendingToolCall[]
     most_recent_stop_reason::Union{Nothing, Symbol} = nothing
     last_compaction::Union{Nothing, CompactionSummaryMessage} = nothing
-    # Input tokens (including cache reads) reported by the most recent API call.
-    # 0 means "unknown" (fresh state restored from a session store), in which
-    # case compaction falls back to estimating from `messages`.
+    # Input tokens (including cache reads and cache writes) reported by the most
+    # recent API call. 0 means "unknown" (fresh state restored from a session
+    # store), in which case compaction falls back to estimating from `messages`.
     context_tokens::Int = 0
     # Provenance for messages that a session store already persisted:
     # how many leading messages of `messages` (skipping a leading compaction

--- a/Agentif/src/messages.jl
+++ b/Agentif/src/messages.jl
@@ -291,7 +291,18 @@ end
     pending_tool_calls::Vector{PendingToolCall} = PendingToolCall[]
     most_recent_stop_reason::Union{Nothing, Symbol} = nothing
     last_compaction::Union{Nothing, CompactionSummaryMessage} = nothing
-    compaction_kept_count::Int = 0
+    # Input tokens (including cache reads) reported by the most recent API call.
+    # 0 means "unknown" (fresh state restored from a session store), in which
+    # case compaction falls back to estimating from `messages`.
+    context_tokens::Int = 0
+    # Provenance for messages that a session store already persisted:
+    # how many leading messages of `messages` (skipping a leading compaction
+    # summary) are already stored, and the 1-based index of the first of them
+    # in the message list that was originally loaded from the store. `compact!`
+    # keeps both up to date so session persistence never has to reconstruct the
+    # kept boundary with index arithmetic.
+    persisted_prefix_count::Int = 0
+    persisted_prefix_start::Int = 1
 end
 
 function set!(dest::AgentState, source::AgentState)
@@ -301,6 +312,8 @@ function set!(dest::AgentState, source::AgentState)
     dest.pending_tool_calls = source.pending_tool_calls
     dest.most_recent_stop_reason = source.most_recent_stop_reason
     dest.last_compaction = source.last_compaction
-    dest.compaction_kept_count = source.compaction_kept_count
+    dest.context_tokens = source.context_tokens
+    dest.persisted_prefix_count = source.persisted_prefix_count
+    dest.persisted_prefix_start = source.persisted_prefix_start
     return
 end

--- a/Agentif/src/middleware.jl
+++ b/Agentif/src/middleware.jl
@@ -192,6 +192,13 @@ function _unique_entry_id(store::SessionStore, base_id::String)
     end
 end
 
+function _reset_persisted_prefix!(state::AgentState)
+    has_summary = !isempty(state.messages) && state.messages[1] isa CompactionSummaryMessage
+    state.persisted_prefix_start = has_summary ? 2 : 1
+    state.persisted_prefix_count = length(state.messages) - (has_summary ? 1 : 0)
+    return state
+end
+
 function session_middleware(agent_handler::AgentHandler, store::Union{Nothing, SessionStore}; channel::Union{Nothing, AbstractChannel} = nothing)
     search_tool = store === nothing ? nothing : _create_search_session_tool(store)
     return function (f::F, agent::Agent, state::AgentState, current_input::AgentTurnInput, abort::Abort; kw...) where {F <: Function}
@@ -209,15 +216,16 @@ function session_middleware(agent_handler::AgentHandler, store::Union{Nothing, S
             pre_eval_msg_count = length(current_state.messages)
             # Everything we just loaded is already persisted; compact! keeps this
             # provenance up to date if it runs mid-evaluation.
-            current_state.persisted_prefix_count = pre_eval_msg_count
-            current_state.persisted_prefix_start = 1
+            _reset_persisted_prefix!(current_state)
             current_leaf = get_branch_leaf(store, bid)
 
             agent = search_tool === nothing ? agent : with_tools(agent, vcat(agent.tools, [search_tool]))
             current_state = agent_handler(f, agent, current_state, current_input, abort; kw...)
 
             # Resolve final entry ID
-            base_eid = something(captured_eid, response_entry_id(current_channel), string(UID8()))
+            response_eid = response_entry_id(current_channel)
+            platform_post_id = captured_eid === nothing ? response_eid : captured_eid
+            base_eid = platform_post_id === nothing ? string(UID8()) : platform_post_id
             final_eid = _unique_entry_id(store, base_eid)
             user_id, ch_id, sch_id, ch_flags = _entry_metadata(current_channel)
 
@@ -234,7 +242,15 @@ function session_middleware(agent_handler::AgentHandler, store::Union{Nothing, S
                     first_kept_idx = current_state.persisted_prefix_start
                     for b in entry_boundaries
                         if b.message_start <= first_kept_idx <= b.message_end
-                            first_kept_eid = b.entry_id
+                            # Lineage pointers operate at entry granularity. If
+                            # the cut lands inside an entry, persist the kept
+                            # suffix again under the new compaction instead of
+                            # replaying the entry's already-summarized prefix.
+                            if first_kept_idx == b.message_start
+                                first_kept_eid = b.entry_id
+                            else
+                                kept_persisted = 0
+                            end
                             break
                         end
                     end
@@ -267,7 +283,7 @@ function session_middleware(agent_handler::AgentHandler, store::Union{Nothing, S
                         channel_id = ch_id,
                         search_channel_id = sch_id,
                         channel_flags = ch_flags,
-                        post_id = captured_eid,
+                        post_id = platform_post_id,
                     )
                     append_entry!(store, eval_entry)
                     set_branch_leaf!(store, bid, eval_entry.id)
@@ -275,8 +291,7 @@ function session_middleware(agent_handler::AgentHandler, store::Union{Nothing, S
                     set_branch_leaf!(store, bid, compaction_entry.id)
                 end
                 current_state.last_compaction = nothing
-                current_state.persisted_prefix_count = length(current_state.messages)
-                current_state.persisted_prefix_start = 1
+                _reset_persisted_prefix!(current_state)
             elseif length(current_state.messages) > pre_eval_msg_count
                 # No compaction: save new messages as a single entry
                 new_messages = current_state.messages[pre_eval_msg_count + 1:end]
@@ -288,11 +303,11 @@ function session_middleware(agent_handler::AgentHandler, store::Union{Nothing, S
                     channel_id = ch_id,
                     search_channel_id = sch_id,
                     channel_flags = ch_flags,
-                    post_id = captured_eid,
+                    post_id = platform_post_id,
                 )
                 append_entry!(store, eval_entry)
                 set_branch_leaf!(store, bid, eval_entry.id)
-                current_state.persisted_prefix_count = length(current_state.messages)
+                _reset_persisted_prefix!(current_state)
             end
 
             return current_state

--- a/Agentif/src/middleware.jl
+++ b/Agentif/src/middleware.jl
@@ -180,6 +180,18 @@ function _maybe_fork_branch!(store::SessionStore, ch::AbstractChannel, bid::Stri
     return
 end
 
+# Entry ids must be unique: a single incoming message can drive several
+# evaluations (queue_middleware), and each needs its own entry. Keep the
+# platform id when it is still free, otherwise suffix it — `post_id` carries the
+# platform id either way, so scrubbing keeps working.
+function _unique_entry_id(store::SessionStore, base_id::String)
+    get_entry(store, base_id) === nothing && return base_id
+    while true
+        candidate = string(base_id, "#", UID8())
+        get_entry(store, candidate) === nothing && return candidate
+    end
+end
+
 function session_middleware(agent_handler::AgentHandler, store::Union{Nothing, SessionStore}; channel::Union{Nothing, AbstractChannel} = nothing)
     search_tool = store === nothing ? nothing : _create_search_session_tool(store)
     return function (f::F, agent::Agent, state::AgentState, current_input::AgentTurnInput, abort::Abort; kw...) where {F <: Function}
@@ -195,31 +207,44 @@ function session_middleware(agent_handler::AgentHandler, store::Union{Nothing, S
             _maybe_fork_branch!(store, current_channel, bid)
             current_state, entry_boundaries = load_branch_with_boundaries(store, bid)
             pre_eval_msg_count = length(current_state.messages)
+            # Everything we just loaded is already persisted; compact! keeps this
+            # provenance up to date if it runs mid-evaluation.
+            current_state.persisted_prefix_count = pre_eval_msg_count
+            current_state.persisted_prefix_start = 1
             current_leaf = get_branch_leaf(store, bid)
 
             agent = search_tool === nothing ? agent : with_tools(agent, vcat(agent.tools, [search_tool]))
             current_state = agent_handler(f, agent, current_state, current_input, abort; kw...)
 
             # Resolve final entry ID
-            final_eid = something(captured_eid, response_entry_id(current_channel), string(UID8()))
+            base_eid = something(captured_eid, response_entry_id(current_channel), string(UID8()))
+            final_eid = _unique_entry_id(store, base_eid)
             user_id, ch_id, sch_id, ch_flags = _entry_metadata(current_channel)
 
             if current_state.last_compaction !== nothing
-                # Compaction happened: create compaction entry + eval entry
-                kept_count = current_state.compaction_kept_count
+                # Compaction happened, possibly mid-evaluation. `persisted_prefix_*`
+                # says exactly which kept messages the store already holds; every
+                # other message goes into this evaluation's entry, which hangs off
+                # the compaction entry so the lineage walk replays
+                # [summary, kept…, new…] in order.
+                # messages[1] is the summary, so at most length-1 can be kept.
+                kept_persisted = clamp(current_state.persisted_prefix_count, 0, max(0, length(current_state.messages) - 1))
                 first_kept_eid = nothing
-                if kept_count > 0 && pre_eval_msg_count > 0
-                    first_kept_original_idx = pre_eval_msg_count - kept_count + 1
+                if kept_persisted > 0
+                    first_kept_idx = current_state.persisted_prefix_start
                     for b in entry_boundaries
-                        if b.message_start <= first_kept_original_idx <= b.message_end
+                        if b.message_start <= first_kept_idx <= b.message_end
                             first_kept_eid = b.entry_id
                             break
                         end
                     end
+                    # No entry to point at: persist the kept messages here instead
+                    # of leaving them unreachable.
+                    first_kept_eid === nothing && (kept_persisted = 0)
                 end
 
                 compaction_entry = SessionEntry(;
-                    id = string(UID8()),
+                    id = _unique_entry_id(store, string(UID8())),
                     parent_id = current_leaf,
                     messages = AgentMessage[current_state.last_compaction],
                     is_compaction = true,
@@ -231,8 +256,8 @@ function session_middleware(agent_handler::AgentHandler, store::Union{Nothing, S
                 )
                 append_entry!(store, compaction_entry)
 
-                # New messages added after compaction: skip summary (1) + kept (N)
-                new_messages = current_state.messages[kept_count + 2:end]
+                # Skip the summary (1) plus the kept messages the store already has.
+                new_messages = current_state.messages[kept_persisted + 2:end]
                 if !isempty(new_messages)
                     eval_entry = SessionEntry(;
                         id = final_eid,
@@ -242,14 +267,16 @@ function session_middleware(agent_handler::AgentHandler, store::Union{Nothing, S
                         channel_id = ch_id,
                         search_channel_id = sch_id,
                         channel_flags = ch_flags,
+                        post_id = captured_eid,
                     )
                     append_entry!(store, eval_entry)
-                    set_branch_leaf!(store, bid, final_eid)
+                    set_branch_leaf!(store, bid, eval_entry.id)
                 else
                     set_branch_leaf!(store, bid, compaction_entry.id)
                 end
                 current_state.last_compaction = nothing
-                current_state.compaction_kept_count = 0
+                current_state.persisted_prefix_count = length(current_state.messages)
+                current_state.persisted_prefix_start = 1
             elseif length(current_state.messages) > pre_eval_msg_count
                 # No compaction: save new messages as a single entry
                 new_messages = current_state.messages[pre_eval_msg_count + 1:end]
@@ -261,9 +288,11 @@ function session_middleware(agent_handler::AgentHandler, store::Union{Nothing, S
                     channel_id = ch_id,
                     search_channel_id = sch_id,
                     channel_flags = ch_flags,
+                    post_id = captured_eid,
                 )
                 append_entry!(store, eval_entry)
-                set_branch_leaf!(store, bid, final_eid)
+                set_branch_leaf!(store, bid, eval_entry.id)
+                current_state.persisted_prefix_count = length(current_state.messages)
             end
 
             return current_state

--- a/Agentif/src/session.jl
+++ b/Agentif/src/session.jl
@@ -105,6 +105,15 @@ function _collect_lineage(store::SessionStore, leaf_entry_id::String)
         push!(seen, current_id)
         entry = get_entry(store, current_id)
         entry === nothing && break
+
+        # The newest compaction summary replaces every older summary. Keep
+        # walking through an older compaction's parent to reach the retained
+        # entries, but never replay that stale summary.
+        if entry.is_compaction && compaction_idx != 0
+            current_id = entry.parent_id
+            continue
+        end
+
         push!(entries, entry)
 
         if entry.is_compaction && compaction_idx == 0

--- a/Agentif/src/session.jl
+++ b/Agentif/src/session.jl
@@ -12,6 +12,10 @@ abstract type SessionStore end
     channel_id::Union{Nothing, String} = nothing
     search_channel_id::Union{Nothing, String} = nothing
     channel_flags::Union{Nothing, Int} = nothing
+    # Platform message id this entry was produced from. Entry ids must be unique
+    # (several evaluations can share one incoming message), so `scrub_post!`
+    # matches on this instead of on the entry id.
+    post_id::Union{Nothing, String} = nothing
 end
 
 struct EntryBoundary
@@ -94,8 +98,11 @@ function _collect_lineage(store::SessionStore, leaf_entry_id::String)
     compaction_idx = 0
     stop_at = nothing
     current_id = leaf_entry_id
+    seen = Set{String}()
 
     while current_id !== nothing
+        current_id in seen && break  # corrupt parent chain; never loop forever
+        push!(seen, current_id)
         entry = get_entry(store, current_id)
         entry === nothing && break
         push!(entries, entry)
@@ -225,14 +232,30 @@ end
 # Default no-op: scrub_post! is implemented by store types that support it
 scrub_post!(store::SessionStore, post_id::String) = nothing
 
+# Content-free copy of an entry: keeps its place (and role) in the entry tree so
+# lineage walks still resolve, but drops everything that could be replayed.
+function scrubbed_entry(entry::SessionEntry)
+    return SessionEntry(;
+        id = entry.id, parent_id = entry.parent_id, created_at = entry.created_at,
+        is_compaction = entry.is_compaction, first_kept_entry_id = entry.first_kept_entry_id,
+        is_deleted = true, channel_id = entry.channel_id,
+        search_channel_id = entry.search_channel_id, channel_flags = entry.channel_flags,
+        post_id = entry.post_id,
+    )
+end
+
+# An entry matches a scrub request when it was produced from that platform post.
+# Entries written before `post_id` existed used the post id as the entry id.
+entry_matches_post(entry::SessionEntry, post_id::String) =
+    entry.post_id === nothing ? entry.id == post_id : entry.post_id == post_id
+
 function scrub_post!(store::InMemorySessionStore, post_id::String)
     lock(store.lock) do
-        entry = get(store.entries, post_id, nothing)
-        entry === nothing && return
-        store.entries[post_id] = SessionEntry(;
-            id=entry.id, parent_id=entry.parent_id, created_at=entry.created_at,
-            is_deleted=true, channel_id=entry.channel_id,
-            search_channel_id=entry.search_channel_id, channel_flags=entry.channel_flags,
-        )
+        for (eid, entry) in collect(store.entries)
+            entry.is_deleted && continue
+            entry_matches_post(entry, post_id) || continue
+            store.entries[eid] = scrubbed_entry(entry)
+        end
     end
+    return nothing
 end

--- a/Agentif/test/runtests.jl
+++ b/Agentif/test/runtests.jl
@@ -135,6 +135,72 @@ function make_base_handler(; with_tool_call::Bool = false, call_counter = Ref(0)
     end
 end
 
+# ── Compaction/session integration helpers ──
+
+# Minimal openai-completions SSE body carrying a single assistant text.
+function summary_sse_body(text::String)
+    chunks = String[]
+    isempty(text) || push!(chunks, "data: " * JSON.json((; choices = [(; index = 0, delta = (; content = text), finish_reason = nothing)])))
+    push!(chunks, "data: " * JSON.json((; choices = [(; index = 0, delta = (;), finish_reason = "stop")])))
+    push!(chunks, "data: [DONE]")
+    return join(chunks, "\n\n") * "\n\n"
+end
+
+# Mock provider used for compaction's summarization call.
+function start_summary_server(; summary_text::String = "SUMMARY", status::Int = 200,
+        error_message::String = "bad request", hits = Ref(0))
+    server = HTTP.serve!("127.0.0.1", 0) do req
+        hits[] += 1
+        status == 200 || return HTTP.Response(
+            status,
+            ["Content-Type" => "application/json"],
+            JSON.json(Dict("error" => Dict("message" => error_message))),
+        )
+        return HTTP.Response(200, ["Content-Type" => "text/event-stream"], summary_sse_body(summary_text))
+    end
+    port = HTTP.Sockets.getsockname(server.listener.server)[2]
+    return server, port
+end
+
+function compaction_test_model(port::Integer; contextWindow::Int)
+    return Model(
+        id = "test-model", name = "test-model", api = "openai-completions",
+        provider = "test", baseUrl = "http://127.0.0.1:$port", reasoning = false,
+        input = ["text"],
+        cost = Dict("input" => 0.0, "output" => 0.0, "cacheRead" => 0.0, "cacheWrite" => 0.0),
+        contextWindow = contextWindow, maxTokens = 4096,
+    )
+end
+
+# Base handler with a scripted per-call usage/tool-call program. Records the
+# messages it was handed on every call so tests can assert what the LLM would
+# have seen.
+function scripted_handler(; usage_inputs::Vector{Int} = Int[], tool_turns = Set{Int}(),
+        calls = Ref(0), observed = Vector{Vector{AgentMessage}}())
+    return function (f, agent::Agent, state::AgentState, input::Agentif.AgentTurnInput, abort::Agentif.Abort; kw...)
+        calls[] += 1
+        n = calls[]
+        push!(observed, copy(state.messages))
+        msg = AssistantMessage(; provider = "test", api = "test", model = "test")
+        Agentif.append_text!(msg, "reply-$n")
+        args = "{\"text\":\"t\"}"
+        n in tool_turns && push!(msg.tool_calls, AgentToolCall(; call_id = "call-$n", name = "echo_back", arguments = args))
+        tokens = n <= length(usage_inputs) ? usage_inputs[n] : 0
+        Agentif.append_state!(state, input, msg, Usage(; input = tokens, total = tokens))
+        if n in tool_turns
+            state.pending_tool_calls = Agentif.PendingToolCall[Agentif.PendingToolCall(; call_id = "call-$n", name = "echo_back", arguments = args)]
+            state.most_recent_stop_reason = :tool_calls
+        else
+            state.pending_tool_calls = Agentif.PendingToolCall[]
+            state.most_recent_stop_reason = :stop
+        end
+        return state
+    end
+end
+
+message_signatures(messages::Vector{AgentMessage}) = [(typeof(m), message_text(m)) for m in messages]
+message_signatures(state::AgentState) = message_signatures(state.messages)
+
 struct SessionTestChannel <: Agentif.AbstractChannel
     id::String
     user::Union{Nothing, Agentif.ChannelUser}
@@ -834,7 +900,9 @@ end
             push!(state.messages, compaction_msg)
             push!(state.messages, UserMessage("kept"))
             state.last_compaction = compaction_msg
-            state.compaction_kept_count = 1
+            # "kept" was produced during this evaluation, so nothing of the
+            # persisted prefix survived the cut.
+            state.persisted_prefix_count = 0
             # Also add the assistant response
             msg = AssistantMessage(; provider = "test", api = "test", model = "test")
             Agentif.append_text!(msg, "response")
@@ -852,10 +920,13 @@ end
         # Verify last_compaction was cleared
         @test result.last_compaction === nothing
 
-        # Loading branch should produce the compacted state
+        # Loading the branch reproduces the in-memory state exactly — including
+        # the kept message, which used to be dropped from persistence.
         loaded = load_branch(store, "chan:compact")
         @test loaded.messages[1] isa CompactionSummaryMessage
         @test loaded.messages[1].summary == "compacted"
+        @test message_signatures(loaded) == message_signatures(result)
+        @test any(m -> m isa UserMessage && message_text(m) == "kept", loaded.messages)
     end
 
     @testset "compaction_middleware passthrough" begin
@@ -1003,6 +1074,356 @@ end
         @test config.reserve_tokens == 16384
         @test config.keep_recent_tokens == 20000
     end
+
+    @testset "context overflow detection" begin
+        @test Agentif.is_context_overflow_error("This model's maximum context length is 8192 tokens")
+        @test Agentif.is_context_overflow_error("prompt is too long: 210000 tokens > 200000")
+        @test Agentif.is_context_overflow_error(ErrorException("Requested tokens exceed context window"))
+        @test !Agentif.is_context_overflow_error("rate limit exceeded")
+        @test !Agentif.is_context_overflow_error(ErrorException("invalid api key"))
+    end
+
+    @testset "estimate_context_tokens" begin
+        msgs = AgentMessage[UserMessage("a" ^ 400), UserMessage("b" ^ 400)]
+        @test Agentif.estimate_context_tokens(msgs) == 200
+        @test Agentif.estimate_context_tokens(AgentMessage[]) == 0
+        state = AgentState(; messages = msgs)
+        @test Agentif.current_context_tokens(state) == 200
+        state.context_tokens = 5000
+        @test Agentif.current_context_tokens(state) == 5000
+    end
+end
+
+# ── Compaction × session persistence ──
+#
+# These drive the real middleware stack (evaluate → session_middleware →
+# tool_call_middleware → compaction_middleware → scripted base handler) with a
+# mock provider serving the summarization call.
+
+new_sqlite_store() = Agentif.SQLiteSessionStore(tempname(); embed = nothing)
+
+const SESSION_STORE_FACTORIES = [
+    ("in-memory", () -> InMemorySessionStore()),
+    ("sqlite", new_sqlite_store),
+]
+
+@testset "compaction mid-evaluation round-trips through $label store" for (label, make_store) in SESSION_STORE_FACTORIES
+    hits = Ref(0)
+    server, port = start_summary_server(; summary_text = "SUMMARY-OF-OLD", hits)
+    try
+        store = make_store()
+        model = compaction_test_model(port; contextWindow = 1000)
+        tool = @tool "Echo text." echo_back(text::String) = "echoed"
+        agent = Agent(; id = "a", prompt = "p", model = model, apikey = "k", tools = [tool])
+        # threshold = 1000 - 200 = 800
+        config = CompactionConfig(; enabled = true, reserve_tokens = 200, keep_recent_tokens = 100)
+        calls = Ref(0)
+        observed = Vector{Vector{AgentMessage}}()
+        # call 3 (first call of the third evaluation) reports a context over the
+        # threshold and requests a tool, so compaction fires mid-evaluation.
+        base_handler = scripted_handler(; usage_inputs = [100, 100, 900, 100], tool_turns = Set([3]), calls, observed)
+
+        run_eval(msg_id, input) = Agentif.evaluate(
+            agent, input;
+            session_store = store, channel = SessionTestChannel("chan:mid", nothing, msg_id),
+            base_handler = base_handler, compaction_config = config,
+        )
+
+        run_eval("m1", "A" ^ 400)   # entry 1: [user, assistant]
+        run_eval("m2", "B" ^ 400)   # entry 2: [user, assistant]
+        result = run_eval("m3", "C" ^ 40)
+
+        @test calls[] == 4
+        @test hits[] == 1  # exactly one summarization call
+        @test result.messages[1] isa CompactionSummaryMessage
+        @test result.messages[1].summary == "SUMMARY-OF-OLD"
+
+        loaded = load_branch(store, "chan:mid")
+        # Invariant 1: reload == in-memory, message for message.
+        @test message_signatures(loaded) == message_signatures(result)
+        # The in-evaluation messages survived persistence (H1a).
+        @test any(m -> m isa UserMessage && message_text(m) == "C" ^ 40, loaded.messages)
+        @test count(m -> m isa AssistantMessage && message_text(m) == "reply-3", loaded.messages) == 1
+        # Kept pre-evaluation history appears exactly once, summarized history not at all (H1b).
+        @test count(m -> message_text(m) == "B" ^ 400, loaded.messages) == 1
+        @test !any(m -> message_text(m) == "A" ^ 400, loaded.messages)
+        @test count(m -> m isa CompactionSummaryMessage, loaded.messages) == 1
+        # Nothing lost: user turn, assistant turn, tool result, final assistant.
+        @test message_signatures(loaded) == [
+            (CompactionSummaryMessage, "SUMMARY-OF-OLD"),
+            (UserMessage, "B" ^ 400),
+            (AssistantMessage, "reply-2"),
+            (UserMessage, "C" ^ 40),
+            (AssistantMessage, "reply-3"),
+            (ToolResultMessage, "echoed"),
+            (AssistantMessage, "reply-4"),
+        ]
+
+        # Loading again from the same leaf is stable (no growth/duplication).
+        @test message_signatures(load_branch(store, "chan:mid")) == message_signatures(loaded)
+    finally
+        close(server)
+    end
+end
+
+@testset "restored over-threshold session compacts on the first call ($label)" for (label, make_store) in SESSION_STORE_FACTORIES
+    hits = Ref(0)
+    server, port = start_summary_server(; summary_text = "RESTORED-SUMMARY", hits)
+    try
+        store = make_store()
+        # threshold = 300 - 100 = 200; the two seeded evaluations estimate ~204
+        model = compaction_test_model(port; contextWindow = 300)
+        agent = Agent(; id = "a", prompt = "p", model = model, apikey = "k")
+        config = CompactionConfig(; enabled = true, reserve_tokens = 100, keep_recent_tokens = 100)
+        calls = Ref(0)
+        observed = Vector{Vector{AgentMessage}}()
+        # Every call reports zero usage: the trigger must come from the restored
+        # messages themselves, not from an in-process token counter.
+        base_handler = scripted_handler(; usage_inputs = Int[], calls, observed)
+
+        run_eval(msg_id, input) = Agentif.evaluate(
+            agent, input;
+            session_store = store, channel = SessionTestChannel("chan:restore", nothing, msg_id),
+            base_handler = base_handler, compaction_config = config,
+        )
+
+        run_eval("m1", "A" ^ 400)
+        run_eval("m2", "B" ^ 400)
+        result = run_eval("m3", "hello again")
+
+        @test hits[] == 1
+        # Invariant 4: the third evaluation compacted BEFORE its first LLM call.
+        @test length(observed) == 3
+        @test observed[3][1] isa CompactionSummaryMessage
+        @test message_signatures(observed[3]) == [
+            (CompactionSummaryMessage, "RESTORED-SUMMARY"),
+            (UserMessage, "B" ^ 400),
+            (AssistantMessage, "reply-2"),
+        ]
+        loaded = load_branch(store, "chan:restore")
+        @test message_signatures(loaded) == message_signatures(result)
+        @test !any(m -> message_text(m) == "A" ^ 400, loaded.messages)
+    finally
+        close(server)
+    end
+end
+
+@testset "failed summary leaves history intact ($mode)" for (mode, server_kw) in [
+        ("provider error", (; status = 400, error_message = "bad request")),
+        ("empty summary", (; summary_text = "")),
+        ("whitespace summary", (; summary_text = "   \n ")),
+    ]
+    hits = Ref(0)
+    server, port = start_summary_server(; hits, server_kw...)
+    try
+        store = InMemorySessionStore()
+        model = compaction_test_model(port; contextWindow = 300)
+        agent = Agent(; id = "a", prompt = "p", model = model, apikey = "k")
+        config = CompactionConfig(; enabled = true, reserve_tokens = 100, keep_recent_tokens = 100)
+        calls = Ref(0)
+        observed = Vector{Vector{AgentMessage}}()
+        base_handler = scripted_handler(; calls, observed)
+
+        run_eval(msg_id, input) = Agentif.evaluate(
+            agent, input;
+            session_store = store, channel = SessionTestChannel("chan:failsum", nothing, msg_id),
+            base_handler = base_handler, compaction_config = config,
+        )
+
+        run_eval("m1", "A" ^ 400)
+        run_eval("m2", "B" ^ 400)
+        result = @test_logs (:warn,) match_mode = :any run_eval("m3", "still here")
+
+        # Invariant 3: summarization was attempted and failed; nothing was lost.
+        @test hits[] >= 1
+        @test !any(m -> m isa CompactionSummaryMessage, result.messages)
+        @test result.most_recent_stop_reason == :stop
+        @test message_signatures(observed[3]) == [
+            (UserMessage, "A" ^ 400),
+            (AssistantMessage, "reply-1"),
+            (UserMessage, "B" ^ 400),
+            (AssistantMessage, "reply-2"),
+        ]
+        loaded = load_branch(store, "chan:failsum")
+        @test message_signatures(loaded) == message_signatures(result)
+        @test message_signatures(loaded) == [
+            (UserMessage, "A" ^ 400),
+            (AssistantMessage, "reply-1"),
+            (UserMessage, "B" ^ 400),
+            (AssistantMessage, "reply-2"),
+            (UserMessage, "still here"),
+            (AssistantMessage, "reply-3"),
+        ]
+    finally
+        close(server)
+    end
+end
+
+@testset "provider context overflow compacts and retries once" begin
+    server, port = start_summary_server(; summary_text = "OVERFLOW-SUMMARY")
+    try
+        # Threshold (100000 - 16384) is far above the estimate, so the only
+        # compaction that can happen is the one the overflow error triggers.
+        model = compaction_test_model(port; contextWindow = 100000)
+        agent = Agent(; id = "a", prompt = "p", model = model, apikey = "k")
+        config = CompactionConfig(; enabled = true, reserve_tokens = 16384, keep_recent_tokens = 4)
+
+        overflow_handler(overflow_calls) = function (f, agent::Agent, state::AgentState, input::Agentif.AgentTurnInput, abort::Agentif.Abort; kw...)
+            overflow_calls[] += 1
+            msg = AssistantMessage(; provider = "test", api = "test", model = "test")
+            if overflow_calls[] == 1
+                f(Agentif.AgentErrorEvent(ErrorException("prompt is too long: 210000 tokens > 200000 maximum")))
+                Agentif.append_state!(state, input, msg, Usage())
+                state.pending_tool_calls = Agentif.PendingToolCall[]
+                state.most_recent_stop_reason = :error
+                return state
+            end
+            Agentif.append_text!(msg, "recovered")
+            Agentif.append_state!(state, input, msg, Usage())
+            state.pending_tool_calls = Agentif.PendingToolCall[]
+            state.most_recent_stop_reason = :stop
+            return state
+        end
+
+        seed_messages() = AgentMessage[
+            UserMessage("O" ^ 4000),
+            let m = AssistantMessage(; provider = "t", api = "t", model = "t"); Agentif.append_text!(m, "a1"); m end,
+            UserMessage("recent-keep"),
+            let m = AssistantMessage(; provider = "t", api = "t", model = "t"); Agentif.append_text!(m, "a2"); m end,
+        ]
+
+        calls = Ref(0)
+        events = Agentif.AgentEvent[]
+        handler = compaction_middleware(overflow_handler(calls), config)
+        result = handler(ev -> push!(events, ev), agent, AgentState(; messages = seed_messages()), "hello", Abort())
+
+        @test calls[] == 2  # one failure, one retry — never more
+        @test result.messages[1] isa CompactionSummaryMessage
+        @test result.messages[1].summary == "OVERFLOW-SUMMARY"
+        @test message_text(Agentif.last_assistant_message(result)) == "recovered"
+        @test result.most_recent_stop_reason == :stop
+        # The rejected turn is not duplicated, and the overflow error is not
+        # surfaced because the retry succeeded.
+        @test count(m -> m isa UserMessage && message_text(m) == "hello", result.messages) == 1
+        @test !any(ev -> ev isa Agentif.AgentErrorEvent, events)
+
+        # Nothing to compact → the original error is surfaced and the failed
+        # turn's messages are left in place.
+        calls2 = Ref(0)
+        events2 = Agentif.AgentEvent[]
+        handler2 = compaction_middleware(overflow_handler(calls2), config)
+        result2 = handler2(ev -> push!(events2, ev), agent, AgentState(), "hello", Abort())
+        @test calls2[] == 1
+        @test !any(m -> m isa CompactionSummaryMessage, result2.messages)
+        @test count(ev -> ev isa Agentif.AgentErrorEvent, events2) == 1
+        @test count(m -> m isa UserMessage && message_text(m) == "hello", result2.messages) == 1
+
+        # A thrown overflow that compaction cannot fix keeps propagating.
+        throwing_handler = function (f, agent::Agent, state::AgentState, input::Agentif.AgentTurnInput, abort::Agentif.Abort; kw...)
+            throw(ErrorException("This model's maximum context length is 8192 tokens"))
+        end
+        handler3 = compaction_middleware(throwing_handler, config)
+        @test_throws ErrorException handler3(identity, agent, AgentState(), "hello", Abort())
+
+        # …but a thrown overflow with compactable history is retried.
+        calls4 = Ref(0)
+        retry_after_throw = function (f, agent::Agent, state::AgentState, input::Agentif.AgentTurnInput, abort::Agentif.Abort; kw...)
+            calls4[] += 1
+            calls4[] == 1 && throw(ErrorException("This model's maximum context length is 8192 tokens"))
+            msg = AssistantMessage(; provider = "test", api = "test", model = "test")
+            Agentif.append_text!(msg, "recovered-after-throw")
+            Agentif.append_state!(state, input, msg, Usage())
+            state.pending_tool_calls = Agentif.PendingToolCall[]
+            state.most_recent_stop_reason = :stop
+            return state
+        end
+        handler4 = compaction_middleware(retry_after_throw, config)
+        result4 = handler4(identity, agent, AgentState(; messages = seed_messages()), "hello", Abort())
+        @test calls4[] == 2
+        @test result4.messages[1] isa CompactionSummaryMessage
+        @test message_text(Agentif.last_assistant_message(result4)) == "recovered-after-throw"
+    finally
+        close(server)
+    end
+end
+
+@testset "compaction entry as branch leaf resumes with summary + kept ($label)" for (label, make_store) in SESSION_STORE_FACTORIES
+    store = make_store()
+    summary = CompactionSummaryMessage(; summary = "SUM", tokens_before = 10, compacted_at = 1.0)
+    append_entry!(store, SessionEntry(; id = "e1", messages = AgentMessage[UserMessage("discarded-old")]))
+    append_entry!(store, SessionEntry(; id = "e2", parent_id = "e1", messages = AgentMessage[UserMessage("kept-recent")]))
+    append_entry!(store, SessionEntry(;
+        id = "c1", parent_id = "e2", messages = AgentMessage[summary],
+        is_compaction = true, first_kept_entry_id = "e2",
+    ))
+    set_branch_leaf!(store, "branch-leaf", "c1")
+
+    # Invariant 2: leaf IS the compaction entry — summary + kept only.
+    loaded = load_branch(store, "branch-leaf")
+    @test message_signatures(loaded) == [(CompactionSummaryMessage, "SUM"), (UserMessage, "kept-recent")]
+
+    state, boundaries = load_branch_with_boundaries(store, "branch-leaf")
+    @test message_signatures(state) == message_signatures(loaded)
+    @test [b.entry_id for b in boundaries] == ["c1", "e2"]
+
+    # Everything compacted (no kept entries) stops at the compaction entry.
+    append_entry!(store, SessionEntry(;
+        id = "c2", parent_id = "e2", messages = AgentMessage[summary], is_compaction = true,
+    ))
+    set_branch_leaf!(store, "branch-all", "c2")
+    @test message_signatures(load_branch(store, "branch-all")) == [(CompactionSummaryMessage, "SUM")]
+end
+
+@testset "sqlite scrub_post! removes replayable content" begin
+    store = new_sqlite_store()
+    append_entry!(store, SessionEntry(; id = "s1", messages = AgentMessage[UserMessage("keep alpha")], post_id = "post-1"))
+    append_entry!(store, SessionEntry(; id = "s2", parent_id = "s1", messages = AgentMessage[UserMessage("secret bravo")], post_id = "post-2"))
+    append_entry!(store, SessionEntry(; id = "s3", parent_id = "s2", messages = AgentMessage[UserMessage("keep charlie")], post_id = "post-3"))
+    set_branch_leaf!(store, "branch-scrub", "s3")
+    @test length(load_branch(store, "branch-scrub").messages) == 3
+
+    scrub_post!(store, "post-2")
+
+    # Invariant 5: content is gone from the lineage, tree structure intact.
+    loaded = load_branch(store, "branch-scrub")
+    @test message_signatures(loaded) == [(UserMessage, "keep alpha"), (UserMessage, "keep charlie")]
+    @test !any(occursin("bravo", message_text(m)) for m in loaded.messages)
+    scrubbed = get_entry(store, "s2")
+    @test scrubbed !== nothing
+    @test isempty(scrubbed.messages)
+    @test scrubbed.is_deleted
+    @test scrubbed.parent_id == "s1"
+    @test get_entry(store, "s3").parent_id == "s2"
+    # Stored JSON no longer carries the message text at all.
+    row = iterate(SQLite.DBInterface.execute(store.db, "SELECT entry FROM session_entries WHERE entry_id = ?", ("s2",)))
+    @test !occursin("bravo", String(row[1].entry))
+    # Search doc removed.
+    results = LocalSearch.search(store.search_store, "secret bravo"; limit = 10)
+    @test !any(r -> r.id == "session:entry:s2", results)
+end
+
+@testset "queued evaluations persist distinctly and stay scrubbable ($label)" for (label, make_store) in SESSION_STORE_FACTORIES
+    store = make_store()
+    message_queue = Channel{Agentif.AgentTurnInput}(1)
+    put!(message_queue, "second message")
+    # Same channel object for both evaluations → same platform entry id.
+    ch = SessionTestChannel("chan:queued", nothing, "post-shared")
+    result = Agentif.evaluate(
+        make_agent(), "first message";
+        session_store = store, channel = ch, message_queue = message_queue,
+        base_handler = make_base_handler(), compaction_config = nothing,
+    )
+
+    # Invariant 6: both evaluations persisted (no UNIQUE violation, no clobber).
+    @test length(result.messages) == 4
+    loaded = load_branch(store, "chan:queued")
+    @test message_signatures(loaded) == message_signatures(result)
+    @test count(m -> m isa UserMessage && message_text(m) == "first message", loaded.messages) == 1
+    @test count(m -> m isa UserMessage && message_text(m) == "second message", loaded.messages) == 1
+
+    # …and scrubbing by the shared platform post id still clears both.
+    scrub_post!(store, "post-shared")
+    @test isempty(load_branch(store, "chan:queued").messages)
 end
 
 @testset "skills_middleware" begin

--- a/Agentif/test/runtests.jl
+++ b/Agentif/test/runtests.jl
@@ -198,7 +198,7 @@ function scripted_handler(; usage_inputs::Vector{Int} = Int[], tool_turns = Set{
     end
 end
 
-message_signatures(messages::Vector{AgentMessage}) = [(typeof(m), message_text(m)) for m in messages]
+message_signatures(messages::AbstractVector{<:AgentMessage}) = [(typeof(m), message_text(m)) for m in messages]
 message_signatures(state::AgentState) = message_signatures(state.messages)
 
 struct SessionTestChannel <: Agentif.AbstractChannel
@@ -210,6 +210,14 @@ end
 Agentif.channel_id(ch::SessionTestChannel) = ch.id
 Agentif.get_current_user(ch::SessionTestChannel) = ch.user
 Agentif.entry_id(ch::SessionTestChannel) = ch.message_id
+
+struct ProactiveSessionTestChannel <: Agentif.AbstractChannel
+    id::String
+    response_id::String
+end
+
+Agentif.channel_id(ch::ProactiveSessionTestChannel) = ch.id
+Agentif.response_entry_id(ch::ProactiveSessionTestChannel) = ch.response_id
 
 mutable struct StreamTestChannel <: Agentif.AbstractChannel
     id::String
@@ -1092,6 +1100,20 @@ end
         state.context_tokens = 5000
         @test Agentif.current_context_tokens(state) == 5000
     end
+
+    @testset "context token usage includes new cache writes" begin
+        state = AgentState(; usage = Usage(; input = 11, cacheRead = 13, cacheWrite = 17))
+        Agentif._record_context_tokens!(state, 7)
+        @test state.context_tokens == 34
+    end
+
+    @testset "persisted prefix excludes a leading compaction summary" begin
+        summary = CompactionSummaryMessage(; summary = "old", tokens_before = 10, compacted_at = 1.0)
+        state = AgentState(; messages = AgentMessage[summary, UserMessage("kept")])
+        Agentif._reset_persisted_prefix!(state)
+        @test state.persisted_prefix_start == 2
+        @test state.persisted_prefix_count == 1
+    end
 end
 
 # ── Compaction × session persistence ──
@@ -1271,7 +1293,9 @@ end
         overflow_handler(overflow_calls) = function (f, agent::Agent, state::AgentState, input::Agentif.AgentTurnInput, abort::Agentif.Abort; kw...)
             overflow_calls[] += 1
             msg = AssistantMessage(; provider = "test", api = "test", model = "test")
+            f(MessageStartEvent(:assistant, msg))
             if overflow_calls[] == 1
+                f(MessageEndEvent(:assistant, msg))
                 f(Agentif.AgentErrorEvent(ErrorException("prompt is too long: 210000 tokens > 200000 maximum")))
                 Agentif.append_state!(state, input, msg, Usage())
                 state.pending_tool_calls = Agentif.PendingToolCall[]
@@ -1279,6 +1303,8 @@ end
                 return state
             end
             Agentif.append_text!(msg, "recovered")
+            f(MessageUpdateEvent(:assistant, msg, :text, "recovered", nothing))
+            f(MessageEndEvent(:assistant, msg))
             Agentif.append_state!(state, input, msg, Usage())
             state.pending_tool_calls = Agentif.PendingToolCall[]
             state.most_recent_stop_reason = :stop
@@ -1306,9 +1332,11 @@ end
         # surfaced because the retry succeeded.
         @test count(m -> m isa UserMessage && message_text(m) == "hello", result.messages) == 1
         @test !any(ev -> ev isa Agentif.AgentErrorEvent, events)
+        @test count(ev -> ev isa MessageStartEvent, events) == 1
+        @test count(ev -> ev isa MessageEndEvent, events) == 1
 
         # Nothing to compact → the original error is surfaced and the failed
-        # turn's messages are left in place.
+        # turn's messages and lifecycle are left in place.
         calls2 = Ref(0)
         events2 = Agentif.AgentEvent[]
         handler2 = compaction_middleware(overflow_handler(calls2), config)
@@ -1316,6 +1344,8 @@ end
         @test calls2[] == 1
         @test !any(m -> m isa CompactionSummaryMessage, result2.messages)
         @test count(ev -> ev isa Agentif.AgentErrorEvent, events2) == 1
+        @test count(ev -> ev isa MessageStartEvent, events2) == 1
+        @test count(ev -> ev isa MessageEndEvent, events2) == 1
         @test count(m -> m isa UserMessage && message_text(m) == "hello", result2.messages) == 1
 
         # A thrown overflow that compaction cannot fix keeps propagating.
@@ -1342,6 +1372,156 @@ end
         @test calls4[] == 2
         @test result4.messages[1] isa CompactionSummaryMessage
         @test message_text(Agentif.last_assistant_message(result4)) == "recovered-after-throw"
+
+        # Once output is visible, retrying would duplicate it. Surface the
+        # overflow and preserve the single partial response instead.
+        progress_calls = Ref(0)
+        progress_handler = function (f, agent::Agent, state::AgentState, input::Agentif.AgentTurnInput, abort::Agentif.Abort; kw...)
+            progress_calls[] += 1
+            msg = AssistantMessage(; provider = "test", api = "test", model = "test")
+            f(MessageStartEvent(:assistant, msg))
+            Agentif.append_text!(msg, "partial")
+            f(MessageUpdateEvent(:assistant, msg, :text, "partial", nothing))
+            f(MessageEndEvent(:assistant, msg))
+            f(Agentif.AgentErrorEvent(ErrorException("prompt is too long after partial output")))
+            Agentif.append_state!(state, input, msg, Usage())
+            state.pending_tool_calls = Agentif.PendingToolCall[]
+            state.most_recent_stop_reason = :error
+            return state
+        end
+        progress_events = Agentif.AgentEvent[]
+        handler5 = compaction_middleware(progress_handler, config)
+        result5 = handler5(
+            ev -> push!(progress_events, ev), agent,
+            AgentState(; messages = seed_messages()), "hello", Abort(),
+        )
+        @test progress_calls[] == 1
+        @test !any(m -> m isa CompactionSummaryMessage, result5.messages)
+        @test count(ev -> ev isa Agentif.AgentErrorEvent, progress_events) == 1
+        @test count(ev -> ev isa MessageUpdateEvent, progress_events) == 1
+    finally
+        close(server)
+    end
+end
+
+@testset "newest compaction replaces older summaries ($label)" for (label, make_store) in SESSION_STORE_FACTORIES
+    store = make_store()
+    old_summary = CompactionSummaryMessage(; summary = "OLD-SUMMARY", tokens_before = 10, compacted_at = 1.0)
+    new_summary = CompactionSummaryMessage(; summary = "NEW-SUMMARY", tokens_before = 20, compacted_at = 2.0)
+    append_entry!(store, SessionEntry(; id = "e1", messages = AgentMessage[UserMessage("discarded")]))
+    append_entry!(store, SessionEntry(; id = "e2", parent_id = "e1", messages = AgentMessage[UserMessage("old-kept")]))
+    append_entry!(store, SessionEntry(; id = "e3", parent_id = "e2", messages = AgentMessage[UserMessage("new-kept")]))
+    append_entry!(store, SessionEntry(;
+        id = "c1", parent_id = "e3", messages = AgentMessage[old_summary],
+        is_compaction = true, first_kept_entry_id = "e2",
+    ))
+    append_entry!(store, SessionEntry(; id = "e4", parent_id = "c1", messages = AgentMessage[UserMessage("after-old")]))
+    append_entry!(store, SessionEntry(;
+        id = "c2", parent_id = "e4", messages = AgentMessage[new_summary],
+        is_compaction = true, first_kept_entry_id = "e3",
+    ))
+    set_branch_leaf!(store, "branch-two-compactions", "c2")
+
+    @test message_signatures(load_branch(store, "branch-two-compactions")) == [
+        (CompactionSummaryMessage, "NEW-SUMMARY"),
+        (UserMessage, "new-kept"),
+        (UserMessage, "after-old"),
+    ]
+end
+
+@testset "second compaction round-trips exactly ($label)" for (label, make_store) in SESSION_STORE_FACTORIES
+    hits = Ref(0)
+    server, port = start_summary_server(; summary_text = "NEW-SUMMARY", hits)
+    try
+        store = make_store()
+        old_summary = CompactionSummaryMessage(; summary = "OLD-SUMMARY", tokens_before = 100, compacted_at = 1.0)
+        append_entry!(store, SessionEntry(;
+            id = "old-kept", messages = AgentMessage[
+                UserMessage("A" ^ 400),
+                let msg = AssistantMessage(; provider = "test", api = "test", model = "test")
+                    Agentif.append_text!(msg, "old reply")
+                    msg
+                end,
+            ],
+        ))
+        append_entry!(store, SessionEntry(;
+            id = "new-kept", parent_id = "old-kept", messages = AgentMessage[
+                UserMessage("B" ^ 400),
+                let msg = AssistantMessage(; provider = "test", api = "test", model = "test")
+                    Agentif.append_text!(msg, "recent reply")
+                    msg
+                end,
+            ],
+        ))
+        append_entry!(store, SessionEntry(;
+            id = "old-compaction", parent_id = "new-kept", messages = AgentMessage[old_summary],
+            is_compaction = true, first_kept_entry_id = "old-kept",
+        ))
+        set_branch_leaf!(store, "branch:repeat", "old-compaction")
+
+        model = compaction_test_model(port; contextWindow = 280)
+        agent = Agent(; id = "a", prompt = "p", model = model, apikey = "k")
+        config = CompactionConfig(; enabled = true, reserve_tokens = 100, keep_recent_tokens = 100)
+        result = Agentif.evaluate(
+            agent, "next";
+            session_store = store, channel = SessionTestChannel("branch:repeat", nothing, "repeat-post"),
+            base_handler = scripted_handler(), compaction_config = config,
+        )
+
+        @test hits[] == 1
+        @test message_signatures(result) == [
+            (CompactionSummaryMessage, "NEW-SUMMARY"),
+            (UserMessage, "B" ^ 400),
+            (AssistantMessage, "recent reply"),
+            (UserMessage, "next"),
+            (AssistantMessage, "reply-1"),
+        ]
+        @test message_signatures(load_branch(store, "branch:repeat")) == message_signatures(result)
+        @test result.persisted_prefix_start == 2
+        @test result.persisted_prefix_count == length(result.messages) - 1
+    finally
+        close(server)
+    end
+end
+
+@testset "mid-entry compaction cut round-trips exactly ($label)" for (label, make_store) in SESSION_STORE_FACTORIES
+    server, port = start_summary_server(; summary_text = "MID-ENTRY-SUMMARY")
+    try
+        store = make_store()
+        append_entry!(store, SessionEntry(;
+            id = "combined-entry", messages = AgentMessage[
+                UserMessage("D" ^ 400),
+                let msg = AssistantMessage(; provider = "test", api = "test", model = "test")
+                    Agentif.append_text!(msg, "discarded reply")
+                    msg
+                end,
+                UserMessage("K" ^ 400),
+                let msg = AssistantMessage(; provider = "test", api = "test", model = "test")
+                    Agentif.append_text!(msg, "kept reply")
+                    msg
+                end,
+            ],
+        ))
+        set_branch_leaf!(store, "branch:mid-entry", "combined-entry")
+
+        model = compaction_test_model(port; contextWindow = 280)
+        agent = Agent(; id = "a", prompt = "p", model = model, apikey = "k")
+        config = CompactionConfig(; enabled = true, reserve_tokens = 100, keep_recent_tokens = 100)
+        result = Agentif.evaluate(
+            agent, "next";
+            session_store = store, channel = SessionTestChannel("branch:mid-entry", nothing, "mid-entry-post"),
+            base_handler = scripted_handler(), compaction_config = config,
+        )
+
+        @test message_signatures(result) == [
+            (CompactionSummaryMessage, "MID-ENTRY-SUMMARY"),
+            (UserMessage, "K" ^ 400),
+            (AssistantMessage, "kept reply"),
+            (UserMessage, "next"),
+            (AssistantMessage, "reply-1"),
+        ]
+        @test message_signatures(load_branch(store, "branch:mid-entry")) == message_signatures(result)
+        @test !any(m -> message_text(m) == "D" ^ 400, result.messages)
     finally
         close(server)
     end
@@ -1424,6 +1604,23 @@ end
     # …and scrubbing by the shared platform post id still clears both.
     scrub_post!(store, "post-shared")
     @test isempty(load_branch(store, "chan:queued").messages)
+end
+
+@testset "proactive response entries stay scrubbable ($label)" for (label, make_store) in SESSION_STORE_FACTORIES
+    store = make_store()
+    message_queue = Channel{Agentif.AgentTurnInput}(1)
+    put!(message_queue, "second proactive message")
+    ch = ProactiveSessionTestChannel("chan:proactive", "response-shared")
+    result = Agentif.evaluate(
+        make_agent(), "first proactive message";
+        session_store = store, channel = ch, message_queue = message_queue,
+        base_handler = make_base_handler(), compaction_config = nothing,
+    )
+
+    @test length(result.messages) == 4
+    @test message_signatures(load_branch(store, "chan:proactive")) == message_signatures(result)
+    scrub_post!(store, "response-shared")
+    @test isempty(load_branch(store, "chan:proactive").messages)
 end
 
 @testset "skills_middleware" begin


### PR DESCRIPTION
## Summary

Fix the compaction and session-persistence defects that could lose current-turn messages, replay summarized history, fail to compact restored sessions, or hang on repeated platform entry IDs.

- Derive compaction pressure from `AgentState` and retry one provider context overflow after a successful compaction.
- Keep failed or empty summary calls non-destructive and pass the active abort handle through summary generation.
- Track the exact persisted prefix across mid-evaluation and repeated compactions.
- Re-persist a kept suffix when a cut lands inside one stored entry, so reload matches the in-memory state exactly.
- Use one cycle-safe lineage walk for both stores and replay only the newest compaction summary.
- Give queued evaluations unique entry IDs while retaining their platform post ID for scrubbing.
- Rewrite scrubbed SQLite entry JSON without messages and remove its search document.

## Review fixes

The maintainer review found and fixed these additional root causes:

- Exclude a leading compaction summary from persisted-prefix counts.
- Skip older compaction summaries while following a newer summary's kept lineage.
- Preserve proactive response IDs in `post_id`, including collision-suffixed entries.
- Count cache-write tokens as context input.
- Buffer an empty failed stream lifecycle before an overflow retry.
- Do not retry an overflow after visible output, which would duplicate streamed content.
- Accept the concrete stored-message vector used by `AgentState`.
- Surface SQLite search-document deletion failures while the session row remains retryable.

## Validation

- Full Agentif test suite passed.
- Full monorepo suite passed:
  - LLMProviders
  - LLMOAuth
  - Agentif
  - LLMTools
  - Claw
- New regression coverage runs against both in-memory and SQLite stores.
- Covered repeated compaction, mid-entry cuts, overflow lifecycle handling, cache writes, proactive response IDs, queued ID collisions, lineage replay, failed summaries, and scrubbing.

Co-authored by Codex
