### PR TITLE
Juco: 10 eval-driven harness iterations + 10 REPL/UX iterations

### DIFF
--- a/Agentif/src/middleware.jl
+++ b/Agentif/src/middleware.jl
@@ -100,7 +100,10 @@ function evaluate_middleware(agent_handler::AgentHandler)
             if e isa CapturedException && e.ex isa AbortEvaluation
                 return result_state === nothing ? state : result_state
             end
-            @error "Agent evaluate failed" evaluate_id model = agent.model.id exception = (e, catch_backtrace())
+            if e isa InterruptException || (e isa CapturedException && e.ex isa InterruptException)
+                rethrow()
+            end
+            @debug "Agent evaluate failed" evaluate_id model = agent.model.id exception = (e, catch_backtrace())
             rethrow()
         finally
             if result_state !== nothing

--- a/Agentif/src/providers/openai_completions_adapter.jl
+++ b/Agentif/src/providers/openai_completions_adapter.jl
@@ -639,6 +639,10 @@ function openai_completions_event_callback(
                 saw_text = true
             end
         end
+        # When a delta carries reasoning_details with text, the details stream is
+        # canonical: providers (e.g. OpenRouter) also mirror the same text into the
+        # plain reasoning field, so processing both would double every token.
+        details_carried_text = false
         if delta.reasoning_details !== nothing
             if !started[]
                 started[] = true
@@ -651,6 +655,7 @@ function openai_completions_event_callback(
                 detail isa AbstractDict || continue
                 text = get(detail, "text", nothing)
                 text isa AbstractString || continue
+                details_carried_text = true
                 text_str = String(text)
                 if startswith(text_str, reasoning_buffer)
                     if isempty(reasoning_buffer)
@@ -680,24 +685,26 @@ function openai_completions_event_callback(
                 assistant_message.content[end].thinkingSignature = JSON.json(details_vec)
             end
         end
-        for field in (:reasoning_content, :reasoning, :reasoning_text)
-            value = getfield(delta, field)
-            if value !== nothing && !isempty(value)
-                if !started[]
-                    started[] = true
-                    f(MessageStartEvent(:assistant, assistant_message))
+        if !details_carried_text
+            for field in (:reasoning_content, :reasoning, :reasoning_text)
+                value = getfield(delta, field)
+                if value !== nothing && !isempty(value)
+                    if !started[]
+                        started[] = true
+                        f(MessageStartEvent(:assistant, assistant_message))
+                    end
+                    # Store field name as thinkingSignature so message building can
+                    # replay thinking to the correct field (matching pi-mono behavior).
+                    sig = string(field)
+                    if isempty(assistant_message.content) || !(assistant_message.content[end] isa ThinkingContent)
+                        push!(assistant_message.content, ThinkingContent(; thinking = value, thinkingSignature = sig))
+                    else
+                        block = assistant_message.content[end]
+                        block.thinking *= value
+                        block.thinkingSignature === nothing && (block.thinkingSignature = sig)
+                    end
+                    f(MessageUpdateEvent(:assistant, assistant_message, :reasoning, value, nothing))
                 end
-                # Store field name as thinkingSignature so message building can
-                # replay thinking to the correct field (matching pi-mono behavior).
-                sig = string(field)
-                if isempty(assistant_message.content) || !(assistant_message.content[end] isa ThinkingContent)
-                    push!(assistant_message.content, ThinkingContent(; thinking = value, thinkingSignature = sig))
-                else
-                    block = assistant_message.content[end]
-                    block.thinking *= value
-                    block.thinkingSignature === nothing && (block.thinkingSignature = sig)
-                end
-                f(MessageUpdateEvent(:assistant, assistant_message, :reasoning, value, nothing))
             end
         end
         if delta.tool_calls !== nothing

--- a/Agentif/src/providers/openai_completions_adapter.jl
+++ b/Agentif/src/providers/openai_completions_adapter.jl
@@ -199,9 +199,17 @@ function openai_completions_build_messages(agent::Agent, state::AgentState, inpu
     transformed = transform_messages(raw_messages, model; normalize_tool_call_id = normalize_tool_call_id)
     last_role = nothing
 
+    # Reasoning replay is round-scoped for OpenRouter-style models: reasoning
+    # must be passed back only within the current tool round (after the latest
+    # user message). Earlier rounds' chain-of-thought is dead weight that grows
+    # every request — DeepSeek et al. explicitly discard it server-side.
+    round_start = something(findlast(m -> m isa UserMessage || m isa CompactionSummaryMessage, transformed), 0)
+    round_scoped_reasoning = compat.thinkingFormat == "openrouter"
+
     i = 1
     while i <= length(transformed)
         msg = transformed[i]
+        stale_reasoning = round_scoped_reasoning && i < round_start
         if compat.requiresAssistantAfterToolResult && last_role == "toolResult" && msg isa UserMessage
             push!(messages, OpenAICompletions.Message(; role = "assistant", content = "I have processed the tool results."))
         end
@@ -257,7 +265,8 @@ function openai_completions_build_messages(agent::Agent, state::AgentState, inpu
                 end
             end
 
-            non_empty_thinking = [b for b in thinking_blocks if !isempty(strip(b.thinking))]
+            non_empty_thinking = stale_reasoning ? ThinkingContent[] :
+                [b for b in thinking_blocks if !isempty(strip(b.thinking))]
             if !isempty(non_empty_thinking)
                 if openai_completions_use_reasoning_split(model)
                     assistant_msg.reasoning_details = openai_completions_reasoning_details_from_blocks(non_empty_thinking)
@@ -282,16 +291,18 @@ function openai_completions_build_messages(agent::Agent, state::AgentState, inpu
 
             if !isempty(tool_calls)
                 assistant_msg.tool_calls = OpenAICompletions.ToolCall[openai_completions_tool_call_from_content(tc) for tc in tool_calls]
-                reasoning_details = Any[]
-                for tc in tool_calls
-                    tc.thoughtSignature === nothing && continue
-                    isempty(tc.thoughtSignature) && continue
-                    try
-                        push!(reasoning_details, JSON.parse(tc.thoughtSignature))
-                    catch
+                if !stale_reasoning
+                    reasoning_details = Any[]
+                    for tc in tool_calls
+                        tc.thoughtSignature === nothing && continue
+                        isempty(tc.thoughtSignature) && continue
+                        try
+                            push!(reasoning_details, JSON.parse(tc.thoughtSignature))
+                        catch
+                        end
                     end
+                    isempty(reasoning_details) || (assistant_msg.reasoning_details = reasoning_details)
                 end
-                isempty(reasoning_details) || (assistant_msg.reasoning_details = reasoning_details)
             end
 
             content = assistant_msg.content

--- a/Agentif/src/providers/openai_completions_adapter.jl
+++ b/Agentif/src/providers/openai_completions_adapter.jl
@@ -89,9 +89,11 @@ function openai_completions_reasoning_details_from_signature(signature::Union{No
 end
 
 function openai_completions_reasoning_details_from_blocks(blocks::Vector{ThinkingContent})
-    signature = blocks[1].thinkingSignature
-    parsed = openai_completions_reasoning_details_from_signature(signature)
-    parsed !== nothing && return parsed
+    # Streaming updates keep the complete detail sequence on the latest block.
+    for block in Iterators.reverse(blocks)
+        parsed = openai_completions_reasoning_details_from_signature(block.thinkingSignature)
+        parsed !== nothing && return parsed
+    end
     text = join((b.thinking for b in blocks), "\n\n")
     return [Dict("text" => text)]
 end
@@ -117,7 +119,6 @@ end
 
 function openai_completions_append_thinking_with_details!(assistant_message::AssistantMessage, details)
     text = openai_completions_reasoning_text(details)
-    isempty(text) && return
     signature = JSON.json(details)
     if isempty(assistant_message.content) || !(assistant_message.content[end] isa ThinkingContent)
         push!(assistant_message.content, ThinkingContent(; thinking = text, thinkingSignature = signature))
@@ -127,6 +128,29 @@ function openai_completions_append_thinking_with_details!(assistant_message::Ass
         block.thinkingSignature = signature
     end
     return
+end
+
+function openai_completions_without_reasoning(msg::AssistantMessage)
+    content = AssistantContentBlock[]
+    for block in msg.content
+        if block isa ThinkingContent
+            continue
+        elseif block isa ToolCallContent
+            push!(content, ToolCallContent(;
+                id = block.id, name = block.name, arguments = block.arguments,
+                thoughtSignature = nothing))
+        else
+            push!(content, block)
+        end
+    end
+    return AssistantMessage(;
+        response_id = msg.response_id,
+        provider = msg.provider,
+        api = msg.api,
+        model = msg.model,
+        content,
+        tool_calls = msg.tool_calls,
+    )
 end
 
 function openai_completions_build_tools(
@@ -196,20 +220,29 @@ function openai_completions_build_messages(agent::Agent, state::AgentState, inpu
         push!(messages, OpenAICompletions.Message(; role, content = system_prompt))
     end
 
-    transformed = transform_messages(raw_messages, model; normalize_tool_call_id = normalize_tool_call_id)
-    last_role = nothing
-
     # Reasoning replay is round-scoped for OpenRouter-style models: reasoning
     # must be passed back only within the current tool round (after the latest
     # user message). Earlier rounds' chain-of-thought is dead weight that grows
     # every request — DeepSeek et al. explicitly discard it server-side.
-    round_start = something(findlast(m -> m isa UserMessage || m isa CompactionSummaryMessage, transformed), 0)
     round_scoped_reasoning = compat.thinkingFormat == "openrouter"
+    if round_scoped_reasoning
+        round_start = something(findlast(
+            m -> m isa UserMessage || m isa CompactionSummaryMessage, raw_messages), 0)
+        for i in firstindex(raw_messages):(round_start - 1)
+            msg = raw_messages[i]
+            msg isa AssistantMessage || continue
+            # Remove stale thinking before transform_messages can downgrade
+            # unsigned or cross-model thinking into ordinary text.
+            raw_messages[i] = openai_completions_without_reasoning(msg)
+        end
+    end
+
+    transformed = transform_messages(raw_messages, model; normalize_tool_call_id = normalize_tool_call_id)
+    last_role = nothing
 
     i = 1
     while i <= length(transformed)
         msg = transformed[i]
-        stale_reasoning = round_scoped_reasoning && i < round_start
         if compat.requiresAssistantAfterToolResult && last_role == "toolResult" && msg isa UserMessage
             push!(messages, OpenAICompletions.Message(; role = "assistant", content = "I have processed the tool results."))
         end
@@ -265,10 +298,14 @@ function openai_completions_build_messages(agent::Agent, state::AgentState, inpu
                 end
             end
 
-            non_empty_thinking = stale_reasoning ? ThinkingContent[] :
-                [b for b in thinking_blocks if !isempty(strip(b.thinking))]
+            non_empty_thinking = [b for b in thinking_blocks if
+                !isempty(strip(b.thinking)) ||
+                    openai_completions_reasoning_details_from_signature(b.thinkingSignature) !== nothing]
             if !isempty(non_empty_thinking)
-                if openai_completions_use_reasoning_split(model)
+                has_openrouter_details = round_scoped_reasoning && any(
+                    b -> openai_completions_reasoning_details_from_signature(b.thinkingSignature) !== nothing,
+                    non_empty_thinking)
+                if openai_completions_use_reasoning_split(model) || has_openrouter_details
                     assistant_msg.reasoning_details = openai_completions_reasoning_details_from_blocks(non_empty_thinking)
                 elseif compat.requiresThinkingAsText
                     thinking_text = join((b.thinking for b in non_empty_thinking), "\n\n")
@@ -291,18 +328,16 @@ function openai_completions_build_messages(agent::Agent, state::AgentState, inpu
 
             if !isempty(tool_calls)
                 assistant_msg.tool_calls = OpenAICompletions.ToolCall[openai_completions_tool_call_from_content(tc) for tc in tool_calls]
-                if !stale_reasoning
-                    reasoning_details = Any[]
-                    for tc in tool_calls
-                        tc.thoughtSignature === nothing && continue
-                        isempty(tc.thoughtSignature) && continue
-                        try
-                            push!(reasoning_details, JSON.parse(tc.thoughtSignature))
-                        catch
-                        end
+                reasoning_details = Any[]
+                for tc in tool_calls
+                    tc.thoughtSignature === nothing && continue
+                    isempty(tc.thoughtSignature) && continue
+                    try
+                        push!(reasoning_details, JSON.parse(tc.thoughtSignature))
+                    catch
                     end
-                    isempty(reasoning_details) || (assistant_msg.reasoning_details = reasoning_details)
                 end
+                isempty(reasoning_details) || (assistant_msg.reasoning_details = reasoning_details)
             end
 
             content = assistant_msg.content
@@ -551,6 +586,7 @@ function openai_completions_event_callback(
         think_tag_state::Union{Nothing, ThinkTagStreamState} = nothing,
     ) where {F <: Function}
     reasoning_buffer = ""
+    reasoning_details_buffer = Any[]
     leading_whitespace = ""
     saw_text = false
     return function (stream, event)
@@ -661,6 +697,8 @@ function openai_completions_event_callback(
             end
             details = delta.reasoning_details
             details_vec = details isa AbstractVector ? details : Any[details]
+            append!(reasoning_details_buffer, details_vec)
+            details_signature = JSON.json(reasoning_details_buffer)
             new_text_parts = String[]
             for detail in details_vec
                 detail isa AbstractDict || continue
@@ -685,15 +723,20 @@ function openai_completions_event_callback(
             new_text = join(new_text_parts, "")
             if !isempty(new_text)
                 if isempty(assistant_message.content) || !(assistant_message.content[end] isa ThinkingContent)
-                    push!(assistant_message.content, ThinkingContent(; thinking = new_text, thinkingSignature = JSON.json(details_vec)))
+                    push!(assistant_message.content, ThinkingContent(; thinking = new_text, thinkingSignature = details_signature))
                 else
                     block = assistant_message.content[end]
                     block.thinking *= new_text
-                    block.thinkingSignature = JSON.json(details_vec)
+                    block.thinkingSignature = details_signature
                 end
                 f(MessageUpdateEvent(:assistant, assistant_message, :reasoning, new_text, nothing))
             elseif !isempty(assistant_message.content) && assistant_message.content[end] isa ThinkingContent
-                assistant_message.content[end].thinkingSignature = JSON.json(details_vec)
+                assistant_message.content[end].thinkingSignature = details_signature
+            else
+                # Encrypted and redacted details can carry no displayable text,
+                # but their exact structure is still required for tool replay.
+                push!(assistant_message.content,
+                    ThinkingContent(; thinking = "", thinkingSignature = details_signature))
             end
         end
         if !details_carried_text

--- a/Agentif/src/providers/openai_completions_adapter.jl
+++ b/Agentif/src/providers/openai_completions_adapter.jl
@@ -655,8 +655,8 @@ function openai_completions_event_callback(
                 detail isa AbstractDict || continue
                 text = get(detail, "text", nothing)
                 text isa AbstractString || continue
-                details_carried_text = true
                 text_str = String(text)
+                details_carried_text |= !isempty(text_str)
                 if startswith(text_str, reasoning_buffer)
                     if isempty(reasoning_buffer)
                         push!(new_text_parts, text_str)

--- a/Agentif/src/stream.jl
+++ b/Agentif/src/stream.jl
@@ -754,9 +754,10 @@ function stream(
             # so appending both would duplicate the thinking content.
             details_text = choice.message.reasoning_details === nothing ? "" :
                 openai_completions_reasoning_text(choice.message.reasoning_details)
-            if !isempty(details_text)
+            if choice.message.reasoning_details !== nothing
                 openai_completions_append_thinking_with_details!(assistant_message, choice.message.reasoning_details)
-            else
+            end
+            if isempty(details_text)
                 reasoning_parts = String[]
                 for field in (:reasoning_content, :reasoning, :reasoning_text)
                     value = getfield(choice.message, field)

--- a/Agentif/src/stream.jl
+++ b/Agentif/src/stream.jl
@@ -749,16 +749,20 @@ function stream(
                     !isempty(thinking) && append_thinking!(assistant_message, thinking)
                 end
             end
-            reasoning_parts = String[]
-            for field in (:reasoning_content, :reasoning, :reasoning_text)
-                value = getfield(choice.message, field)
-                value === nothing && continue
-                isempty(value) && continue
-                push!(reasoning_parts, value)
-            end
-            isempty(reasoning_parts) || append_thinking!(assistant_message, join(reasoning_parts, "\n\n"))
+            # reasoning_details is canonical when present: providers (e.g.
+            # OpenRouter) mirror the same text into the plain reasoning fields,
+            # so appending both would duplicate the thinking content.
             if choice.message.reasoning_details !== nothing
                 openai_completions_append_thinking_with_details!(assistant_message, choice.message.reasoning_details)
+            else
+                reasoning_parts = String[]
+                for field in (:reasoning_content, :reasoning, :reasoning_text)
+                    value = getfield(choice.message, field)
+                    value === nothing && continue
+                    isempty(value) && continue
+                    push!(reasoning_parts, value)
+                end
+                isempty(reasoning_parts) || append_thinking!(assistant_message, join(reasoning_parts, "\n\n"))
             end
             text = message_text(assistant_message)
             if !isempty(text)

--- a/Agentif/src/stream.jl
+++ b/Agentif/src/stream.jl
@@ -752,7 +752,9 @@ function stream(
             # reasoning_details is canonical when present: providers (e.g.
             # OpenRouter) mirror the same text into the plain reasoning fields,
             # so appending both would duplicate the thinking content.
-            if choice.message.reasoning_details !== nothing
+            details_text = choice.message.reasoning_details === nothing ? "" :
+                openai_completions_reasoning_text(choice.message.reasoning_details)
+            if !isempty(details_text)
                 openai_completions_append_thinking_with_details!(assistant_message, choice.message.reasoning_details)
             else
                 reasoning_parts = String[]

--- a/Agentif/test/runtests.jl
+++ b/Agentif/test/runtests.jl
@@ -3693,3 +3693,50 @@ end
         close(ws_server)
     end
 end
+
+@testset "openrouter reasoning_details deltas are not double-appended" begin
+    # OpenRouter mirrors each reasoning token into BOTH delta.reasoning and
+    # delta.reasoning_details[].text. The details stream is canonical; the
+    # plain field must be skipped for those deltas or every token doubles.
+    chunks = String[]
+    for tok in ("Let", " me", " think")
+        push!(chunks, "data: " * JSON.json((; choices = [(; index = 0,
+            delta = (; reasoning = tok,
+                reasoning_details = [Dict("type" => "reasoning.text", "text" => tok)]),
+            finish_reason = nothing)])))
+    end
+    push!(chunks, "data: " * JSON.json((; choices = [(; index = 0,
+        delta = (; content = "42"), finish_reason = nothing)])))
+    push!(chunks, "data: " * JSON.json((; choices = [(; index = 0, delta = (;), finish_reason = "stop")])))
+    push!(chunks, "data: [DONE]")
+    body = join(chunks, "\n\n") * "\n\n"
+
+    server = HTTP.serve!("127.0.0.1", 0) do req
+        return HTTP.Response(200, ["Content-Type" => "text/event-stream"], body)
+    end
+    try
+        port = test_server_port(server)
+        model = Model(
+            id = "test-reasoning", name = "test-reasoning", api = "openai-completions",
+            provider = "openrouter", baseUrl = "http://127.0.0.1:$port", reasoning = true,
+            input = ["text"],
+            cost = Dict("input" => 0.0, "output" => 0.0, "cacheRead" => 0.0, "cacheWrite" => 0.0),
+            contextWindow = 128000, maxTokens = 4096,
+            compat = Dict{String, Any}("thinkingFormat" => "openrouter"),
+        )
+        agent = Agent(prompt = "p", model = model, apikey = "k")
+        reasoning_deltas = String[]
+        state = stream(agent, AgentState(), "q", Abort()) do event
+            if event isa MessageUpdateEvent && event.kind == :reasoning
+                push!(reasoning_deltas, event.delta)
+            end
+        end
+        msg = state.messages[end]
+        thinking = join((b.thinking for b in msg.content if b isa Agentif.ThinkingContent), "")
+        @test thinking == "Let me think"
+        @test join(reasoning_deltas, "") == "Let me think"
+        @test Agentif.message_text(msg) == "42"
+    finally
+        close(server)
+    end
+end

--- a/Agentif/test/runtests.jl
+++ b/Agentif/test/runtests.jl
@@ -3705,6 +3705,11 @@ end
                 reasoning_details = [Dict("type" => "reasoning.text", "text" => tok)]),
             finish_reason = nothing)])))
     end
+    # Details without usable text must not suppress the plain reasoning fallback.
+    push!(chunks, "data: " * JSON.json((; choices = [(; index = 0,
+        delta = (; reasoning = " fallback",
+            reasoning_details = [Dict("type" => "reasoning.text", "text" => "")]),
+        finish_reason = nothing)])))
     push!(chunks, "data: " * JSON.json((; choices = [(; index = 0,
         delta = (; content = "42"), finish_reason = nothing)])))
     push!(chunks, "data: " * JSON.json((; choices = [(; index = 0, delta = (;), finish_reason = "stop")])))
@@ -3733,8 +3738,42 @@ end
         end
         msg = state.messages[end]
         thinking = join((b.thinking for b in msg.content if b isa Agentif.ThinkingContent), "")
-        @test thinking == "Let me think"
-        @test join(reasoning_deltas, "") == "Let me think"
+        @test thinking == "Let me think fallback"
+        @test join(reasoning_deltas, "") == "Let me think fallback"
+        @test Agentif.message_text(msg) == "42"
+    finally
+        close(server)
+    end
+end
+
+@testset "openrouter non-streaming reasoning falls back from metadata-only details" begin
+    body = JSON.json((;
+        id = "chatcmpl-test", object = "chat.completion", created = 0,
+        model = "test-reasoning",
+        choices = [(; index = 0,
+            message = (; role = "assistant", content = "42", reasoning = "fallback",
+                reasoning_details = [Dict("type" => "reasoning.encrypted", "data" => "sig")]),
+            finish_reason = "stop")],
+        usage = (; prompt_tokens = 1, completion_tokens = 2, total_tokens = 3),
+    ))
+    server = HTTP.serve!("127.0.0.1", 0) do req
+        return HTTP.Response(200, ["Content-Type" => "application/json"], body)
+    end
+    try
+        port = test_server_port(server)
+        model = Model(
+            id = "test-reasoning", name = "test-reasoning", api = "openai-completions",
+            provider = "openrouter", baseUrl = "http://127.0.0.1:$port", reasoning = true,
+            input = ["text"],
+            cost = Dict("input" => 0.0, "output" => 0.0, "cacheRead" => 0.0, "cacheWrite" => 0.0),
+            contextWindow = 128000, maxTokens = 4096,
+            compat = Dict{String, Any}("thinkingFormat" => "openrouter"),
+        )
+        agent = Agent(prompt = "p", model = model, apikey = "k")
+        state = stream(_ -> nothing, agent, AgentState(), "q", Abort(); stream = false)
+        msg = state.messages[end]
+        thinking = join((b.thinking for b in msg.content if b isa Agentif.ThinkingContent), "")
+        @test thinking == "fallback"
         @test Agentif.message_text(msg) == "42"
     finally
         close(server)

--- a/Agentif/test/runtests.jl
+++ b/Agentif/test/runtests.jl
@@ -3737,10 +3737,13 @@ end
             end
         end
         msg = state.messages[end]
-        thinking = join((b.thinking for b in msg.content if b isa Agentif.ThinkingContent), "")
+        thinking_blocks = [b for b in msg.content if b isa Agentif.ThinkingContent]
+        thinking = join((b.thinking for b in thinking_blocks), "")
         @test thinking == "Let me think fallback"
         @test join(reasoning_deltas, "") == "Let me think fallback"
         @test Agentif.message_text(msg) == "42"
+        details = JSON.parse(only(thinking_blocks).thinkingSignature)
+        @test [get(d, "text", nothing) for d in details] == ["Let", " me", " think", ""]
     finally
         close(server)
     end
@@ -3772,9 +3775,12 @@ end
         agent = Agent(prompt = "p", model = model, apikey = "k")
         state = stream(_ -> nothing, agent, AgentState(), "q", Abort(); stream = false)
         msg = state.messages[end]
-        thinking = join((b.thinking for b in msg.content if b isa Agentif.ThinkingContent), "")
+        thinking_blocks = [b for b in msg.content if b isa Agentif.ThinkingContent]
+        thinking = join((b.thinking for b in thinking_blocks), "")
         @test thinking == "fallback"
         @test Agentif.message_text(msg) == "42"
+        @test JSON.parse(only(thinking_blocks).thinkingSignature) ==
+            [Dict("type" => "reasoning.encrypted", "data" => "sig")]
     finally
         close(server)
     end
@@ -3790,24 +3796,56 @@ end
         compat = Dict{String, Any}("thinkingFormat" => "openrouter"),
     )
     agent = Agent(prompt = "p", model = model, apikey = "k")
-    mk_assistant(text, thinking) = AssistantMessage(;
-        provider = "openrouter", api = "openai-completions", model = "test-rr",
-        content = Agentif.AssistantContentBlock[
-            Agentif.ThinkingContent(; thinking, thinkingSignature = "reasoning"),
-            Agentif.TextContent(; text),
-        ])
+    old_details = [Dict("type" => "reasoning.text", "text" => "old thinking")]
+    current_details = [Dict("type" => "reasoning.encrypted", "data" => "current-sig")]
     state = AgentState()
     push!(state.messages, Agentif.UserMessage([Agentif.TextContent(; text = "round one")]))
-    push!(state.messages, mk_assistant("answer one", "old thinking"))
+    push!(state.messages, AssistantMessage(;
+        provider = "other", api = "openai-completions", model = "other-model",
+        content = Agentif.AssistantContentBlock[
+            # Cross-model and unsigned thinking becomes text in transform_messages;
+            # round scoping must remove it before that conversion.
+            Agentif.ThinkingContent(; thinking = "old unsigned thinking"),
+            Agentif.TextContent(; text = "answer one"),
+            Agentif.ToolCallContent(; id = "old-call", name = "bash", arguments = Dict("command" => "true"),
+                thoughtSignature = JSON.json(only(old_details))),
+        ]))
+    push!(state.messages, Agentif.ToolResultMessage(;
+        call_id = "old-call", name = "bash", content = [Agentif.TextContent(; text = "ok")], is_error = false))
     push!(state.messages, Agentif.UserMessage([Agentif.TextContent(; text = "round two")]))
-    push!(state.messages, mk_assistant("answer two", "current thinking"))
+    push!(state.messages, AssistantMessage(;
+        provider = "openrouter", api = "openai-completions", model = "test-rr",
+        content = Agentif.AssistantContentBlock[
+            Agentif.ThinkingContent(; thinking = "current thinking",
+                thinkingSignature = JSON.json(current_details)),
+            Agentif.ToolCallContent(; id = "current-call", name = "bash",
+                arguments = Dict("command" => "true")),
+        ]))
 
     messages, _ = Agentif.openai_completions_build_messages(agent, state, [Agentif.ToolResultMessage(;
-        call_id = "c1", name = "bash", content = [Agentif.TextContent(; text = "ok")], is_error = false)], model)
+        call_id = "current-call", name = "bash", content = [Agentif.TextContent(; text = "ok")], is_error = false)], model)
     assistants = [m for m in messages if m.role == "assistant"]
     @test length(assistants) == 2
     # prior-round reasoning dropped; current-round reasoning replayed
-    first_extra = assistants[1].extra
-    @test first_extra === nothing || !haskey(first_extra, "reasoning")
-    @test assistants[2].extra !== nothing && assistants[2].extra["reasoning"] == "current thinking"
+    first_content = assistants[1].content
+    @test !occursin("old unsigned thinking", JSON.json(first_content))
+    @test assistants[1].reasoning_details === nothing
+    @test assistants[2].reasoning_details == current_details
+
+    compacted = AgentState(messages = Agentif.StoredAgentMessage[
+        Agentif.CompactionSummaryMessage(; summary = "summary", tokens_before = 100, compacted_at = time()),
+        AssistantMessage(;
+            provider = "openrouter", api = "openai-completions", model = "test-rr",
+            content = Agentif.AssistantContentBlock[
+                Agentif.ThinkingContent(; thinking = "after summary",
+                    thinkingSignature = JSON.json(current_details)),
+                Agentif.ToolCallContent(; id = "summary-call", name = "bash",
+                    arguments = Dict("command" => "true")),
+            ]),
+    ])
+    compacted_messages, _ = Agentif.openai_completions_build_messages(
+        agent, compacted, [Agentif.ToolResultMessage(;
+            call_id = "summary-call", name = "bash",
+            content = [Agentif.TextContent(; text = "ok")], is_error = false)], model)
+    @test only(m.reasoning_details for m in compacted_messages if m.role == "assistant") == current_details
 end

--- a/Agentif/test/runtests.jl
+++ b/Agentif/test/runtests.jl
@@ -3779,3 +3779,35 @@ end
         close(server)
     end
 end
+
+@testset "openrouter reasoning replay is round-scoped" begin
+    model = Model(
+        id = "test-rr", name = "test-rr", api = "openai-completions",
+        provider = "openrouter", baseUrl = "http://localhost", reasoning = true,
+        input = ["text"],
+        cost = Dict("input" => 0.0, "output" => 0.0, "cacheRead" => 0.0, "cacheWrite" => 0.0),
+        contextWindow = 128000, maxTokens = 4096,
+        compat = Dict{String, Any}("thinkingFormat" => "openrouter"),
+    )
+    agent = Agent(prompt = "p", model = model, apikey = "k")
+    mk_assistant(text, thinking) = AssistantMessage(;
+        provider = "openrouter", api = "openai-completions", model = "test-rr",
+        content = Agentif.AssistantContentBlock[
+            Agentif.ThinkingContent(; thinking, thinkingSignature = "reasoning"),
+            Agentif.TextContent(; text),
+        ])
+    state = AgentState()
+    push!(state.messages, Agentif.UserMessage([Agentif.TextContent(; text = "round one")]))
+    push!(state.messages, mk_assistant("answer one", "old thinking"))
+    push!(state.messages, Agentif.UserMessage([Agentif.TextContent(; text = "round two")]))
+    push!(state.messages, mk_assistant("answer two", "current thinking"))
+
+    messages, _ = Agentif.openai_completions_build_messages(agent, state, [Agentif.ToolResultMessage(;
+        call_id = "c1", name = "bash", content = [Agentif.TextContent(; text = "ok")], is_error = false)], model)
+    assistants = [m for m in messages if m.role == "assistant"]
+    @test length(assistants) == 2
+    # prior-round reasoning dropped; current-round reasoning replayed
+    first_extra = assistants[1].extra
+    @test first_extra === nothing || !haskey(first_extra, "reasoning")
+    @test assistants[2].extra !== nothing && assistants[2].extra["reasoning"] == "current thinking"
+end

--- a/Agentif/test/runtests.jl
+++ b/Agentif/test/runtests.jl
@@ -88,6 +88,29 @@ function test_force_close_stream(http)
     error("Unable to find the test server stream transport")
 end
 
+@testset "evaluate interruption is not logged as a failure" begin
+    interrupted_handler = Agentif.evaluate_middleware(
+        (f, agent, state, input, abort; kw...) -> throw(InterruptException()))
+    logger = Test.TestLogger(; min_level = Logging.Error)
+    @test_throws InterruptException Logging.with_logger(logger) do
+        interrupted_handler(_ -> nothing, make_agent(), AgentState(), "stop", Abort())
+    end
+    @test isempty(logger.logs)
+end
+
+@testset "evaluate failures log only at debug level" begin
+    failed_handler = Agentif.evaluate_middleware(
+        (f, agent, state, input, abort; kw...) -> error("expected failure"))
+    logger = Test.TestLogger(; min_level = Logging.Debug)
+    @test_throws ErrorException Logging.with_logger(logger) do
+        failed_handler(_ -> nothing, make_agent(), AgentState(), "fail", Abort())
+    end
+    failure_logs = filter(log -> log.message == "Agent evaluate failed", logger.logs)
+    @test length(failure_logs) == 1
+    @test only(failure_logs).level == Logging.Debug
+    @test all(log -> log.level < Logging.Error, logger.logs)
+end
+
 function fake_jwt(payload::AbstractDict)
     encoded = Base64.base64encode(JSON.json(payload))
     encoded = replace(encoded, '+' => '-', '/' => '_')

--- a/Juco/Project.toml
+++ b/Juco/Project.toml
@@ -6,11 +6,16 @@ version = "0.2.0"
 Agentif = "b1e21dde-9d8e-492f-89d0-ee48af23bfc5"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+LLMOAuth = "f3f4c4b3-4b8a-4e8c-9b4f-7b8e4e6e5b2d"
 LLMProviders = "e1f4c4b3-4b8a-4e8c-9b4f-7b8e4e6e5b2a"
 LLMTools = "d2f4c4b3-4b8a-4e8c-9b4f-7b8e4e6e5b2c"
 LocalSearch = "3edf9609-13f2-4288-b0a3-8bd6d521158e"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
+REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 SQLite = "0aa819cd-b072-5ff4-a722-6bc24af294d9"
+
+[apps]
+juco = {}
 
 [weakdeps]
 ReplMaker = "b873ce64-0db9-51f5-a568-4457d8e49576"
@@ -20,6 +25,7 @@ JucoReplMakerExt = ["ReplMaker"]
 
 [sources]
 Agentif = {path = "../Agentif"}
+LLMOAuth = {path = "../LLMOAuth"}
 LLMProviders = {path = "../LLMProviders"}
 LLMTools = {path = "../LLMTools"}
 LocalSearch = {url = "https://github.com/quinnj/LocalSearch.jl.git"}

--- a/Juco/Project.toml
+++ b/Juco/Project.toml
@@ -33,6 +33,7 @@ LocalSearch = {url = "https://github.com/quinnj/LocalSearch.jl.git"}
 [compat]
 Agentif = "1"
 JSON = "1"
+LLMOAuth = "1"
 LLMProviders = "1"
 LLMTools = "1"
 LocalSearch = "0.1"

--- a/Juco/Project.toml
+++ b/Juco/Project.toml
@@ -5,10 +5,18 @@ version = "0.2.0"
 [deps]
 Agentif = "b1e21dde-9d8e-492f-89d0-ee48af23bfc5"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 LLMProviders = "e1f4c4b3-4b8a-4e8c-9b4f-7b8e4e6e5b2a"
 LLMTools = "d2f4c4b3-4b8a-4e8c-9b4f-7b8e4e6e5b2c"
 LocalSearch = "3edf9609-13f2-4288-b0a3-8bd6d521158e"
+Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 SQLite = "0aa819cd-b072-5ff4-a722-6bc24af294d9"
+
+[weakdeps]
+ReplMaker = "b873ce64-0db9-51f5-a568-4457d8e49576"
+
+[extensions]
+JucoReplMakerExt = ["ReplMaker"]
 
 [sources]
 Agentif = {path = "../Agentif"}
@@ -18,9 +26,11 @@ LocalSearch = {url = "https://github.com/quinnj/LocalSearch.jl.git"}
 
 [compat]
 Agentif = "1"
+JSON = "1"
 LLMProviders = "1"
 LLMTools = "1"
 LocalSearch = "0.1"
+ReplMaker = "0.2"
 SQLite = "1.6"
 julia = "1.11"
 

--- a/Juco/README.md
+++ b/Juco/README.md
@@ -37,6 +37,12 @@ Juco.main(["-p", "explain this repo", "--preset", "pi"])  # CLI form
 Juco.install_cli()               # write a `juco` shell launcher to ~/.local/bin
 ```
 
+On Julia 1.12 or later, the package entry point also runs directly:
+
+```sh
+julia --project=. -m Juco --help
+```
+
 Or live inside the standard Julia REPL, Pkg-style:
 
 ```julia
@@ -47,16 +53,21 @@ Juco.repl_mode!()   # press } at an empty julia> prompt for a juco> mode
 The REPL shows tool calls as compact one-liners (`▸ bash julia test.jl ✓ 0.4s`),
 streams model reasoning dimmed as it happens, renders final answers as Markdown,
 and prints a per-turn usage line (`⏱ 12s · 5 tools · 18k in (38% cached) · $0.002`).
-Slash commands: `/help`, `/new`, `/sessions`, `/resume`, `/model`, `/memories`.
+Slash commands: `/help`, `/new`, `/sessions`, `/resume`, `/model`, `/skills`, `/memories`.
 End a line with `\\` to continue on the next line. Ctrl-C interrupts the current
 response, not the session; `NO_COLOR` is respected.
 
-Configuration via environment: `JUCO_MODEL_PROVIDER` / `JUCO_MODEL` select the model
-(defaults: `anthropic` / `claude-sonnet-4-5`); the API key comes from the provider's
-conventional env var (`ANTHROPIC_API_KEY`, `XAI_API_KEY`, ...) or `JUCO_API_KEY`.
-`JUCO_REASONING` sets reasoning effort (e.g. `medium`); for OpenRouter models,
-`JUCO_OPENROUTER_ORDER` pins endpoint routing (stable routing keeps upstream
-prompt caches warm). See `Juco.main(["-h"])` for all CLI flags.
+Interactive sessions use the model state stored in SQLite. A new database starts
+in OpenRouter mode with `deepseek/deepseek-v4-flash-0731`; use `/model` to select
+and persist another OpenRouter or Codex model. Codex mode requires a prior
+`LLMOAuth.codex_login()`.
+
+For `Juco.evaluate` and one-shot CLI calls, `JUCO_MODEL_PROVIDER` / `JUCO_MODEL`
+select the model (defaults: `anthropic` / `claude-sonnet-4-5`). The API key comes
+from the provider's conventional environment variable (`ANTHROPIC_API_KEY`,
+`OPENROUTER_API_KEY`, ...) or `JUCO_API_KEY`. `JUCO_REASONING` sets reasoning
+effort. `JUCO_OPENROUTER_ORDER` pins OpenRouter endpoint routing. See
+`Juco.main(["-h"])` for all CLI flags.
 
 ## Eval
 

--- a/Juco/README.md
+++ b/Juco/README.md
@@ -34,12 +34,29 @@ using Juco
 Juco.repl()                      # interactive session
 Juco.evaluate("fix the bug")     # one programmatic turn
 Juco.main(["-p", "explain this repo", "--preset", "pi"])  # CLI form
+Juco.install_cli()               # write a `juco` shell launcher to ~/.local/bin
 ```
+
+Or live inside the standard Julia REPL, Pkg-style:
+
+```julia
+using Juco, ReplMaker
+Juco.repl_mode!()   # press } at an empty julia> prompt for a juco> mode
+```
+
+The REPL shows tool calls as compact one-liners (`▸ bash julia test.jl ✓ 0.4s`),
+streams model reasoning dimmed as it happens, renders final answers as Markdown,
+and prints a per-turn usage line (`⏱ 12s · 5 tools · 18k in (38% cached) · $0.002`).
+Slash commands: `/help`, `/new`, `/sessions`, `/resume`, `/model`, `/memories`.
+End a line with `\\` to continue on the next line. Ctrl-C interrupts the current
+response, not the session; `NO_COLOR` is respected.
 
 Configuration via environment: `JUCO_MODEL_PROVIDER` / `JUCO_MODEL` select the model
 (defaults: `anthropic` / `claude-sonnet-4-5`); the API key comes from the provider's
 conventional env var (`ANTHROPIC_API_KEY`, `XAI_API_KEY`, ...) or `JUCO_API_KEY`.
-See `Juco.main(["-h"])` for all CLI flags.
+`JUCO_REASONING` sets reasoning effort (e.g. `medium`); for OpenRouter models,
+`JUCO_OPENROUTER_ORDER` pins endpoint routing (stable routing keeps upstream
+prompt caches warm). See `Juco.main(["-h"])` for all CLI flags.
 
 ## Eval
 

--- a/Juco/eval/HISTORY.md
+++ b/Juco/eval/HISTORY.md
@@ -1,0 +1,6 @@
+# Eval run history
+
+| when | label | pass | calls | tokens in (cached) | tokens out | s |
+|---|---|---|---|---|---|---|
+| 2026-08-11 20:25 | r2-final-a | 21/21 | 107 | 287k (128k) | 16k | 320.8 |
+| 2026-08-11 20:31 | r2-final-b | 21/21 | 106 | 296k (139k) | 17k | 314.4 |

--- a/Juco/eval/env.jl
+++ b/Juco/eval/env.jl
@@ -1,17 +1,7 @@
-# Loads OPENROUTER_API_KEY from ~/league-easy/.env into ENV (if not already set)
-# and applies the eval model configuration.
+# Validates OPENROUTER_API_KEY and applies the pinned eval model configuration.
 function load_eval_env!()
-    if !haskey(ENV, "OPENROUTER_API_KEY")
-        envfile = joinpath(homedir(), "league-easy", ".env")
-        if isfile(envfile)
-            for line in eachline(envfile)
-                m = match(r"^\s*(?:export\s+)?OPENROUTER_API_KEY\s*=\s*\"?([^\"\s]+)\"?", line)
-                m === nothing && continue
-                ENV["OPENROUTER_API_KEY"] = m.captures[1]
-                break
-            end
-        end
-    end
+    isempty(get(ENV, "OPENROUTER_API_KEY", "")) &&
+        throw(ArgumentError("OPENROUTER_API_KEY must be set to run Juco evals"))
     ENV["JUCO_MODEL_PROVIDER"] = "openrouter"
     ENV["JUCO_MODEL"] = "deepseek/deepseek-v4-flash-0731"
     ENV["JUCO_REASONING"] = "medium"

--- a/Juco/eval/env.jl
+++ b/Juco/eval/env.jl
@@ -1,0 +1,19 @@
+# Loads OPENROUTER_API_KEY from ~/league-easy/.env into ENV (if not already set)
+# and applies the eval model configuration.
+function load_eval_env!()
+    if !haskey(ENV, "OPENROUTER_API_KEY")
+        envfile = joinpath(homedir(), "league-easy", ".env")
+        if isfile(envfile)
+            for line in eachline(envfile)
+                m = match(r"^\s*(?:export\s+)?OPENROUTER_API_KEY\s*=\s*\"?([^\"\s]+)\"?", line)
+                m === nothing && continue
+                ENV["OPENROUTER_API_KEY"] = m.captures[1]
+                break
+            end
+        end
+    end
+    ENV["JUCO_MODEL_PROVIDER"] = "openrouter"
+    ENV["JUCO_MODEL"] = "deepseek/deepseek-v4-flash-0731"
+    ENV["JUCO_REASONING"] = "medium"
+    return nothing
+end

--- a/Juco/eval/env.jl
+++ b/Juco/eval/env.jl
@@ -15,5 +15,9 @@ function load_eval_env!()
     ENV["JUCO_MODEL_PROVIDER"] = "openrouter"
     ENV["JUCO_MODEL"] = "deepseek/deepseek-v4-flash-0731"
     ENV["JUCO_REASONING"] = "medium"
+    # pin the eval to one endpoint: stable routing keeps upstream prompt caches
+    # warm and makes cost/latency comparable across runs (fp8 — the fp4
+    # endpoint was observed mangling tool calls)
+    ENV["JUCO_OPENROUTER_ORDER"] = "siliconflow/fp8"
     return nothing
 end

--- a/Juco/eval/history.jl
+++ b/Juco/eval/history.jl
@@ -1,0 +1,28 @@
+using Dates
+
+function validate_eval_label(label::AbstractString)
+    value = String(label)
+    occursin(r"^[A-Za-z0-9][A-Za-z0-9._-]*$", value) ||
+        throw(ArgumentError("eval label must use only letters, digits, '.', '_', or '-'"))
+    return value
+end
+
+# Append this run's aggregates to eval/HISTORY.md so the iteration record
+# lives in the repo, not in ephemeral terminal scrollback.
+function record_history(label::AbstractString, results;
+        path::AbstractString = joinpath(@__DIR__, "HISTORY.md"))
+    label = validate_eval_label(label)
+    passed = count(r -> r.passed, results)
+    calls = sum(r -> r.tool_calls, results; init = 0)
+    tin = sum(r -> r.tokens_in, results; init = 0)
+    tout = sum(r -> r.tokens_out, results; init = 0)
+    cached = sum(r -> get(r, :tokens_cached, 0), results; init = 0)
+    secs = round(sum(r -> r.seconds, results; init = 0.0); digits = 1)
+    fresh = !isfile(path)
+    open(path, "a") do io
+        fresh && println(io, "# Eval run history\n\n| when | label | pass | calls | tokens in (cached) | tokens out | s |\n|---|---|---|---|---|---|---|")
+        ts = Dates.format(Dates.now(), "yyyy-mm-dd HH:MM")
+        println(io, "| $(ts) | $(label) | $(passed)/$(length(results)) | $(calls) | $(round(Int, tin / 1000))k ($(round(Int, cached / 1000))k) | $(round(Int, tout / 1000))k | $(secs) |")
+    end
+    return nothing
+end

--- a/Juco/eval/iterate.jl
+++ b/Juco/eval/iterate.jl
@@ -4,15 +4,14 @@
 #   julia --project=. Juco/eval/iterate.jl <label> [task ...]
 #
 # Transcripts + a results summary land in <transcript_root>/<label>/.
-using Dates
-
 include(joinpath(@__DIR__, "env.jl"))
 load_eval_env!()
 include(joinpath(@__DIR__, "run.jl"))
+include(joinpath(@__DIR__, "history.jl"))
 
 function iterate_main(args)
     isempty(args) && error("usage: iterate.jl <label> [task ...]")
-    label = args[1]
+    label = validate_eval_label(args[1])
     root = get(ENV, "JUCO_EVAL_DIR", joinpath(tempdir(), "juco-evals"))
     transcript_dir = joinpath(root, label)
     mkpath(transcript_dir)
@@ -29,25 +28,6 @@ function iterate_main(args)
     println("transcripts: ", transcript_dir)
     record_history(label, results)
     return results
-end
-
-# Append this run's aggregates to eval/HISTORY.md so the iteration record
-# lives in the repo, not in ephemeral terminal scrollback.
-function record_history(label::AbstractString, results)
-    passed = count(r -> r.passed, results)
-    calls = sum(r -> r.tool_calls, results; init = 0)
-    tin = sum(r -> r.tokens_in, results; init = 0)
-    tout = sum(r -> r.tokens_out, results; init = 0)
-    cached = sum(r -> get(r, :tokens_cached, 0), results; init = 0)
-    secs = round(sum(r -> r.seconds, results; init = 0.0); digits = 1)
-    path = joinpath(@__DIR__, "HISTORY.md")
-    fresh = !isfile(path)
-    open(path, "a") do io
-        fresh && println(io, "# Eval run history\n\n| when | label | pass | calls | tokens in (cached) | tokens out | s |\n|---|---|---|---|---|---|---|")
-        ts = Dates.format(Dates.now(), "yyyy-mm-dd HH:MM")
-        println(io, "| $(ts) | $(label) | $(passed)/$(length(results)) | $(calls) | $(round(Int, tin / 1000))k ($(round(Int, cached / 1000))k) | $(round(Int, tout / 1000))k | $(secs) |")
-    end
-    return nothing
 end
 
 if abspath(PROGRAM_FILE) == @__FILE__

--- a/Juco/eval/iterate.jl
+++ b/Juco/eval/iterate.jl
@@ -4,6 +4,8 @@
 #   julia --project=. Juco/eval/iterate.jl <label> [task ...]
 #
 # Transcripts + a results summary land in <transcript_root>/<label>/.
+using Dates
+
 include(joinpath(@__DIR__, "env.jl"))
 load_eval_env!()
 include(joinpath(@__DIR__, "run.jl"))
@@ -25,7 +27,27 @@ function iterate_main(args)
         end
     end
     println("transcripts: ", transcript_dir)
+    record_history(label, results)
     return results
+end
+
+# Append this run's aggregates to eval/HISTORY.md so the iteration record
+# lives in the repo, not in ephemeral terminal scrollback.
+function record_history(label::AbstractString, results)
+    passed = count(r -> r.passed, results)
+    calls = sum(r -> r.tool_calls, results; init = 0)
+    tin = sum(r -> r.tokens_in, results; init = 0)
+    tout = sum(r -> r.tokens_out, results; init = 0)
+    cached = sum(r -> get(r, :tokens_cached, 0), results; init = 0)
+    secs = round(sum(r -> r.seconds, results; init = 0.0); digits = 1)
+    path = joinpath(@__DIR__, "HISTORY.md")
+    fresh = !isfile(path)
+    open(path, "a") do io
+        fresh && println(io, "# Eval run history\n\n| when | label | pass | calls | tokens in (cached) | tokens out | s |\n|---|---|---|---|---|---|---|")
+        ts = Dates.format(Dates.now(), "yyyy-mm-dd HH:MM")
+        println(io, "| $(ts) | $(label) | $(passed)/$(length(results)) | $(calls) | $(round(Int, tin / 1000))k ($(round(Int, cached / 1000))k) | $(round(Int, tout / 1000))k | $(secs) |")
+    end
+    return nothing
 end
 
 if abspath(PROGRAM_FILE) == @__FILE__

--- a/Juco/eval/iterate.jl
+++ b/Juco/eval/iterate.jl
@@ -1,0 +1,32 @@
+# Iteration driver: runs the full task suite on the :juco preset with the
+# pinned DeepSeek eval model and writes transcripts for close analysis.
+#
+#   julia --project=. Juco/eval/iterate.jl <label> [task ...]
+#
+# Transcripts + a results summary land in <transcript_root>/<label>/.
+include(joinpath(@__DIR__, "env.jl"))
+load_eval_env!()
+include(joinpath(@__DIR__, "run.jl"))
+
+function iterate_main(args)
+    isempty(args) && error("usage: iterate.jl <label> [task ...]")
+    label = args[1]
+    root = get(ENV, "JUCO_EVAL_DIR", joinpath(tempdir(), "juco-evals"))
+    transcript_dir = joinpath(root, label)
+    mkpath(transcript_dir)
+    tasks = length(args) > 1 ? filter(t -> t.name in args[2:end], TASKS) : TASKS
+    results = run_eval(; presets = [:juco], tasks, transcript_dir)
+    open(joinpath(transcript_dir, "results.txt"), "w") do io
+        for r in results
+            println(io, r.task, " ", r.passed ? "PASS" : "FAIL",
+                " calls=", r.tool_calls, " in=", r.tokens_in, " out=", r.tokens_out,
+                " s=", r.seconds, r.aborted ? " ABORTED" : "")
+        end
+    end
+    println("transcripts: ", transcript_dir)
+    return results
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    iterate_main(ARGS)
+end

--- a/Juco/eval/iterate.jl
+++ b/Juco/eval/iterate.jl
@@ -20,6 +20,7 @@ function iterate_main(args)
         for r in results
             println(io, r.task, " ", r.passed ? "PASS" : "FAIL",
                 " calls=", r.tool_calls, " in=", r.tokens_in, " out=", r.tokens_out,
+                " cached=", get(r, :tokens_cached, 0),
                 " s=", r.seconds, r.aborted ? " ABORTED" : "")
         end
     end

--- a/Juco/eval/run.jl
+++ b/Juco/eval/run.jl
@@ -11,21 +11,56 @@
 # runs are independent (no memory/session bleed between tasks).
 
 using Juco
+using Agentif
 
 include(joinpath(@__DIR__, "tasks.jl"))
 
-function run_one(task, preset::Symbol; verbose::Bool = false, max_turns::Int = 25, kw...)
+# Transcript writer: records assistant reasoning/text/tool calls and tool
+# results to a plain-text file so eval runs can be analyzed closely.
+function transcript_recorder(io::IO)
+    return function (event)
+        if event isa Agentif.MessageEndEvent && event.message isa Agentif.AssistantMessage
+            for block in event.message.content
+                if block isa Agentif.ThinkingContent && !isempty(block.thinking)
+                    println(io, "--- reasoning ---\n", block.thinking)
+                elseif block isa Agentif.TextContent && !isempty(block.text)
+                    println(io, "--- assistant ---\n", block.text)
+                end
+            end
+        elseif event isa Agentif.ToolExecutionStartEvent
+            println(io, "--- tool call: ", event.tool_call.name, " ---\n", event.tool_call.arguments)
+        elseif event isa Agentif.ToolExecutionEndEvent
+            text = join((b.text for b in event.result.content if b isa Agentif.TextContent), "\n")
+            length(text) > 3000 && (text = first(text, 3000) * "\n...[transcript-truncated]")
+            println(io, "--- tool result", event.result.is_error ? " (ERROR)" : "",
+                " (", event.duration_ms, "ms) ---\n", text)
+        elseif event isa Agentif.AgentErrorEvent
+            println(io, "--- agent error ---\n", event.error)
+        end
+        flush(io)
+        return nothing
+    end
+end
+
+function run_one(task, preset::Symbol; verbose::Bool = false, max_turns::Int = 25,
+        transcript_dir::Union{Nothing, String} = nothing, kw...)
     mktempdir() do dir
         task.setup(dir)
         jdb = Juco.opendb(joinpath(mktempdir(), "eval.sqlite"))
         io = verbose ? stdout : devnull
+        tio = transcript_dir === nothing ? nothing :
+            open(joinpath(transcript_dir, "$(preset)-$(task.name).txt"), "w")
         t0 = time()
         result = try
             Juco.evaluate(task.prompt;
-                base_dir = dir, jdb, preset, io, show_tools = verbose, max_turns, kw...)
+                base_dir = dir, jdb, preset, io, show_tools = verbose, max_turns,
+                on_event = tio === nothing ? nothing : transcript_recorder(tio), kw...)
         catch e
             verbose && showerror(stderr, e, catch_backtrace())
+            tio === nothing || println(tio, "--- runner exception ---\n", sprint(showerror, e))
             nothing
+        finally
+            tio === nothing || close(tio)
         end
         elapsed = time() - t0
         passed = try
@@ -45,11 +80,13 @@ function run_one(task, preset::Symbol; verbose::Bool = false, max_turns::Int = 2
     end
 end
 
-function run_eval(; presets = [:bash, :juco, :pi], tasks = TASKS, verbose::Bool = false, kw...)
+function run_eval(; presets = [:bash, :juco, :pi], tasks = TASKS, verbose::Bool = false,
+        transcript_dir::Union{Nothing, String} = nothing, kw...)
+    transcript_dir === nothing || mkpath(transcript_dir)
     results = []
     for preset in presets, task in tasks
         print(stderr, "running $(preset)/$(task.name) ... ")
-        r = run_one(task, preset; verbose, kw...)
+        r = run_one(task, preset; verbose, transcript_dir, kw...)
         println(stderr, r.passed ? "PASS" : "FAIL", " ($(r.tool_calls) calls, $(r.seconds)s)")
         push!(results, r)
     end

--- a/Juco/eval/run.jl
+++ b/Juco/eval/run.jl
@@ -83,6 +83,7 @@ function run_one(task, preset::Symbol; verbose::Bool = false, max_turns::Int = 2
             aborted = result === nothing ? true : result.aborted,
             tokens_in = usage === nothing ? 0 : usage.input + usage.cacheRead + usage.cacheWrite,
             tokens_out = usage === nothing ? 0 : usage.output,
+            tokens_cached = usage === nothing ? 0 : usage.cacheRead,
             seconds = round(elapsed; digits = 1),
         )
     end

--- a/Juco/eval/run.jl
+++ b/Juco/eval/run.jl
@@ -54,15 +54,18 @@ function run_one(task, preset::Symbol; verbose::Bool = false, max_turns::Int = 2
         transcript_dir::Union{Nothing, String} = nothing, kw...)
     mktempdir() do dir
         task.setup(dir)
-        jdb = Juco.opendb(joinpath(mktempdir(), "eval.sqlite"))
         io = verbose ? stdout : devnull
         tio = transcript_dir === nothing ? nothing :
             open(joinpath(transcript_dir, "$(preset)-$(task.name).txt"), "w")
         t0 = time()
         result = try
-            Juco.evaluate(task.prompt;
-                base_dir = dir, jdb, preset, io, show_tools = verbose, max_turns,
-                on_event = tio === nothing ? nothing : transcript_recorder(tio), kw...)
+            mktempdir() do db_dir
+                Juco.with_jdb(joinpath(db_dir, "eval.sqlite")) do jdb
+                    Juco.evaluate(task.prompt;
+                        base_dir = dir, jdb, preset, io, show_tools = verbose, max_turns,
+                        on_event = tio === nothing ? nothing : transcript_recorder(tio), kw...)
+                end
+            end
         catch e
             verbose && showerror(stderr, e, catch_backtrace())
             tio === nothing || println(tio, "--- runner exception ---\n", sprint(showerror, e))

--- a/Juco/eval/run.jl
+++ b/Juco/eval/run.jl
@@ -17,8 +17,17 @@ include(joinpath(@__DIR__, "tasks.jl"))
 
 # Transcript writer: records assistant reasoning/text/tool calls and tool
 # results to a plain-text file so eval runs can be analyzed closely.
+# Tool events fire from concurrent tasks, so writes are serialized by a lock.
 function transcript_recorder(io::IO)
+    lk = ReentrantLock()
     return function (event)
+        lock(lk) do
+            _record_event(io, event)
+        end
+    end
+end
+
+function _record_event(io::IO, event)
         if event isa Agentif.MessageEndEvent && event.message isa Agentif.AssistantMessage
             for block in event.message.content
                 if block isa Agentif.ThinkingContent && !isempty(block.thinking)
@@ -34,12 +43,11 @@ function transcript_recorder(io::IO)
             length(text) > 3000 && (text = first(text, 3000) * "\n...[transcript-truncated]")
             println(io, "--- tool result", event.result.is_error ? " (ERROR)" : "",
                 " (", event.duration_ms, "ms) ---\n", text)
-        elseif event isa Agentif.AgentErrorEvent
-            println(io, "--- agent error ---\n", event.error)
-        end
-        flush(io)
-        return nothing
+    elseif event isa Agentif.AgentErrorEvent
+        println(io, "--- agent error ---\n", event.error)
     end
+    flush(io)
+    return nothing
 end
 
 function run_one(task, preset::Symbol; verbose::Bool = false, max_turns::Int = 25,

--- a/Juco/eval/run.jl
+++ b/Juco/eval/run.jl
@@ -5,7 +5,7 @@
 #   julia --project=. Juco/eval/run.jl --preset juco         # one preset
 #   julia --project=. Juco/eval/run.jl --task fix-bug -v     # one task, verbose
 #
-# Model selection: JUCO_PROVIDER / JUCO_MODEL / JUCO_API_KEY (or provider key env).
+# Model selection: JUCO_MODEL_PROVIDER / JUCO_MODEL / JUCO_API_KEY (or provider key env).
 #
 # Each run gets a fresh temp working directory and a fresh temp sqlite db, so
 # runs are independent (no memory/session bleed between tasks).

--- a/Juco/eval/tasks.jl
+++ b/Juco/eval/tasks.jl
@@ -421,16 +421,19 @@ const TASKS = [
             using Test
             small = render_rows(3)
             @test small == "row 1: 1\\nrow 2: 4\\nrow 3: 9\\n"
+            big_ref = Ref{String}()
             t0 = time()
-            big = render_rows(200_000)
+            allocated = @allocated big_ref[] = render_rows(20_000)
             elapsed = time() - t0
-            @test endswith(big, "row 200000: 40000000000\\n")
-            @test count(==('\\n'), big) == 200_000
-            @test elapsed < 5.0  # the current implementation is quadratic and far slower
+            big = big_ref[]
+            @test endswith(big, "row 20000: 400000000\\n")
+            @test count(==('\\n'), big) == 20_000
+            @test allocated < 100_000_000  # quadratic concatenation allocates several GB
+            @test elapsed < 5.0
             println("OK")
             """)
     end,
-    prompt = "test_render.jl times out its performance assertion. Make render_rows fast enough (same output) so the test passes.",
+    prompt = "test_render.jl fails its performance assertion. Make render_rows efficient enough (same output) so the test passes.",
     check = dir -> _run_ok(dir, `julia --startup-file=no test_render.jl`),
 ),
 

--- a/Juco/eval/tasks.jl
+++ b/Juco/eval/tasks.jl
@@ -315,8 +315,10 @@ const TASKS = [
     end,
     prompt = "Migrate the request API in src/ from `retries` (count after the first attempt) to `attempts` (total attempt count, default 1), updating the docstring and every call site so behavior is preserved and migration_test.jl passes. The old `retries` keyword must be fully gone.",
     check = function (dir)
-        occursin("retries", read(joinpath(dir, "src", "client.jl"), String)) && return false
-        occursin("retries", read(joinpath(dir, "src", "api.jl"), String)) && return false
+        # the retries KEYWORD must be gone (prose like "no retries" in a docstring is fine)
+        kw = r"retries\s*(=|::)|;\s*retries\b"
+        occursin(kw, read(joinpath(dir, "src", "client.jl"), String)) && return false
+        occursin(kw, read(joinpath(dir, "src", "api.jl"), String)) && return false
         return _run_ok(dir, `julia --startup-file=no migration_test.jl`)
     end,
 ),

--- a/Juco/eval/tasks.jl
+++ b/Juco/eval/tasks.jl
@@ -8,8 +8,75 @@
 # the core competencies of a coding agent: explore, implement, fix, refactor,
 # create, and edit precisely.
 
+import TOML
+
 function _run_ok(dir, cmd)
     return success(pipeline(Cmd(cmd; dir); stdout = devnull, stderr = devnull))
+end
+
+_run_julia_ok(dir, code::AbstractString) =
+    _run_ok(dir, Cmd(["julia", "--startup-file=no", "-e", String(code)]))
+
+const REGRESSION_ORDERS_TEST = """
+    include("src/orders.jl")
+    using Test
+    # Order sheets use underscore thousands separators.
+    @test order_total(["1_000", "2_500", "7"]) == 3507
+    @test order_total(["10", "20"]) == 30
+    println("OK")
+    """
+
+const REGRESSION_AUDIT_TEST = """
+    include("src/audit.jl")
+    using Test
+    @test audit_row("42") == "ok"
+    @test audit_row("abc") == "reject"
+    @test audit_row("") == "reject"
+    @test audit_row("4.5") == "reject"
+    println("OK")
+    """
+
+const FLAKY_INVENTORY_TEST = """
+    include("inventory.jl")
+    using Test
+    items = Dict("zinc" => 3, "apple" => 5, "mango" => 2, "kiwi" => 9, "fig" => 1,
+                 "pear" => 4, "plum" => 6, "date" => 7, "lime" => 8, "yam" => 10)
+    @test inventory_report(items) == "apple=5\\ndate=7\\nfig=1\\nkiwi=9\\nlime=8\\nmango=2\\npear=4\\nplum=6\\nyam=10\\nzinc=3"
+    println("OK")
+    """
+
+const DEEP_TRACE_TEST = """
+    include("src/a_entry.jl")
+    using Test
+    @test process([1, 2, 3]) == 2.0
+    @test process([10]) == 10.0
+    println("OK")
+    """
+
+const UNICODE_MENU_SOURCE = """
+    const MENU = [
+        ("café ☕", 3.50),
+        ("汉堡 🍔", 8.25),
+        ("寿司 🍣", 12.00),
+        ("crêpe 🥞", 6.75),
+    ]
+    price_of(name) = only(p for (n, p) in MENU if n == name)
+    """
+
+function validators_source(; widened::Bool = false)
+    chunks = String[]
+    for i in 1:100
+        upper = widened && i == 57 ? 250 : i + 100
+        push!(chunks, """
+            # Validator $(i): checks range [$(i), $(upper)].
+            function validate_$(i)(x)
+                x < $(i) && return false
+                x > $(upper) && return false
+                return true
+            end
+            """)
+    end
+    return join(chunks, "\n")
 end
 
 const TASKS = [
@@ -380,27 +447,16 @@ const TASKS = [
                 "reject"
             end
             """)
-        write(joinpath(dir, "test_orders.jl"), """
-            include("src/orders.jl")
-            using Test
-            # Order sheets use underscore thousands separators.
-            @test order_total(["1_000", "2_500", "7"]) == 3507
-            @test order_total(["10", "20"]) == 30
-            println("OK")
-            """)
-        write(joinpath(dir, "test_audit.jl"), """
-            include("src/audit.jl")
-            using Test
-            @test audit_row("42") == "ok"
-            @test audit_row("abc") == "reject"
-            @test audit_row("") == "reject"
-            @test audit_row("4.5") == "reject"
-            println("OK")
-            """)
+        write(joinpath(dir, "test_orders.jl"), REGRESSION_ORDERS_TEST)
+        write(joinpath(dir, "test_audit.jl"), REGRESSION_AUDIT_TEST)
     end,
     prompt = "test_orders.jl fails. Fix the code so BOTH test_orders.jl and test_audit.jl pass — do not modify either test file.",
-    check = dir -> _run_ok(dir, `julia --startup-file=no test_orders.jl`) &&
-        _run_ok(dir, `julia --startup-file=no test_audit.jl`),
+    check = function (dir)
+        read(joinpath(dir, "test_orders.jl"), String) == REGRESSION_ORDERS_TEST || return false
+        read(joinpath(dir, "test_audit.jl"), String) == REGRESSION_AUDIT_TEST || return false
+        return _run_ok(dir, `julia --startup-file=no test_orders.jl`) &&
+            _run_ok(dir, `julia --startup-file=no test_audit.jl`)
+    end,
 ),
 
 (
@@ -434,21 +490,25 @@ const TASKS = [
             """)
     end,
     prompt = "test_render.jl fails its performance assertion. Make render_rows efficient enough (same output) so the test passes.",
-    check = dir -> _run_ok(dir, `julia --startup-file=no test_render.jl`),
+    check = function (dir)
+        _run_ok(dir, `julia --startup-file=no test_render.jl`) || return false
+        code = """
+            include("render.jl")
+            @assert render_rows(3) == "row 1: 1\\nrow 2: 4\\nrow 3: 9\\n"
+            result = Ref{String}()
+            allocated = @allocated result[] = render_rows(20_000)
+            @assert endswith(result[], "row 20000: 400000000\\n")
+            @assert count(==('\\n'), result[]) == 20_000
+            @assert allocated < 100_000_000
+            """
+        return _run_julia_ok(dir, code)
+    end,
 ),
 
 (
     name = "unicode-edit",
     setup = function (dir)
-        write(joinpath(dir, "menu.jl"), """
-            const MENU = [
-                ("café ☕", 3.50),
-                ("汉堡 🍔", 8.25),
-                ("寿司 🍣", 12.00),
-                ("crêpe 🥞", 6.75),
-            ]
-            price_of(name) = only(p for (n, p) in MENU if n == name)
-            """)
+        write(joinpath(dir, "menu.jl"), UNICODE_MENU_SOURCE)
         write(joinpath(dir, "test_menu.jl"), """
             include("menu.jl")
             using Test
@@ -461,8 +521,9 @@ const TASKS = [
     prompt = "The burger price changed: update 汉堡 🍔 to 9.75 in menu.jl so test_menu.jl passes. Change nothing else.",
     check = function (dir)
         content = read(joinpath(dir, "menu.jl"), String)
-        occursin("(\"汉堡 🍔\", 9.75)", content) || return false
-        occursin("(\"café ☕\", 3.50)", content) || return false
+        expected = replace(UNICODE_MENU_SOURCE,
+            "(\"汉堡 🍔\", 8.25)" => "(\"汉堡 🍔\", 9.75)")
+        content == expected || return false
         return _run_ok(dir, `julia --startup-file=no test_menu.jl`)
     end,
 ),
@@ -480,7 +541,8 @@ const TASKS = [
     prompt = "requests.jsonl has one JSON object per line. Find the req id with the highest duration_ms and write EXACTLY that id (nothing else) to answer.txt.",
     check = function (dir)
         isfile(joinpath(dir, "answer.txt")) || return false
-        return strip(read(joinpath(dir, "answer.txt"), String)) == "req-03141"
+        answer = read(joinpath(dir, "answer.txt"), String)
+        return answer == "req-03141" || answer == "req-03141\n"
     end,
 ),
 
@@ -526,7 +588,18 @@ const TASKS = [
             """)
     end,
     prompt = "Add support for the color purple (ansi code 35): it must be registered, renderable, and documented, consistently across the project, so test_colors.jl passes.",
-    check = dir -> _run_ok(dir, `julia --startup-file=no test_colors.jl`),
+    check = function (dir)
+        _run_ok(dir, `julia --startup-file=no test_colors.jl`) || return false
+        code = """
+            include("src/render.jl")
+            @assert length(SUPPORTED_COLORS) == 4
+            @assert Set(SUPPORTED_COLORS) == Set(["red", "green", "blue", "purple"])
+            @assert [ansi_code(c) for c in ("red", "green", "blue", "purple")] == [31, 32, 34, 35]
+            doc = replace(read("docs.md", String), r"\\s+" => "")
+            @assert occursin("|purple|35|", doc)
+            """
+        return _run_julia_ok(dir, code)
+    end,
 ),
 
 (
@@ -542,21 +615,21 @@ const TASKS = [
                 return join(lines, "\\n")
             end
             """)
-        write(joinpath(dir, "test_inventory.jl"), """
-            include("inventory.jl")
-            using Test
-            items = Dict("zinc" => 3, "apple" => 5, "mango" => 2, "kiwi" => 9, "fig" => 1,
-                         "pear" => 4, "plum" => 6, "date" => 7, "lime" => 8, "yam" => 10)
-            @test inventory_report(items) == "apple=5\\ndate=7\\nfig=1\\nkiwi=9\\nlime=8\\nmango=2\\npear=4\\nplum=6\\nyam=10\\nzinc=3"
-            println("OK")
-            """)
+        write(joinpath(dir, "test_inventory.jl"), FLAKY_INVENTORY_TEST)
     end,
     prompt = "test_inventory.jl fails (or passes only by luck) because the report order is nondeterministic. Make inventory_report deterministic so the test always passes. Do not modify the test.",
     check = function (dir)
-        for _ in 1:5
-            _run_ok(dir, `julia --startup-file=no test_inventory.jl`) || return false
-        end
-        return true
+        read(joinpath(dir, "test_inventory.jl"), String) == FLAKY_INVENTORY_TEST || return false
+        _run_ok(dir, `julia --startup-file=no test_inventory.jl`) || return false
+        code = """
+            include("inventory.jl")
+            pairs = ["zinc" => 3, "apple" => 5, "mango" => 2, "kiwi" => 9, "fig" => 1,
+                     "pear" => 4, "plum" => 6, "date" => 7, "lime" => 8, "yam" => 10]
+            expected = "apple=5\\ndate=7\\nfig=1\\nkiwi=9\\nlime=8\\nmango=2\\npear=4\\nplum=6\\nyam=10\\nzinc=3"
+            @assert inventory_report(Dict(pairs)) == expected
+            @assert inventory_report(Dict(reverse(pairs))) == expected
+            """
+        return _run_julia_ok(dir, code)
     end,
 ),
 
@@ -586,7 +659,12 @@ const TASKS = [
             """)
     end,
     prompt = "test_stamp.jl fails because the Stamp package doesn't load. Diagnose and fix the package so the test passes.",
-    check = dir -> _run_ok(dir, `julia --startup-file=no test_stamp.jl`),
+    check = function (dir)
+        project = TOML.parsefile(joinpath(dir, "Stamp", "Project.toml"))
+        deps = get(project, "deps", Dict{String, Any}())
+        get(deps, "Dates", nothing) == "ade2ca70-3891-5945-98fb-dc099432e06a" || return false
+        return _run_ok(dir, `julia --startup-file=no test_stamp.jl`)
+    end,
 ),
 
 (
@@ -622,7 +700,21 @@ const TASKS = [
             """)
     end,
     prompt = "The docstrings in fmt.jl promise keyword arguments the functions don't actually accept, and test_fmt.jl exercises the documented behavior. Implement the functions to match their docs so the test passes.",
-    check = dir -> _run_ok(dir, `julia --startup-file=no test_fmt.jl`),
+    check = function (dir)
+        source = read(joinpath(dir, "fmt.jl"), String)
+        occursin("shorten(s; max = 10, ellipsis = \"…\")", source) || return false
+        occursin("pad_id(n; width = 6)", source) || return false
+        _run_ok(dir, `julia --startup-file=no test_fmt.jl`) || return false
+        code = """
+            include("fmt.jl")
+            @assert shorten("hello") == "hello"
+            @assert shorten("hello world, long"; max = 8) == "hello w…"
+            @assert shorten("ééé"; max = 2) == "é…"
+            @assert shorten("abcdefgh"; max = 6, ellipsis = "...") == "abc..."
+            @assert pad_id(42; width = 3) == "042"
+            """
+        return _run_julia_ok(dir, code)
+    end,
 ),
 
 (
@@ -649,33 +741,24 @@ const TASKS = [
         write(joinpath(dir, "src", "e_output.jl"), """
             emit(xs) = sum(xs) / length(xs)
             """)
-        write(joinpath(dir, "test_pipeline.jl"), """
-            include("src/a_entry.jl")
-            using Test
-            @test process([1, 2, 3]) == 2.0
-            @test process([10]) == 10.0
-            println("OK")
-            """)
+        write(joinpath(dir, "test_pipeline.jl"), DEEP_TRACE_TEST)
     end,
     prompt = "test_pipeline.jl fails: process returns the wrong values. Track the bug through the pipeline in src/ and fix it. Do not modify the test.",
-    check = dir -> _run_ok(dir, `julia --startup-file=no test_pipeline.jl`),
+    check = function (dir)
+        read(joinpath(dir, "test_pipeline.jl"), String) == DEEP_TRACE_TEST || return false
+        _run_ok(dir, `julia --startup-file=no test_pipeline.jl`) || return false
+        return _run_julia_ok(dir, """
+            include("src/a_entry.jl")
+            @assert process([1, 2, 3]) == 2.0
+            @assert process([10]) == 10.0
+            """)
+    end,
 ),
 
 (
     name = "big-file-precision",
     setup = function (dir)
-        chunks = String[]
-        for i in 1:100
-            push!(chunks, """
-                # Validator $(i): checks range [$(i), $(i + 100)].
-                function validate_$(i)(x)
-                    x < $(i) && return false
-                    x > $(i + 100) && return false
-                    return true
-                end
-                """)
-        end
-        write(joinpath(dir, "validators.jl"), join(chunks, "\n"))
+        write(joinpath(dir, "validators.jl"), validators_source())
         write(joinpath(dir, "test_validators.jl"), """
             include("validators.jl")
             using Test
@@ -690,8 +773,7 @@ const TASKS = [
     prompt = "In validators.jl (100 near-identical validators), widen validate_57's upper bound from 157 to 250 (and its comment) without touching any other validator, so test_validators.jl passes.",
     check = function (dir)
         content = read(joinpath(dir, "validators.jl"), String)
-        count("x > 250 && return false", content) == 1 || return false
-        occursin("x > 157", content) && return false
+        content == validators_source(; widened = true) || return false
         return _run_ok(dir, `julia --startup-file=no test_validators.jl`)
     end,
 ),

--- a/Juco/eval/tasks.jl
+++ b/Juco/eval/tasks.jl
@@ -327,12 +327,14 @@ const TASKS = [
     name = "output-discipline",
     setup = function (dir)
         write(joinpath(dir, "process.jl"), """
-            # Processes 8000 records; record 4217 is corrupt.
-            for i in 1:8000
-                if i == 4217
-                    println("record \$i: ERROR malformed field 'qty' (got \\"seven\\")")
+            # Validates every record in records.csv.
+            for (i, line) in enumerate(eachline("records.csv"))
+                id, qty = split(line, ",")
+                parsed = tryparse(Int, qty)
+                if parsed === nothing
+                    println("record \$i (\$id): ERROR malformed field 'qty' (got \\"\$qty\\")")
                 else
-                    println("record \$i: ok")
+                    println("record \$i (\$id): ok")
                 end
             end
             """)

--- a/Juco/eval/tasks.jl
+++ b/Juco/eval/tasks.jl
@@ -354,4 +354,343 @@ const TASKS = [
     end,
 ),
 
+
+# ─── Round-2 tasks (added with the second iteration phase) ───
+
+
+(
+    name = "regression-guard",
+    setup = function (dir)
+        mkpath(joinpath(dir, "src"))
+        write(joinpath(dir, "src", "qty.jl"), """
+            # Shared quantity parser used across the codebase.
+            parse_qty(s) = parse(Int, strip(s))
+            """)
+        write(joinpath(dir, "src", "orders.jl"), """
+            include("qty.jl")
+            order_total(qtys) = sum(parse_qty, qtys)
+            """)
+        write(joinpath(dir, "src", "audit.jl"), """
+            include("qty.jl")
+            # Audit rejects malformed rows loudly.
+            audit_row(s) = try
+                parse_qty(s)
+                "ok"
+            catch
+                "reject"
+            end
+            """)
+        write(joinpath(dir, "test_orders.jl"), """
+            include("src/orders.jl")
+            using Test
+            # Order sheets use underscore thousands separators.
+            @test order_total(["1_000", "2_500", "7"]) == 3507
+            @test order_total(["10", "20"]) == 30
+            println("OK")
+            """)
+        write(joinpath(dir, "test_audit.jl"), """
+            include("src/audit.jl")
+            using Test
+            @test audit_row("42") == "ok"
+            @test audit_row("abc") == "reject"
+            @test audit_row("") == "reject"
+            @test audit_row("4.5") == "reject"
+            println("OK")
+            """)
+    end,
+    prompt = "test_orders.jl fails. Fix the code so BOTH test_orders.jl and test_audit.jl pass — do not modify either test file.",
+    check = dir -> _run_ok(dir, `julia --startup-file=no test_orders.jl`) &&
+        _run_ok(dir, `julia --startup-file=no test_audit.jl`),
+),
+
+(
+    name = "perf-fix",
+    setup = function (dir)
+        write(joinpath(dir, "render.jl"), """
+            # Renders n table rows into a single string.
+            function render_rows(n)
+                out = ""
+                for i in 1:n
+                    out = out * "row " * string(i) * ": " * string(i * i) * "\\n"
+                end
+                return out
+            end
+            """)
+        write(joinpath(dir, "test_render.jl"), """
+            include("render.jl")
+            using Test
+            small = render_rows(3)
+            @test small == "row 1: 1\\nrow 2: 4\\nrow 3: 9\\n"
+            t0 = time()
+            big = render_rows(200_000)
+            elapsed = time() - t0
+            @test endswith(big, "row 200000: 40000000000\\n")
+            @test count(==('\\n'), big) == 200_000
+            @test elapsed < 5.0  # the current implementation is quadratic and far slower
+            println("OK")
+            """)
+    end,
+    prompt = "test_render.jl times out its performance assertion. Make render_rows fast enough (same output) so the test passes.",
+    check = dir -> _run_ok(dir, `julia --startup-file=no test_render.jl`),
+),
+
+(
+    name = "unicode-edit",
+    setup = function (dir)
+        write(joinpath(dir, "menu.jl"), """
+            const MENU = [
+                ("café ☕", 3.50),
+                ("汉堡 🍔", 8.25),
+                ("寿司 🍣", 12.00),
+                ("crêpe 🥞", 6.75),
+            ]
+            price_of(name) = only(p for (n, p) in MENU if n == name)
+            """)
+        write(joinpath(dir, "test_menu.jl"), """
+            include("menu.jl")
+            using Test
+            @test price_of("汉堡 🍔") == 9.75
+            @test price_of("café ☕") == 3.50
+            @test price_of("寿司 🍣") == 12.00
+            println("OK")
+            """)
+    end,
+    prompt = "The burger price changed: update 汉堡 🍔 to 9.75 in menu.jl so test_menu.jl passes. Change nothing else.",
+    check = function (dir)
+        content = read(joinpath(dir, "menu.jl"), String)
+        occursin("(\"汉堡 🍔\", 9.75)", content) || return false
+        occursin("(\"café ☕\", 3.50)", content) || return false
+        return _run_ok(dir, `julia --startup-file=no test_menu.jl`)
+    end,
+),
+
+(
+    name = "json-log-mine",
+    setup = function (dir)
+        lines = String[]
+        for i in 1:5000
+            dur = i == 3141 ? 98765 : (i * 7) % 900 + 10
+            push!(lines, "{\"req\": \"req-$(lpad(i, 5, '0'))\", \"path\": \"/api/v$(i % 3)\", \"duration_ms\": $(dur), \"status\": $(i % 17 == 0 ? 500 : 200)}")
+        end
+        write(joinpath(dir, "requests.jsonl"), join(lines, "\n") * "\n")
+    end,
+    prompt = "requests.jsonl has one JSON object per line. Find the req id with the highest duration_ms and write EXACTLY that id (nothing else) to answer.txt.",
+    check = function (dir)
+        isfile(joinpath(dir, "answer.txt")) || return false
+        return strip(read(joinpath(dir, "answer.txt"), String)) == "req-03141"
+    end,
+),
+
+(
+    name = "cross-file-invariant",
+    setup = function (dir)
+        mkpath(joinpath(dir, "src"))
+        write(joinpath(dir, "src", "colors.jl"), """
+            const SUPPORTED_COLORS = ["red", "green", "blue"]
+            """)
+        write(joinpath(dir, "src", "render.jl"), """
+            include("colors.jl")
+            function ansi_code(color)
+                color == "red" && return 31
+                color == "green" && return 32
+                color == "blue" && return 34
+                error("unsupported color: \$color")
+            end
+            """)
+        write(joinpath(dir, "docs.md"), """
+            # Supported colors
+
+            | color | ansi |
+            |-------|------|
+            | red   | 31   |
+            | green | 32   |
+            | blue  | 34   |
+            """)
+        write(joinpath(dir, "test_colors.jl"), """
+            include("src/render.jl")
+            using Test
+            @test "purple" in SUPPORTED_COLORS
+            @test ansi_code("purple") == 35
+            for c in SUPPORTED_COLORS
+                @test ansi_code(c) isa Int
+            end
+            # docs table must list every supported color with its code
+            doc = read("docs.md", String)
+            for c in SUPPORTED_COLORS
+                @test occursin(Regex("\\\\|\\\\s*" * c * "\\\\s*\\\\|\\\\s*" * string(ansi_code(c)) * "\\\\s*\\\\|"), doc)
+            end
+            println("OK")
+            """)
+    end,
+    prompt = "Add support for the color purple (ansi code 35): it must be registered, renderable, and documented, consistently across the project, so test_colors.jl passes.",
+    check = dir -> _run_ok(dir, `julia --startup-file=no test_colors.jl`),
+),
+
+(
+    name = "flaky-test",
+    setup = function (dir)
+        write(joinpath(dir, "inventory.jl"), """
+            # Returns items formatted as "name=count", one per line.
+            function inventory_report(items::Dict{String, Int})
+                lines = String[]
+                for (k, v) in items
+                    push!(lines, "\$(k)=\$(v)")
+                end
+                return join(lines, "\\n")
+            end
+            """)
+        write(joinpath(dir, "test_inventory.jl"), """
+            include("inventory.jl")
+            using Test
+            items = Dict("zinc" => 3, "apple" => 5, "mango" => 2, "kiwi" => 9, "fig" => 1,
+                         "pear" => 4, "plum" => 6, "date" => 7, "lime" => 8, "yam" => 10)
+            @test inventory_report(items) == "apple=5\\ndate=7\\nfig=1\\nkiwi=9\\nlime=8\\nmango=2\\npear=4\\nplum=6\\nyam=10\\nzinc=3"
+            println("OK")
+            """)
+    end,
+    prompt = "test_inventory.jl fails (or passes only by luck) because the report order is nondeterministic. Make inventory_report deterministic so the test always passes. Do not modify the test.",
+    check = function (dir)
+        for _ in 1:5
+            _run_ok(dir, `julia --startup-file=no test_inventory.jl`) || return false
+        end
+        return true
+    end,
+),
+
+(
+    name = "dep-wiring",
+    setup = function (dir)
+        mkpath(joinpath(dir, "Stamp", "src"))
+        write(joinpath(dir, "Stamp", "Project.toml"), """
+            name = "Stamp"
+            uuid = "7f2b1e60-1f7c-4c2e-9d7b-3a1a2b3c4d5e"
+            version = "0.1.0"
+            """)
+        write(joinpath(dir, "Stamp", "src", "Stamp.jl"), """
+            module Stamp
+            using Dates
+            stamp(msg) = "[\$(Dates.format(Dates.DateTime(2026, 1, 2, 3, 4, 5), "yyyy-mm-dd HH:MM:SS"))] \$msg"
+            export stamp
+            end
+            """)
+        write(joinpath(dir, "test_stamp.jl"), """
+            using Pkg
+            Pkg.activate("Stamp"; io = devnull)
+            using Stamp
+            using Test
+            @test stamp("hello") == "[2026-01-02 03:04:05] hello"
+            println("OK")
+            """)
+    end,
+    prompt = "test_stamp.jl fails because the Stamp package doesn't load. Diagnose and fix the package so the test passes.",
+    check = dir -> _run_ok(dir, `julia --startup-file=no test_stamp.jl`),
+),
+
+(
+    name = "api-doc-sync",
+    setup = function (dir)
+        write(joinpath(dir, "fmt.jl"), """
+            \"\"\"
+                shorten(s; max = 10, ellipsis = "…")
+
+            Truncate `s` to at most `max` characters. When truncation happens, the
+            result ends with `ellipsis` (still within the `max` budget).
+            \"\"\"
+            shorten(s) = length(s) <= 10 ? s : first(s, 10)
+
+            \"\"\"
+                pad_id(n; width = 6)
+
+            Zero-pad an integer id to `width` digits.
+            \"\"\"
+            pad_id(n) = lpad(n, 6, '0')
+            """)
+        write(joinpath(dir, "test_fmt.jl"), """
+            include("fmt.jl")
+            using Test
+            @test shorten("hello") == "hello"
+            @test shorten("hello world, long"; max = 8) == "hello w…"
+            @test shorten("hello world, long") == "hello wor…"
+            @test shorten("abcdef"; max = 6, ellipsis = "...") == "abcdef"
+            @test shorten("abcdefgh"; max = 6, ellipsis = "...") == "abc..."
+            @test pad_id(42) == "000042"
+            @test pad_id(42; width = 3) == "042"
+            println("OK")
+            """)
+    end,
+    prompt = "The docstrings in fmt.jl promise keyword arguments the functions don't actually accept, and test_fmt.jl exercises the documented behavior. Implement the functions to match their docs so the test passes.",
+    check = dir -> _run_ok(dir, `julia --startup-file=no test_fmt.jl`),
+),
+
+(
+    name = "deep-trace",
+    setup = function (dir)
+        mkpath(joinpath(dir, "src"))
+        write(joinpath(dir, "src", "a_entry.jl"), """
+            include("b_config.jl")
+            include("c_loader.jl")
+            include("d_transform.jl")
+            include("e_output.jl")
+            process(data) = emit(transform(load(data, default_config())))
+            """)
+        write(joinpath(dir, "src", "b_config.jl"), """
+            # scale must default to 1.0 (identity); someone fat-fingered it.
+            default_config() = (scale = 0.0, offset = 0)
+            """)
+        write(joinpath(dir, "src", "c_loader.jl"), """
+            load(data, cfg) = [(x, cfg) for x in data]
+            """)
+        write(joinpath(dir, "src", "d_transform.jl"), """
+            transform(rows) = [x * cfg.scale + cfg.offset for (x, cfg) in rows]
+            """)
+        write(joinpath(dir, "src", "e_output.jl"), """
+            emit(xs) = sum(xs) / length(xs)
+            """)
+        write(joinpath(dir, "test_pipeline.jl"), """
+            include("src/a_entry.jl")
+            using Test
+            @test process([1, 2, 3]) == 2.0
+            @test process([10]) == 10.0
+            println("OK")
+            """)
+    end,
+    prompt = "test_pipeline.jl fails: process returns the wrong values. Track the bug through the pipeline in src/ and fix it. Do not modify the test.",
+    check = dir -> _run_ok(dir, `julia --startup-file=no test_pipeline.jl`),
+),
+
+(
+    name = "big-file-precision",
+    setup = function (dir)
+        chunks = String[]
+        for i in 1:100
+            push!(chunks, """
+                # Validator $(i): checks range [$(i), $(i + 100)].
+                function validate_$(i)(x)
+                    x < $(i) && return false
+                    x > $(i + 100) && return false
+                    return true
+                end
+                """)
+        end
+        write(joinpath(dir, "validators.jl"), join(chunks, "\n"))
+        write(joinpath(dir, "test_validators.jl"), """
+            include("validators.jl")
+            using Test
+            # validator 57 must now accept exactly [57, 250]
+            @test validate_57(57) && validate_57(250) && !validate_57(251) && !validate_57(56)
+            # spot-check that neighbours are untouched
+            @test validate_56(156) && !validate_56(157)
+            @test validate_58(158) && !validate_58(159)
+            println("OK")
+            """)
+    end,
+    prompt = "In validators.jl (100 near-identical validators), widen validate_57's upper bound from 157 to 250 (and its comment) without touching any other validator, so test_validators.jl passes.",
+    check = function (dir)
+        content = read(joinpath(dir, "validators.jl"), String)
+        count("x > 250 && return false", content) == 1 || return false
+        occursin("x > 157", content) && return false
+        return _run_ok(dir, `julia --startup-file=no test_validators.jl`)
+    end,
+),
+
 ]

--- a/Juco/eval/tasks.jl
+++ b/Juco/eval/tasks.jl
@@ -158,4 +158,196 @@ const TASKS = [
     end,
 ),
 
+# ─── Harder tasks (added for the iteration phase) ───
+
+(
+    name = "multi-file-feature",
+    setup = function (dir)
+        mkpath(joinpath(dir, "src"))
+        write(joinpath(dir, "src", "Queue.jl"), """
+            # A simple FIFO queue used as the style reference for this codebase.
+            struct Queue
+                items::Vector{Any}
+            end
+            Queue() = Queue(Any[])
+            enqueue!(q::Queue, x) = (push!(q.items, x); q)
+            dequeue!(q::Queue) = popfirst!(q.items)
+            Base.isempty(q::Queue) = isempty(q.items)
+            Base.length(q::Queue) = length(q.items)
+            """)
+        write(joinpath(dir, "src", "Collections.jl"), """
+            module Collections
+            include("Queue.jl")
+            export Queue, enqueue!, dequeue!
+            end
+            """)
+        write(joinpath(dir, "test_stack.jl"), """
+            include("src/Collections.jl")
+            using .Collections, Test
+            s = Stack()
+            push!(s, 1); push!(s, 2); push!(s, 3)
+            @test peek(s) == 3
+            @test pop!(s) == 3
+            @test pop!(s) == 2
+            @test length(s) == 1
+            @test !isempty(s)
+            @test pop!(s) == 1
+            @test isempty(s)
+            println("OK")
+            """)
+    end,
+    prompt = "Add a Stack type to the Collections module (src/) with push!, pop!, peek, isempty, and length support, following the existing Queue style, so test_stack.jl passes.",
+    check = dir -> _run_ok(dir, `julia --startup-file=no test_stack.jl`),
+),
+
+(
+    name = "debug-suite",
+    setup = function (dir)
+        mkpath(joinpath(dir, "src"))
+        write(joinpath(dir, "src", "text.jl"), """
+            # Count words in a string.
+            count_words(s) = length(split(strip(s)))
+
+            # Reverse each word but keep word order.
+            function reverse_words(s)
+                join(reverse.(split(s, " ")), " ")
+            end
+
+            # Truncate to n chars, appending an ellipsis when truncated
+            function truncate_text(s, n)
+                length(s) <= n && return s
+                return first(s, n) * "..."
+            en
+            """)
+        write(joinpath(dir, "src", "num.jl"), """
+            # Sum of digits of a non-negative integer.
+            function digit_sum(n)
+                total = 0
+                while n > 0
+                    total += n % 10
+                    n = n ÷ 10
+                end
+                return total
+            end
+
+            # Clamp x into [lo, hi].
+            clamp_to(x, lo, hi) = max(lo, min(hi, lo))
+            """)
+        write(joinpath(dir, "runtests.jl"), """
+            include("src/text.jl")
+            include("src/num.jl")
+            using Test
+            @test count_words("  the quick brown fox  ") == 4
+            @test reverse_words("abc def") == "cba fed"
+            @test truncate_text("hello world", 5) == "hello..."
+            @test truncate_text("hi", 5) == "hi"
+            @test digit_sum(1234) == 10
+            @test clamp_to(5, 1, 10) == 5
+            @test clamp_to(-3, 1, 10) == 1
+            @test clamp_to(42, 1, 10) == 10
+            println("OK")
+            """)
+    end,
+    prompt = "runtests.jl fails to even load: there are multiple distinct problems in src/ (at least one syntax error and at least one logic bug). Fix the source files — do not change runtests.jl — until the whole suite passes.",
+    check = dir -> _run_ok(dir, `julia --startup-file=no runtests.jl`),
+),
+
+(
+    name = "needle",
+    setup = function (dir)
+        mkpath(joinpath(dir, "src"))
+        for i in 1:40
+            body = i == 23 ?
+                "handler_23(x) = x * 2  # BUG: spec says triple\n" :
+                "handler_$(i)(x) = x * 3\n"
+            write(joinpath(dir, "src", "handler_$(lpad(i, 2, '0')).jl"), body)
+        end
+        write(joinpath(dir, "main.jl"), """
+            for f in sort(readdir("src"))
+                include(joinpath("src", f))
+            end
+            using Test
+            for i in 1:40
+                h = getfield(Main, Symbol("handler_", i))
+                @test h(7) == 21
+            end
+            println("OK")
+            """)
+    end,
+    prompt = "Exactly one of the 40 handlers in src/ violates the spec that every handler must triple its input. main.jl catches it. Find the offender efficiently and fix it. Do not modify main.jl.",
+    check = dir -> _run_ok(dir, `julia --startup-file=no main.jl`),
+),
+
+(
+    name = "api-migration",
+    setup = function (dir)
+        mkpath(joinpath(dir, "src"))
+        write(joinpath(dir, "src", "client.jl"), """
+            \"\"\"
+                request(url; retries = 0)
+
+            Fake HTTP client. `retries` is the number of retries AFTER the initial
+            attempt (so retries = 2 means up to 3 total attempts).
+            \"\"\"
+            function request(url; retries::Int = 0)
+                attempts_made = 1 + retries
+                return "GET \$url [\$attempts_made attempts]"
+            end
+            """)
+        write(joinpath(dir, "src", "api.jl"), """
+            include("client.jl")
+            fetch_user(id) = request("/users/\$id"; retries = 2)
+            fetch_repo(name) = request("/repos/\$name"; retries = 4)
+            fetch_status() = request("/status")
+            """)
+        write(joinpath(dir, "migration_test.jl"), """
+            include("src/api.jl")
+            using Test
+            # After migration: request takes `attempts` = TOTAL attempt count,
+            # and callers must preserve their current total-attempt behavior.
+            @test request("/x"; attempts = 3) == "GET /x [3 attempts]"
+            @test request("/x") == "GET /x [1 attempts]"
+            @test fetch_user(1) == "GET /users/1 [3 attempts]"
+            @test fetch_repo("a") == "GET /repos/a [5 attempts]"
+            @test fetch_status() == "GET /status [1 attempts]"
+            println("OK")
+            """)
+    end,
+    prompt = "Migrate the request API in src/ from `retries` (count after the first attempt) to `attempts` (total attempt count, default 1), updating the docstring and every call site so behavior is preserved and migration_test.jl passes. The old `retries` keyword must be fully gone.",
+    check = function (dir)
+        occursin("retries", read(joinpath(dir, "src", "client.jl"), String)) && return false
+        occursin("retries", read(joinpath(dir, "src", "api.jl"), String)) && return false
+        return _run_ok(dir, `julia --startup-file=no migration_test.jl`)
+    end,
+),
+
+(
+    name = "output-discipline",
+    setup = function (dir)
+        write(joinpath(dir, "process.jl"), """
+            # Processes 8000 records; record 4217 is corrupt.
+            for i in 1:8000
+                if i == 4217
+                    println("record \$i: ERROR malformed field 'qty' (got \\"seven\\")")
+                else
+                    println("record \$i: ok")
+                end
+            end
+            """)
+        write(joinpath(dir, "records.csv"),
+            join(["id_$(i),$(i == 4217 ? "seven" : string(i % 50))" for i in 1:8000], "\n") * "\n")
+    end,
+    prompt = "Running `julia process.jl` reports exactly one corrupt record buried in ~8000 lines of output. Find which record is corrupt and fix its qty field in records.csv to the number 7. Change only that one line.",
+    check = function (dir)
+        lines = readlines(joinpath(dir, "records.csv"))
+        length(lines) == 8000 || return false
+        lines[4217] == "id_4217,7" || return false
+        for (i, line) in enumerate(lines)
+            i == 4217 && continue
+            line == "id_$(i),$(i % 50)" || return false
+        end
+        return true
+    end,
+),
+
 ]

--- a/Juco/ext/JucoReplMakerExt/JucoReplMakerExt.jl
+++ b/Juco/ext/JucoReplMakerExt/JucoReplMakerExt.jl
@@ -1,0 +1,17 @@
+module JucoReplMakerExt
+
+using Juco, ReplMaker
+
+function Juco.repl_mode!(; db_path::AbstractString = Juco.DEFAULT_DB_PATH, start_key::Char = '}', kw...)
+    st = Juco.mode_state(db_path)
+    ReplMaker.initrepl(input -> Juco.mode_eval(st, input; kw...);
+        prompt_text = "juco> ",
+        prompt_color = :magenta,
+        start_key = start_key,
+        mode_name = :juco,
+        valid_input_checker = Returns(true),
+        startup_text = true)
+    return nothing
+end
+
+end

--- a/Juco/ext/JucoReplMakerExt/JucoReplMakerExt.jl
+++ b/Juco/ext/JucoReplMakerExt/JucoReplMakerExt.jl
@@ -1,6 +1,21 @@
 module JucoReplMakerExt
 
-using Juco, ReplMaker
+using Juco, ReplMaker, REPL
+using REPL: LineEdit
+
+# Tab-completion for `$skill-name` tokens in the juco> mode.
+struct SkillCompletionProvider <: LineEdit.CompletionProvider
+    skills::Vector{Juco.Skill}
+end
+
+function LineEdit.complete_line(c::SkillCompletionProvider, s::LineEdit.PromptState; hint::Bool = false)
+    full = LineEdit.input_string(s)
+    cursor = position(LineEdit.buffer(s))
+    names, byterange, should = Juco.skill_completions(full, cursor, c.skills)
+    completions = [LineEdit.NamedCompletion(n) for n in names]
+    region = REPL.to_region(full, byterange)
+    return completions, region, should
+end
 
 function Juco.repl_mode!(; db_path::AbstractString = Juco.DEFAULT_DB_PATH, start_key::Char = '}', kw...)
     st = Juco.mode_state(db_path)
@@ -10,6 +25,7 @@ function Juco.repl_mode!(; db_path::AbstractString = Juco.DEFAULT_DB_PATH, start
         start_key = start_key,
         mode_name = :juco,
         valid_input_checker = Returns(true),
+        completion_provider = SkillCompletionProvider(st.skills),
         startup_text = true)
     return nothing
 end

--- a/Juco/src/Juco.jl
+++ b/Juco/src/Juco.jl
@@ -15,16 +15,20 @@ module Juco
 using Dates
 using JSON
 using Markdown
+using REPL.TerminalMenus
 using Agentif
 using LLMTools
 using LLMProviders
+using LLMOAuth
 using SQLite
 using LocalSearch
 
 include("db.jl")
 include("tools.jl")
 include("prompt.jl")
+include("skills.jl")
 include("display.jl")
+include("modes.jl")
 include("agent.jl")
 
 export repl

--- a/Juco/src/Juco.jl
+++ b/Juco/src/Juco.jl
@@ -15,6 +15,7 @@ module Juco
 using Dates
 using JSON
 using Markdown
+import REPL
 using REPL.TerminalMenus
 using Agentif
 using LLMTools

--- a/Juco/src/Juco.jl
+++ b/Juco/src/Juco.jl
@@ -13,6 +13,8 @@ Usage:
 module Juco
 
 using Dates
+using JSON
+using Markdown
 using Agentif
 using LLMTools
 using LLMProviders
@@ -22,6 +24,7 @@ using LocalSearch
 include("db.jl")
 include("tools.jl")
 include("prompt.jl")
+include("display.jl")
 include("agent.jl")
 
 export repl

--- a/Juco/src/agent.jl
+++ b/Juco/src/agent.jl
@@ -313,7 +313,15 @@ function handle_command(st::ReplState, input::AbstractString, io::IO)
         if length(parts) == 1
             model_menu!(st, io)
         else
-            mode, mid = length(parts) >= 3 ? (String(parts[2]), String(parts[3])) : (st.mode, String(parts[2]))
+            length(parts) <= 3 || return println(io, red(io,
+                "usage: /model [mode] [model-id]"))
+            mode, mid = if length(parts) == 3
+                String(parts[2]), String(parts[3])
+            elseif parts[2] in MODEL_MODES
+                String(parts[2]), MODE_DEFAULT_MODEL[String(parts[2])]
+            else
+                st.mode, String(parts[2])
+            end
             mode in MODEL_MODES || return println(io, red(io, "unknown mode: $(mode) (expected $(join(MODEL_MODES, " or ")))"))
             getModel(mode_provider(mode), mid) === nothing && return println(io, red(io, "unknown model: $(mode)/$(mid)"))
             st.mode, st.model_id = mode, mid

--- a/Juco/src/agent.jl
+++ b/Juco/src/agent.jl
@@ -227,23 +227,11 @@ function _evaluate(input::AbstractString;
         on_event === nothing || on_event(event)
         return nothing
     end
-    # Reasoning config shape differs per API: OpenRouter-style models take
-    # {"reasoning": {"effort": ...}}, codex takes a plain reasoning string, and
-    # native OpenAI reasoning models take reasoning_effort.
-    is_openrouter = agent.model.compat !== nothing &&
-        get(agent.model.compat, "thinkingFormat", "") == "openrouter"
-    eval_kw = if reasoning_effort === nothing
-        (;)
-    elseif is_openrouter
-        (; reasoning = Dict("effort" => reasoning_effort))
-    elseif agent.model.api == "openai-codex"
-        (; reasoning = reasoning_effort)
-    else
-        (; reasoning_effort)
-    end
+    eval_kw = reasoning_options(agent.model, reasoning_effort)
+    is_openrouter = agent.model.provider == "openrouter"
     is_openrouter && (eval_kw = merge(eval_kw, (; provider = openrouter_provider_prefs())))
     # codex manages its own sampling; other completions APIs take a temperature pin
-    temperature !== nothing && agent.model.api != "openai-codex" &&
+    temperature !== nothing && agent.model.provider != "openai-codex" &&
         (eval_kw = merge(eval_kw, (; temperature = Float64(temperature))))
     t0 = time()
     state = Agentif.evaluate(handler, agent, String(input);
@@ -258,6 +246,17 @@ function _evaluate(input::AbstractString;
     end
     return (; state, session_id = sid, tool_calls = tool_calls[],
         aborted = Agentif.isaborted(abort), ctx_pct)
+end
+
+# OpenRouter enables some reasoning models by default. An omitted setting does
+# not mean "none", so send the user's disabled selection explicitly.
+function reasoning_options(model, reasoning_effort::Union{Nothing, AbstractString})
+    if model.provider == "openrouter" && model.reasoning
+        return (; reasoning = Dict("effort" => something(reasoning_effort, "none")))
+    elseif reasoning_effort === nothing
+        return (;)
+    end
+    return (; reasoning_effort = String(reasoning_effort))
 end
 
 # Estimated share of the model's context window occupied by the conversation.
@@ -485,7 +484,11 @@ function wait_turn(turn::Task, abort::Agentif.Abort, io::IO;
     end
 end
 
-function run_turn(st::ReplState, input::String, io::IO; steering::Bool = stdin isa Base.TTY, kw...)
+function run_turn(st::ReplState, input::String, io::IO;
+        steering::Bool = stdin isa Base.TTY,
+        evaluator::Function = evaluate,
+        kw...,
+    )
     expanded, used = expand_skills(input, st.skills)
     isempty(used) || println(io, dim(io, "⚡ skills: " * join(used, ", ")))
     abort = Agentif.Abort()
@@ -506,7 +509,8 @@ function run_turn(st::ReplState, input::String, io::IO; steering::Bool = stdin i
             reserve_tokens = max(cw - 1_000, 1_000), keep_recent_tokens = 2_000))
     end
     t0 = time()
-    turn = @async evaluate(expanded; jdb = st.jdb, session_id = st.session_id,
+    turn = @async evaluator(expanded; jdb = st.jdb, session_id = st.session_id,
+        base_dir = st.base_dir,
         provider = mode_provider(st.mode), model_id = st.model_id,
         apikey = mode_apikey(st.mode), reasoning_effort = st.reasoning,
         io, show_usage = true, abort, steer, on_steer, io_lock, extra_kw..., kw...)

--- a/Juco/src/agent.jl
+++ b/Juco/src/agent.jl
@@ -167,9 +167,19 @@ SQLite db under `session_id`, so repeated calls with the same `session_id`
 continue the conversation.
 """
 function evaluate(input::AbstractString;
-        base_dir::AbstractString = pwd(),
         db_path::AbstractString = DEFAULT_DB_PATH,
-        jdb::JucoDB = opendb(db_path),
+        jdb::Union{Nothing, JucoDB} = nothing,
+        kw...,
+    )
+    jdb === nothing && return with_jdb(db_path) do owned_jdb
+        _evaluate(input; jdb = owned_jdb, kw...)
+    end
+    return _evaluate(input; jdb, kw...)
+end
+
+function _evaluate(input::AbstractString;
+        base_dir::AbstractString = pwd(),
+        jdb::JucoDB,
         session_id::Union{Nothing, AbstractString} = nothing,
         io::IO = stdout,
         show_tools::Bool = true,
@@ -460,7 +470,18 @@ function repl(;
         io::IO = stdout,
         kw...,
     )
-    jdb = opendb(db_path)
+    return with_jdb(db_path) do jdb
+        _repl(jdb; db_path, continue_last, base_dir, io, kw...)
+    end
+end
+
+function _repl(jdb::JucoDB;
+        db_path::AbstractString,
+        continue_last::Bool,
+        base_dir::AbstractString,
+        io::IO,
+        kw...,
+    )
     session_id = continue_last ? latest_session(jdb) : nothing
     continue_last && session_id === nothing && println(io, "No previous session found; starting a new one.")
     session_id === nothing && (session_id = "juco-" * string(Agentif.UID8()))
@@ -520,12 +541,13 @@ function mode_eval(st::ReplState, input::AbstractString; kw...)
 end
 
 function print_sessions(db_path::AbstractString)
-    jdb = opendb(db_path)
-    sessions = list_sessions(jdb)
-    isempty(sessions) && return println("No sessions.")
-    for s in sessions
-        ts = Dates.format(Dates.unix2datetime(s.updated_at), "yyyy-mm-dd HH:MM")
-        println("$(s.id)  $(ts)  $(s.cwd)  $(s.title)")
+    return with_jdb(db_path) do jdb
+        sessions = list_sessions(jdb)
+        isempty(sessions) && return println("No sessions.")
+        for s in sessions
+            ts = Dates.format(Dates.unix2datetime(s.updated_at), "yyyy-mm-dd HH:MM")
+            println("$(s.id)  $(ts)  $(s.cwd)  $(s.title)")
+        end
     end
 end
 
@@ -625,9 +647,10 @@ function main(args::Vector{String} = ARGS)
     opts.list && return print_sessions(opts.db_path)
     if opts.prompt !== nothing
         (; db_path, base_dir, provider, model_id, preset, continue_last, prompt) = opts
-        jdb = opendb(db_path)
-        session_id = continue_last ? latest_session(jdb) : nothing
-        evaluate(prompt; jdb, session_id, base_dir, provider, model_id, preset)
+        with_jdb(db_path) do jdb
+            session_id = continue_last ? latest_session(jdb) : nothing
+            evaluate(prompt; jdb, session_id, base_dir, provider, model_id, preset)
+        end
     else
         repl(; db_path = opts.db_path, continue_last = opts.continue_last,
             base_dir = opts.base_dir, preset = opts.preset)

--- a/Juco/src/agent.jl
+++ b/Juco/src/agent.jl
@@ -570,7 +570,7 @@ Flags:
 The interactive session uses the persisted model selection (see /model).
 """
 
-function main(args::Vector{String} = ARGS)
+function parse_cli_args(args::Vector{String})
     db_path = DEFAULT_DB_PATH
     base_dir = pwd()
     provider = default_provider()
@@ -578,38 +578,59 @@ function main(args::Vector{String} = ARGS)
     preset = :juco
     continue_last = false
     prompt = nothing
+    list = false
+    help = false
     i = 1
     while i <= length(args)
         a = args[i]
         if a in ("-h", "--help")
-            return print(CLI_HELP)
+            help = true
+            break
         elseif a in ("-c", "--continue")
             continue_last = true
         elseif a in ("-l", "--list")
-            return print_sessions(db_path)
+            list = true
         elseif a in ("-p", "--prompt")
+            i < length(args) || throw(ArgumentError("$a requires a value"))
             i += 1; prompt = args[i]
         elseif a == "--db"
+            i < length(args) || throw(ArgumentError("$a requires a value"))
             i += 1; db_path = args[i]
         elseif a == "--dir"
+            i < length(args) || throw(ArgumentError("$a requires a value"))
             i += 1; base_dir = args[i]
         elseif a == "--provider"
+            i < length(args) || throw(ArgumentError("$a requires a value"))
             i += 1; provider = args[i]
         elseif a == "--model"
+            i < length(args) || throw(ArgumentError("$a requires a value"))
             i += 1; model_id = args[i]
         elseif a == "--preset"
+            i < length(args) || throw(ArgumentError("$a requires a value"))
             i += 1; preset = Symbol(args[i])
         else
-            error("Unknown flag: $a (see juco --help)")
+            throw(ArgumentError("Unknown flag: $a (see juco --help)"))
         end
         i += 1
     end
-    if prompt !== nothing
+    preset in (:juco, :pi, :bash) ||
+        throw(ArgumentError("unknown preset: $preset (expected juco, pi, or bash)"))
+    list && prompt !== nothing && throw(ArgumentError("--list and --prompt cannot be used together"))
+    return (; db_path, base_dir, provider, model_id, preset, continue_last, prompt, list, help)
+end
+
+function main(args::Vector{String} = ARGS)
+    opts = parse_cli_args(args)
+    opts.help && return print(CLI_HELP)
+    opts.list && return print_sessions(opts.db_path)
+    if opts.prompt !== nothing
+        (; db_path, base_dir, provider, model_id, preset, continue_last, prompt) = opts
         jdb = opendb(db_path)
         session_id = continue_last ? latest_session(jdb) : nothing
         evaluate(prompt; jdb, session_id, base_dir, provider, model_id, preset)
     else
-        repl(; db_path, continue_last, base_dir, preset)
+        repl(; db_path = opts.db_path, continue_last = opts.continue_last,
+            base_dir = opts.base_dir, preset = opts.preset)
     end
     return nothing
 end

--- a/Juco/src/agent.jl
+++ b/Juco/src/agent.jl
@@ -196,8 +196,8 @@ function _evaluate(input::AbstractString;
         kw...,
     )
     sid = session_id === nothing ? "juco-" * string(Agentif.UID8()) : String(session_id)
-    touch_session!(jdb, sid; title = first(String(input), 80), cwd = abspath(base_dir))
     agent = build_agent(; base_dir, jdb, kw...)
+    touch_session!(jdb, sid; title = first(String(input), 80), cwd = abspath(base_dir))
     ch = TerminalChannel(sid, io; io_lock)
     # tool executions run on concurrent tasks, so the counter must be atomic
     tool_calls = Threads.Atomic{Int}(0)

--- a/Juco/src/agent.jl
+++ b/Juco/src/agent.jl
@@ -5,6 +5,22 @@ default_model() = get(ENV, "JUCO_MODEL", "claude-sonnet-4-5")
 default_reasoning() = let v = get(ENV, "JUCO_REASONING", ""); isempty(v) ? nothing : v end
 const DEFAULT_MAX_TURNS = 50
 
+# OpenRouter routing preferences. Sorting by price keeps routing stable so
+# upstream prompt caches stay warm across a session's turns (round-robin
+# routing defeats them) — but with a quality floor: endpoints must support all
+# request parameters (tools!) and fp4-class quantizations are excluded, since
+# an fp4 endpoint was observed emitting raw tool-call markup as text.
+# JUCO_OPENROUTER_ORDER pins specific endpoint tags, comma-separated.
+function openrouter_provider_prefs()
+    order = get(ENV, "JUCO_OPENROUTER_ORDER", "")
+    isempty(order) || return Dict{String, Any}("order" => strip.(split(order, ",")), "allow_fallbacks" => true)
+    return Dict{String, Any}(
+        "sort" => "price",
+        "require_parameters" => true,
+        "quantizations" => ["fp8", "int8", "fp16", "bf16", "unknown"],
+    )
+end
+
 const PROVIDER_KEY_ENV = Dict(
     "anthropic" => "ANTHROPIC_API_KEY",
     "openai" => "OPENAI_API_KEY",
@@ -126,13 +142,15 @@ function evaluate(input::AbstractString;
     end
     # OpenRouter-style models take {"reasoning": {"effort": ...}}; native OpenAI
     # reasoning models take reasoning_effort. Send the shape the model expects.
+    is_openrouter = get(agent.model.compat, "thinkingFormat", "") == "openrouter"
     eval_kw = if reasoning_effort === nothing
         (;)
-    elseif get(agent.model.compat, "thinkingFormat", "") == "openrouter"
+    elseif is_openrouter
         (; reasoning = Dict("effort" => reasoning_effort))
     else
         (; reasoning_effort)
     end
+    is_openrouter && (eval_kw = merge(eval_kw, (; provider = openrouter_provider_prefs())))
     state = Agentif.evaluate(handler, agent, String(input);
         session_store = jdb.session_store, channel = ch, abort, level, eval_kw...)
     return (; state, session_id = sid, tool_calls = tool_calls[], aborted = Agentif.isaborted(abort))

--- a/Juco/src/agent.jl
+++ b/Juco/src/agent.jl
@@ -99,13 +99,14 @@ function build_agent(;
         model_id::String = default_model(),
         apikey::String = "",
         memory_limit::Int = 50,
+        max_turns::Union{Nothing, Int} = nothing,
     )
     model = getModel(provider, model_id)
     model === nothing && error("Unknown model: provider=$(repr(provider)) model_id=$(repr(model_id))")
     isempty(apikey) && (apikey = resolve_apikey(provider))
     mems = (jdb !== nothing && preset === :juco) ? memories(jdb; limit = memory_limit) : String[]
     return Agentif.Agent(
-        prompt = build_prompt(base_dir, preset; memories = mems),
+        prompt = build_prompt(base_dir, preset; memories = mems, max_turns),
         model = model,
         apikey = apikey,
         tools = toolset(preset, base_dir, jdb),
@@ -199,7 +200,7 @@ function _evaluate(input::AbstractString;
         kw...,
     )
     sid = session_id === nothing ? "juco-" * string(Agentif.UID8()) : String(session_id)
-    agent = build_agent(; base_dir, jdb, kw...)
+    agent = build_agent(; base_dir, jdb, max_turns, kw...)
     ch = TerminalChannel(sid, io; io_lock)
     # tool executions run on concurrent tasks, so the counter must be atomic
     tool_calls = Threads.Atomic{Int}(0)

--- a/Juco/src/agent.jl
+++ b/Juco/src/agent.jl
@@ -197,7 +197,6 @@ function _evaluate(input::AbstractString;
     )
     sid = session_id === nothing ? "juco-" * string(Agentif.UID8()) : String(session_id)
     agent = build_agent(; base_dir, jdb, kw...)
-    touch_session!(jdb, sid; title = first(String(input), 80), cwd = abspath(base_dir))
     ch = TerminalChannel(sid, io; io_lock)
     # tool executions run on concurrent tasks, so the counter must be atomic
     tool_calls = Threads.Atomic{Int}(0)
@@ -231,6 +230,7 @@ function _evaluate(input::AbstractString;
     t0 = time()
     state = Agentif.evaluate(handler, agent, String(input);
         session_store = jdb.session_store, channel = ch, abort, level, eval_kw...)
+    touch_session!(jdb, sid; title = first(String(input), 80), cwd = abspath(base_dir))
     if show_usage
         ctx_pct = context_percent(agent, state)
         lock(io_lock) do

--- a/Juco/src/agent.jl
+++ b/Juco/src/agent.jl
@@ -2,6 +2,7 @@
 
 default_provider() = get(ENV, "JUCO_MODEL_PROVIDER", "anthropic")
 default_model() = get(ENV, "JUCO_MODEL", "claude-sonnet-4-5")
+default_reasoning() = let v = get(ENV, "JUCO_REASONING", ""); isempty(v) ? nothing : v end
 const DEFAULT_MAX_TURNS = 50
 
 const PROVIDER_KEY_ENV = Dict(
@@ -76,6 +77,8 @@ function evaluate(input::AbstractString;
         io::IO = stdout,
         show_tools::Bool = true,
         max_turns::Int = DEFAULT_MAX_TURNS,
+        reasoning_effort::Union{Nothing, String} = default_reasoning(),
+        on_event::Union{Nothing, Function} = nothing,
         level = nothing,
         kw...,
     )
@@ -98,10 +101,20 @@ function evaluate(input::AbstractString;
         elseif event isa Agentif.AgentErrorEvent && show_tools
             println(io, "\e[31m[error] $(event.error)\e[0m")
         end
+        on_event === nothing || on_event(event)
         return nothing
     end
+    # OpenRouter-style models take {"reasoning": {"effort": ...}}; native OpenAI
+    # reasoning models take reasoning_effort. Send the shape the model expects.
+    eval_kw = if reasoning_effort === nothing
+        (;)
+    elseif get(agent.model.compat, "thinkingFormat", "") == "openrouter"
+        (; reasoning = Dict("effort" => reasoning_effort))
+    else
+        (; reasoning_effort)
+    end
     state = Agentif.evaluate(handler, agent, String(input);
-        session_store = jdb.session_store, channel = ch, abort, level)
+        session_store = jdb.session_store, channel = ch, abort, level, eval_kw...)
     return (; state, session_id = sid, tool_calls = tool_calls[], aborted = Agentif.isaborted(abort))
 end
 

--- a/Juco/src/agent.jl
+++ b/Juco/src/agent.jl
@@ -562,14 +562,20 @@ end
 shell_project_argument(project::AbstractString) =
     Base.shell_escape_posixly("--project=$(project)")
 
+function active_project_dir()
+    project = Base.active_project()
+    project === nothing && error("no active Julia project; start Julia with --project before installing the launcher")
+    return dirname(project)
+end
+
 """
     Juco.install_cli(; dir = joinpath(homedir(), ".local", "bin"))
 
 Write a `juco` launcher script to `dir` so the agent can be started from any
-shell. The script runs this monorepo's environment.
+shell. The script runs the active Julia environment that loaded Juco.
 """
 function install_cli(; dir::AbstractString = joinpath(homedir(), ".local", "bin"))
-    project = dirname(pkgdir(Juco))
+    project = active_project_dir()
     mkpath(dir)
     path = joinpath(dir, "juco")
     write(path, """

--- a/Juco/src/agent.jl
+++ b/Juco/src/agent.jl
@@ -4,7 +4,13 @@ default_provider() = get(ENV, "JUCO_MODEL_PROVIDER", "anthropic")
 default_model() = get(ENV, "JUCO_MODEL", "claude-sonnet-4-5")
 default_reasoning() = let v = get(ENV, "JUCO_REASONING", ""); isempty(v) ? nothing : v end
 # Coding agents want low-variance sampling; JUCO_TEMPERATURE="" disables the pin.
-default_temperature() = tryparse(Float64, get(ENV, "JUCO_TEMPERATURE", "0.2"))
+function default_temperature()
+    raw = get(ENV, "JUCO_TEMPERATURE", "0.2")
+    isempty(raw) && return nothing
+    value = tryparse(Float64, raw)
+    value === nothing && throw(ArgumentError("JUCO_TEMPERATURE must be a number or empty"))
+    return value
+end
 const DEFAULT_MAX_TURNS = 50
 
 # OpenRouter routing preferences. Sorting by price keeps routing stable so
@@ -190,7 +196,7 @@ function _evaluate(input::AbstractString;
         show_usage::Bool = false,
         max_turns::Int = DEFAULT_MAX_TURNS,
         reasoning_effort::Union{Nothing, String} = default_reasoning(),
-        temperature::Union{Nothing, Float64} = default_temperature(),
+        temperature::Union{Nothing, Real} = default_temperature(),
         on_event::Union{Nothing, Function} = nothing,
         abort::Agentif.Abort = Agentif.Abort(),
         steer::Union{Nothing, Channel{String}} = nothing,
@@ -208,19 +214,24 @@ function _evaluate(input::AbstractString;
     agent = Agentif.with_tools(agent,
         Agentif.AgentTool[instrument_tool(t, tool_calls, max_turns, steer, on_steer, steer_lock) for t in agent.tools])
     disp = show_tools ? display_handler(io; show_reasoning, io_lock) : nothing
+    fatal_error = Ref{Union{Nothing, Exception}}(nothing)
     handler = function (event)
         if event isa Agentif.ToolExecutionStartEvent
             n = Threads.atomic_add!(tool_calls, 1) + 1
             n > max_turns && Agentif.abort!(abort)
         end
-        disp === nothing || disp(event)
+        fatal = event isa Agentif.AgentErrorEvent &&
+            !startswith(sprint(showerror, event.error), "SSE stream interrupted:")
+        fatal && (fatal_error[] = event.error)
+        (disp === nothing || fatal) || disp(event)
         on_event === nothing || on_event(event)
         return nothing
     end
     # Reasoning config shape differs per API: OpenRouter-style models take
     # {"reasoning": {"effort": ...}}, codex takes a plain reasoning string, and
     # native OpenAI reasoning models take reasoning_effort.
-    is_openrouter = get(agent.model.compat, "thinkingFormat", "") == "openrouter"
+    is_openrouter = agent.model.compat !== nothing &&
+        get(agent.model.compat, "thinkingFormat", "") == "openrouter"
     eval_kw = if reasoning_effort === nothing
         (;)
     elseif is_openrouter
@@ -233,10 +244,11 @@ function _evaluate(input::AbstractString;
     is_openrouter && (eval_kw = merge(eval_kw, (; provider = openrouter_provider_prefs())))
     # codex manages its own sampling; other completions APIs take a temperature pin
     temperature !== nothing && agent.model.api != "openai-codex" &&
-        (eval_kw = merge(eval_kw, (; temperature)))
+        (eval_kw = merge(eval_kw, (; temperature = Float64(temperature))))
     t0 = time()
     state = Agentif.evaluate(handler, agent, String(input);
         session_store = jdb.session_store, channel = ch, abort, level, eval_kw...)
+    fatal_error[] === nothing || throw(fatal_error[])
     touch_session!(jdb, sid; title = first(String(input), 80), cwd = abspath(base_dir))
     ctx_pct = context_percent(agent, state)
     if show_usage

--- a/Juco/src/agent.jl
+++ b/Juco/src/agent.jl
@@ -3,6 +3,8 @@
 default_provider() = get(ENV, "JUCO_MODEL_PROVIDER", "anthropic")
 default_model() = get(ENV, "JUCO_MODEL", "claude-sonnet-4-5")
 default_reasoning() = let v = get(ENV, "JUCO_REASONING", ""); isempty(v) ? nothing : v end
+# Coding agents want low-variance sampling; JUCO_TEMPERATURE="" disables the pin.
+default_temperature() = tryparse(Float64, get(ENV, "JUCO_TEMPERATURE", "0.2"))
 const DEFAULT_MAX_TURNS = 50
 
 # OpenRouter routing preferences. Sorting by price keeps routing stable so
@@ -187,6 +189,7 @@ function _evaluate(input::AbstractString;
         show_usage::Bool = false,
         max_turns::Int = DEFAULT_MAX_TURNS,
         reasoning_effort::Union{Nothing, String} = default_reasoning(),
+        temperature::Union{Nothing, Float64} = default_temperature(),
         on_event::Union{Nothing, Function} = nothing,
         abort::Agentif.Abort = Agentif.Abort(),
         steer::Union{Nothing, Channel{String}} = nothing,
@@ -227,6 +230,9 @@ function _evaluate(input::AbstractString;
         (; reasoning_effort)
     end
     is_openrouter && (eval_kw = merge(eval_kw, (; provider = openrouter_provider_prefs())))
+    # codex manages its own sampling; other completions APIs take a temperature pin
+    temperature !== nothing && agent.model.api != "openai-codex" &&
+        (eval_kw = merge(eval_kw, (; temperature)))
     t0 = time()
     state = Agentif.evaluate(handler, agent, String(input);
         session_store = jdb.session_store, channel = ch, abort, level, eval_kw...)

--- a/Juco/src/agent.jl
+++ b/Juco/src/agent.jl
@@ -163,7 +163,7 @@ with_budget_notice(tool::Agentif.AgentTool, counter::Threads.Atomic{Int}, max_tu
 # ─── One-shot evaluation (used by the REPL per turn, and by the eval harness) ───
 
 """
-    Juco.evaluate(input; kw...) -> (; state, session_id, tool_calls, aborted)
+    Juco.evaluate(input; kw...) -> (; state, session_id, tool_calls, aborted, ctx_pct)
 
 Run one agent turn. Session history is persisted to (and reloaded from) the
 SQLite db under `session_id`, so repeated calls with the same `session_id`
@@ -238,13 +238,14 @@ function _evaluate(input::AbstractString;
     state = Agentif.evaluate(handler, agent, String(input);
         session_store = jdb.session_store, channel = ch, abort, level, eval_kw...)
     touch_session!(jdb, sid; title = first(String(input), 80), cwd = abspath(base_dir))
+    ctx_pct = context_percent(agent, state)
     if show_usage
-        ctx_pct = context_percent(agent, state)
         lock(io_lock) do
             println(io, dim(io, usage_line(state.usage, agent.model, tool_calls[], time() - t0; ctx_pct)))
         end
     end
-    return (; state, session_id = sid, tool_calls = tool_calls[], aborted = Agentif.isaborted(abort))
+    return (; state, session_id = sid, tool_calls = tool_calls[],
+        aborted = Agentif.isaborted(abort), ctx_pct)
 end
 
 # Estimated share of the model's context window occupied by the conversation.
@@ -306,13 +307,21 @@ end
 model_label(st::ReplState) =
     "$(st.mode) · $(st.model_id)" * (st.reasoning === nothing ? "" : " · $(st.reasoning)")
 
+function switch_session!(st::ReplState, session_id::AbstractString)
+    st.session_id = String(session_id)
+    st.force_compact = false
+    st.last_answer = ""
+    st.last_ctx_pct = nothing
+    return nothing
+end
+
 function handle_command(st::ReplState, input::AbstractString, io::IO)
     parts = split(strip(input))
     cmd = parts[1]
     if cmd == "/help"
         println(io, REPL_HELP)
     elseif cmd == "/new"
-        st.session_id = "juco-" * string(Agentif.UID8())
+        switch_session!(st, "juco-" * string(Agentif.UID8()))
         println(io, dim(io, "new session $(st.session_id)"))
     elseif cmd == "/sessions"
         sessions = list_sessions(st.jdb)
@@ -324,7 +333,7 @@ function handle_command(st::ReplState, input::AbstractString, io::IO)
         end
     elseif cmd == "/resume"
         if length(parts) >= 2
-            st.session_id = String(parts[2])
+            switch_session!(st, parts[2])
             println(io, dim(io, "resumed $(st.session_id)"))
         else
             resume_menu!(st, io)
@@ -507,10 +516,16 @@ function run_turn(st::ReplState, input::String, io::IO; steering::Bool = stdin i
         result = wait_turn(turn, abort, io; io_lock)
         if result !== nothing
             note_turn_result!(st, result, model)
-            steered[] > 0 && println(io, dim(io, "↳ $(steered[]) steering message$(steered[] == 1 ? "" : "s") delivered"))
+            steered[] > 0 && locked_println(io, io_lock,
+                dim(io, "↳ $(steered[]) steering message$(steered[] == 1 ? "" : "s") delivered"))
         end
         # ring the bell after long turns so a tabbed-away user notices
-        time() - t0 > 30 && stdin isa Base.TTY && (print(io, "\a"); flush(io))
+        if time() - t0 > 30 && stdin isa Base.TTY
+            lock(io_lock) do
+                print(io, "\a")
+                flush(io)
+            end
+        end
         return result
     finally
         steer === nothing || !isopen(steer) || close(steer)
@@ -534,7 +549,9 @@ end
 function note_turn_result!(st::ReplState, result, model)
     msg = Agentif.last_assistant_message(result.state)
     msg === nothing || (st.last_answer = Agentif.message_text(msg))
-    if model !== nothing && model.contextWindow > 0
+    if hasproperty(result, :ctx_pct)
+        st.last_ctx_pct = result.ctx_pct
+    elseif model !== nothing && model.contextWindow > 0
         est = Agentif.estimate_context_tokens(result.state.messages)
         st.last_ctx_pct = clamp(round(Int, 100 * est / model.contextWindow), 0, 100)
     end

--- a/Juco/src/agent.jl
+++ b/Juco/src/agent.jl
@@ -102,15 +102,32 @@ function build_agent(;
     )
 end
 
-# Warn the model inside tool results when the tool-call budget runs low, so it
-# wraps up instead of being cut off mid-flight (SWE-agent's cost-limit pattern).
+# Tool instrumentation: appended to each tool result as needed —
+#   - budget notice: warn the model when the tool-call budget runs low, so it
+#     wraps up instead of being cut off mid-flight (SWE-agent's pattern)
+#   - steering: user messages typed while the model works are delivered with
+#     the next completed tool result (`on_steer` fires at delivery, so the UI
+#     can show exactly when a queued message became active)
 const BUDGET_WARN_MARGIN = 5
 
-function with_budget_notice(tool::Agentif.AgentTool{F, T}, counter::Threads.Atomic{Int}, max_turns::Int) where {F, T}
+function instrument_tool(tool::Agentif.AgentTool{F, T}, counter::Threads.Atomic{Int}, max_turns::Int,
+        steer::Union{Nothing, Channel{String}}, on_steer::Union{Nothing, Function}) where {F, T}
     wrapped = function (args...)
         result = tool.func(args...)
+        result isa String || return result
+        if steer !== nothing
+            texts = String[]
+            while isready(steer)
+                push!(texts, take!(steer))
+            end
+            if !isempty(texts)
+                on_steer === nothing || foreach(on_steer, texts)
+                result *= "\n\n[the user interjected with new instructions — take them into account now]:\n" *
+                    join(texts, "\n")
+            end
+        end
         used = counter[]
-        if result isa String && used >= max_turns - BUDGET_WARN_MARGIN
+        if used >= max_turns - BUDGET_WARN_MARGIN
             remaining = max(0, max_turns - used)
             result *= "\n\n[harness: only $(remaining) tool calls remain — wrap up now: make your final change and verify]"
         end
@@ -119,6 +136,10 @@ function with_budget_notice(tool::Agentif.AgentTool{F, T}, counter::Threads.Atom
     return Agentif.AgentTool{typeof(wrapped), T}(;
         name = tool.name, description = tool.description, strict = tool.strict, func = wrapped)
 end
+
+# kept for API/tests compatibility: budget-only instrumentation
+with_budget_notice(tool::Agentif.AgentTool, counter::Threads.Atomic{Int}, max_turns::Int) =
+    instrument_tool(tool, counter, max_turns, nothing, nothing)
 
 # ─── One-shot evaluation (used by the REPL per turn, and by the eval harness) ───
 
@@ -142,6 +163,8 @@ function evaluate(input::AbstractString;
         reasoning_effort::Union{Nothing, String} = default_reasoning(),
         on_event::Union{Nothing, Function} = nothing,
         abort::Agentif.Abort = Agentif.Abort(),
+        steer::Union{Nothing, Channel{String}} = nothing,
+        on_steer::Union{Nothing, Function} = nothing,
         level = nothing,
         kw...,
     )
@@ -152,7 +175,7 @@ function evaluate(input::AbstractString;
     # tool executions run on concurrent tasks, so the counter must be atomic
     tool_calls = Threads.Atomic{Int}(0)
     agent = Agentif.with_tools(agent,
-        Agentif.AgentTool[with_budget_notice(t, tool_calls, max_turns) for t in agent.tools])
+        Agentif.AgentTool[instrument_tool(t, tool_calls, max_turns, steer, on_steer) for t in agent.tools])
     disp = show_tools ? display_handler(io; show_reasoning) : nothing
     handler = function (event)
         if event isa Agentif.ToolExecutionStartEvent
@@ -163,13 +186,16 @@ function evaluate(input::AbstractString;
         on_event === nothing || on_event(event)
         return nothing
     end
-    # OpenRouter-style models take {"reasoning": {"effort": ...}}; native OpenAI
-    # reasoning models take reasoning_effort. Send the shape the model expects.
+    # Reasoning config shape differs per API: OpenRouter-style models take
+    # {"reasoning": {"effort": ...}}, codex takes a plain reasoning string, and
+    # native OpenAI reasoning models take reasoning_effort.
     is_openrouter = get(agent.model.compat, "thinkingFormat", "") == "openrouter"
     eval_kw = if reasoning_effort === nothing
         (;)
     elseif is_openrouter
         (; reasoning = Dict("effort" => reasoning_effort))
+    elseif agent.model.api == "openai-codex"
+        (; reasoning = reasoning_effort)
     else
         (; reasoning_effort)
     end
@@ -177,8 +203,19 @@ function evaluate(input::AbstractString;
     t0 = time()
     state = Agentif.evaluate(handler, agent, String(input);
         session_store = jdb.session_store, channel = ch, abort, level, eval_kw...)
-    show_usage && println(io, dim(io, usage_line(state.usage, agent.model, tool_calls[], time() - t0)))
+    if show_usage
+        ctx_pct = context_percent(agent, state)
+        println(io, dim(io, usage_line(state.usage, agent.model, tool_calls[], time() - t0; ctx_pct)))
+    end
     return (; state, session_id = sid, tool_calls = tool_calls[], aborted = Agentif.isaborted(abort))
+end
+
+# Estimated share of the model's context window occupied by the conversation.
+function context_percent(agent::Agentif.Agent, state::Agentif.AgentState)
+    cw = agent.model.contextWindow
+    cw > 0 || return nothing
+    est = Agentif.estimate_context_tokens(state.messages) + cld(ncodeunits(agent.prompt), 4)
+    return clamp(round(Int, 100 * est / cw), 0, 100)
 end
 
 # ─── REPL / CLI ───
@@ -187,21 +224,37 @@ const REPL_HELP = """
 /help                 show this help
 /new                  start a new session
 /sessions             list recent sessions
-/resume [id]          resume a session (most recent if no id)
-/model [prov] [id]    show or switch the model
+/resume [id]          pick a past session to resume (menu when no id)
+/model [mode] [id]    choose model mode, model, and reasoning (menus when no args)
+/skills               list \$skills discovered from ~/.agent/skills and ./.agent/skills
 /memories             list saved memories
 /quit                 exit (also: exit, quit, ctrl-d)
+Use \$skill-name in a prompt to inject a skill (tab-completes in juco> mode).
+Typing while the model works queues a steering message for the next tool boundary.
 End a line with \\ to continue typing on the next line.
 Ctrl-C during a response interrupts that response, not the REPL."""
 
-# Mutable REPL state threaded through slash commands.
+# Mutable REPL state threaded through slash commands. Model selection is
+# persistent (sqlite config); skills are re-discovered each launch.
 mutable struct ReplState
     jdb::JucoDB
     session_id::String
-    provider::String
+    mode::String
     model_id::String
+    reasoning::Union{Nothing, String}
+    skills::Vector{Skill}
+    base_dir::String
     quit::Bool
 end
+
+function ReplState(jdb::JucoDB, session_id::String; base_dir::AbstractString = pwd())
+    mode, model_id, reasoning = load_model_state(jdb)
+    return ReplState(jdb, session_id, mode, model_id, reasoning,
+        discover_skills(base_dir), String(abspath(base_dir)), false)
+end
+
+model_label(st::ReplState) =
+    "$(st.mode) · $(st.model_id)" * (st.reasoning === nothing ? "" : " · $(st.reasoning)")
 
 function handle_command(st::ReplState, input::AbstractString, io::IO)
     parts = split(strip(input))
@@ -220,18 +273,28 @@ function handle_command(st::ReplState, input::AbstractString, io::IO)
             println(io, marker, s.id, dim(io, "  $(ts)  $(first(s.title, 60))"))
         end
     elseif cmd == "/resume"
-        target = length(parts) >= 2 ? String(parts[2]) : latest_session(st.jdb)
-        target === nothing && return println(io, "No sessions to resume.")
-        st.session_id = target
-        println(io, dim(io, "resumed $(st.session_id)"))
+        if length(parts) >= 2
+            st.session_id = String(parts[2])
+            println(io, dim(io, "resumed $(st.session_id)"))
+        else
+            resume_menu!(st, io)
+        end
     elseif cmd == "/model"
         if length(parts) == 1
-            println(io, "$(st.provider)/$(st.model_id)")
+            model_menu!(st, io)
         else
-            prov, mid = length(parts) >= 3 ? (String(parts[2]), String(parts[3])) : (st.provider, String(parts[2]))
-            getModel(prov, mid) === nothing && return println(io, red(io, "unknown model: $(prov)/$(mid)"))
-            st.provider, st.model_id = prov, mid
-            println(io, dim(io, "model set to $(prov)/$(mid)"))
+            mode, mid = length(parts) >= 3 ? (String(parts[2]), String(parts[3])) : (st.mode, String(parts[2]))
+            mode in MODEL_MODES || return println(io, red(io, "unknown mode: $(mode) (expected $(join(MODEL_MODES, " or ")))"))
+            getModel(mode_provider(mode), mid) === nothing && return println(io, red(io, "unknown model: $(mode)/$(mid)"))
+            st.mode, st.model_id = mode, mid
+            st.reasoning in reasoning_levels(mode, mid) || (st.reasoning = nothing)
+            save_model_state!(st.jdb, st.mode, st.model_id, st.reasoning)
+            println(io, dim(io, "model set: $(model_label(st))"))
+        end
+    elseif cmd == "/skills"
+        isempty(st.skills) && return println(io, "No skills found in $(join(skill_dirs(st.base_dir), " or ")).")
+        for s in st.skills
+            println(io, "\$", s.name, dim(io, isempty(s.description) ? "" : "  — $(s.description)"))
         end
     elseif cmd == "/memories"
         mems = memories(st.jdb)
@@ -264,37 +327,66 @@ end
 
 # Run one turn on a worker task so ctrl-c aborts the TURN (via Abort), not the
 # REPL. A second ctrl-c while aborting force-detaches.
-function run_turn(st::ReplState, input::String, io::IO; kw...)
+#
+# While the turn runs, a pump task reads stdin lines into the steering channel:
+# each line is shown as queued immediately, then echoed again (via on_steer)
+# at the moment a completed tool call actually delivers it to the model.
+function run_turn(st::ReplState, input::String, io::IO; steering::Bool = stdin isa Base.TTY, kw...)
+    expanded, used = expand_skills(input, st.skills)
+    isempty(used) || println(io, dim(io, "⚡ skills: " * join(used, ", ")))
     abort = Agentif.Abort()
-    turn = @async evaluate(input; jdb = st.jdb, session_id = st.session_id,
-        provider = st.provider, model_id = st.model_id, io, show_usage = true, abort, kw...)
-    while true
+    steer = steering ? Channel{String}(32) : nothing
+    on_steer = steer === nothing ? nothing :
+        text -> println(io, steer_active_line(io, text))
+    turn = @async evaluate(expanded; jdb = st.jdb, session_id = st.session_id,
+        provider = mode_provider(st.mode), model_id = st.model_id,
+        apikey = mode_apikey(st.mode), reasoning_effort = st.reasoning,
+        io, show_usage = true, abort, steer, on_steer, kw...)
+    pump = steer === nothing ? nothing : @async begin
         try
-            return fetch(turn)
-        catch e
-            if e isa InterruptException
-                Agentif.abort!(abort)
-                println(io, dim(io, "\n^C interrupting — waiting for the turn to stop (ctrl-c again to detach)"))
-                timedwait(() -> istaskdone(turn), 10.0; pollint = 0.1) === :ok || return nothing
-            elseif e isa TaskFailedException
-                inner = e.task.exception
-                inner isa InterruptException && continue
-                msg = sprint(showerror, inner)
-                println(io, red(io, "error: " * first(split(msg, '\n'))))
-                println(io, dim(io, "the session is intact — try again or rephrase"))
-                return nothing
-            else
-                rethrow()
+            while !istaskdone(turn)
+                raw = readline(stdin; keep = true)
+                isempty(raw) && break  # EOF
+                s = strip(raw)
+                isempty(s) && continue
+                put!(steer, String(s))
+                println(io, steer_queued_line(io, s))
+            end
+        catch
+            # interrupted at turn end, or stdin closed — either way we're done
+        end
+    end
+    try
+        while true
+            try
+                return fetch(turn)
+            catch e
+                if e isa InterruptException
+                    Agentif.abort!(abort)
+                    println(io, dim(io, "\n^C interrupting — waiting for the turn to stop (ctrl-c again to detach)"))
+                    timedwait(() -> istaskdone(turn), 10.0; pollint = 0.1) === :ok || return nothing
+                elseif e isa TaskFailedException
+                    inner = e.task.exception
+                    inner isa InterruptException && continue
+                    msg = sprint(showerror, inner)
+                    println(io, red(io, "error: " * first(split(msg, '\n'))))
+                    println(io, dim(io, "the session is intact — try again or rephrase"))
+                    return nothing
+                else
+                    rethrow()
+                end
             end
         end
+    finally
+        # unblock the pump's readline without consuming the next prompt input
+        pump === nothing || istaskdone(pump) || schedule(pump, InterruptException(); error = true)
     end
 end
 
 function repl(;
         db_path::AbstractString = DEFAULT_DB_PATH,
         continue_last::Bool = false,
-        provider::String = default_provider(),
-        model_id::String = default_model(),
+        base_dir::AbstractString = pwd(),
         io::IO = stdout,
         kw...,
     )
@@ -302,9 +394,10 @@ function repl(;
     session_id = continue_last ? latest_session(jdb) : nothing
     continue_last && session_id === nothing && println(io, "No previous session found; starting a new one.")
     session_id === nothing && (session_id = "juco-" * string(Agentif.UID8()))
-    st = ReplState(jdb, session_id, provider, model_id, false)
-    println(io, bold(io, "juco"), dim(io, " · $(provider)/$(model_id) · session $(session_id)"))
-    println(io, dim(io, "db $(abspath(db_path)) · /help for commands · exit to quit"))
+    st = ReplState(jdb, session_id; base_dir)
+    println(io, bold(io, "juco"), dim(io, " · $(model_label(st)) · session $(session_id)"))
+    skills_note = isempty(st.skills) ? "" : " · $(length(st.skills)) skill$(length(st.skills) == 1 ? "" : "s")"
+    println(io, dim(io, "db $(abspath(db_path))$(skills_note) · /help for commands · exit to quit"))
     isa(stdin, Base.TTY) && Base.exit_on_sigint(false)
     try
         while !st.quit
@@ -342,8 +435,8 @@ Requires ReplMaker: `using Juco, ReplMaker; Juco.repl_mode!()`.
 """
 function repl_mode! end
 
-mode_state(db_path::AbstractString = DEFAULT_DB_PATH) =
-    ReplState(opendb(db_path), "juco-" * string(Agentif.UID8()), default_provider(), default_model(), false)
+mode_state(db_path::AbstractString = DEFAULT_DB_PATH; base_dir::AbstractString = pwd()) =
+    ReplState(opendb(db_path), "juco-" * string(Agentif.UID8()); base_dir)
 
 function mode_eval(st::ReplState, input::AbstractString; kw...)
     s = String(strip(input))
@@ -399,10 +492,12 @@ Flags:
   -p, --prompt <text>       one-shot prompt
   --db <path>               sqlite db path (default: ~/.juco/juco.sqlite)
   --dir <path>              working directory for tools (default: pwd)
-  --provider <name>         model provider (default: \$JUCO_MODEL_PROVIDER or anthropic)
-  --model <id>              model id (default: \$JUCO_MODEL or claude-sonnet-4-5)
+  --provider <name>         one-shot only: model provider override
+  --model <id>              one-shot only: model id override
   --preset <name>           toolset preset: juco | pi | bash (default: juco)
   -h, --help                show this help
+
+The interactive session uses the persisted model selection (see /model).
 """
 
 function main(args::Vector{String} = ARGS)
@@ -444,7 +539,10 @@ function main(args::Vector{String} = ARGS)
         session_id = continue_last ? latest_session(jdb) : nothing
         evaluate(prompt; jdb, session_id, base_dir, provider, model_id, preset)
     else
-        repl(; db_path, continue_last, base_dir, provider, model_id, preset)
+        repl(; db_path, continue_last, base_dir, preset)
     end
     return nothing
 end
+
+# Entry point for `julia -m Juco` and the Pkg app shim (`pkg> app add Juco`).
+(@main)(args) = (main(collect(String, args)); Cint(0))

--- a/Juco/src/agent.jl
+++ b/Juco/src/agent.jl
@@ -257,6 +257,14 @@ end
 
 # ─── REPL / CLI ───
 
+const REPL_TIPS = [
+    "type \$ then tab in juco> mode to inject a skill into your prompt",
+    "keep typing while I work — your message steers me at the next tool boundary",
+    "/model picks the mode, model, and reasoning level; the choice persists",
+    "/copy puts my last answer on the clipboard; /compact folds old context",
+    "end a line with \\ to keep typing on the next line",
+]
+
 const REPL_HELP = """
 /help                 show this help
 /new                  start a new session
@@ -265,6 +273,8 @@ const REPL_HELP = """
 /model [mode] [id]    choose model mode, model, and reasoning (menus when no args)
 /skills               list \$skills discovered from ~/.agent/skills and ./.agent/skills
 /memories             list saved memories
+/copy                 copy the last answer to the clipboard
+/compact              fold older context into a summary on the next message
 /quit                 exit (also: exit, quit, ctrl-d)
 Use \$skill-name in a prompt to inject a skill (tab-completes in juco> mode).
 Typing while the model works queues a steering message for the next tool boundary.
@@ -282,12 +292,15 @@ mutable struct ReplState
     skills::Vector{Skill}
     base_dir::String
     quit::Bool
+    force_compact::Bool
+    last_answer::String
+    last_ctx_pct::Union{Nothing, Int}
 end
 
 function ReplState(jdb::JucoDB, session_id::String; base_dir::AbstractString = pwd())
     mode, model_id, reasoning = load_model_state(jdb)
     return ReplState(jdb, session_id, mode, model_id, reasoning,
-        discover_skills(base_dir), String(abspath(base_dir)), false)
+        discover_skills(base_dir), String(abspath(base_dir)), false, false, "", nothing)
 end
 
 model_label(st::ReplState) =
@@ -345,6 +358,22 @@ function handle_command(st::ReplState, input::AbstractString, io::IO)
         mems = memories(st.jdb)
         isempty(mems) && return println(io, "No memories.")
         foreach(m -> println(io, "- ", m), mems)
+    elseif cmd == "/copy"
+        isempty(st.last_answer) && return println(io, "Nothing to copy yet.")
+        clip = Sys.isapple() ? `pbcopy` : Sys.iswindows() ? `clip` : `xclip -selection clipboard`
+        ok = try
+            open(clip, "w") do p
+                write(p, st.last_answer)
+            end
+            true
+        catch
+            false
+        end
+        println(io, ok ? dim(io, "copied the last answer ($(length(st.last_answer)) chars)") :
+            red(io, "clipboard tool unavailable ($(clip.exec[1]))"))
+    elseif cmd == "/compact"
+        st.force_compact = true
+        println(io, dim(io, "⇣ compaction armed — older context folds into a summary on your next message"))
     elseif cmd == "/quit"
         st.quit = true
     else
@@ -354,9 +383,11 @@ function handle_command(st::ReplState, input::AbstractString, io::IO)
 end
 
 # Read one logical input: trailing backslash continues on the next line.
-# Returns nothing on EOF.
-function read_input(io::IO)
-    print(io, bold(io, "juco> "))
+# Returns nothing on EOF. When context usage is high, the prompt says so
+# (e.g. `juco 72%>`), pointing at /compact before quality degrades.
+function read_input(io::IO; ctx_pct::Union{Nothing, Int} = nothing)
+    label = ctx_pct !== nothing && ctx_pct >= 60 ? "juco $(ctx_pct)%> " : "juco> "
+    print(io, bold(io, label))
     raw = readline(stdin; keep = true)
     isempty(raw) && return nothing
     input = String(strip(raw))
@@ -439,12 +470,25 @@ function run_turn(st::ReplState, input::String, io::IO; steering::Bool = stdin i
     abort = Agentif.Abort()
     io_lock = ReentrantLock()
     steer = steering ? Channel{String}(32) : nothing
+    steered = Threads.Atomic{Int}(0)
     on_steer = steer === nothing ? nothing :
-        text -> locked_println(io, io_lock, steer_active_line(io, text))
+        text -> begin
+            Threads.atomic_add!(steered, 1)
+            locked_println(io, io_lock, steer_active_line(io, text))
+        end
+    model = getModel(mode_provider(st.mode), st.model_id)
+    extra_kw = (;)
+    if st.force_compact
+        st.force_compact = false
+        cw = model === nothing ? 128_000 : model.contextWindow
+        extra_kw = (; compaction_config = Agentif.CompactionConfig(;
+            reserve_tokens = max(cw - 1_000, 1_000), keep_recent_tokens = 2_000))
+    end
+    t0 = time()
     turn = @async evaluate(expanded; jdb = st.jdb, session_id = st.session_id,
         provider = mode_provider(st.mode), model_id = st.model_id,
         apikey = mode_apikey(st.mode), reasoning_effort = st.reasoning,
-        io, show_usage = true, abort, steer, on_steer, io_lock, kw...)
+        io, show_usage = true, abort, steer, on_steer, io_lock, extra_kw..., kw...)
     pump = steer === nothing ? nothing : @async begin
         try
             while !istaskdone(turn)
@@ -460,7 +504,14 @@ function run_turn(st::ReplState, input::String, io::IO; steering::Bool = stdin i
         end
     end
     try
-        return wait_turn(turn, abort, io; io_lock)
+        result = wait_turn(turn, abort, io; io_lock)
+        if result !== nothing
+            note_turn_result!(st, result, model)
+            steered[] > 0 && println(io, dim(io, "↳ $(steered[]) steering message$(steered[] == 1 ? "" : "s") delivered"))
+        end
+        # ring the bell after long turns so a tabbed-away user notices
+        time() - t0 > 30 && stdin isa Base.TTY && (print(io, "\a"); flush(io))
+        return result
     finally
         steer === nothing || !isopen(steer) || close(steer)
         if pump !== nothing
@@ -476,6 +527,18 @@ function run_turn(st::ReplState, input::String, io::IO; steering::Bool = stdin i
             end
         end
     end
+end
+
+# Record what the REPL wants to know about a finished turn: the final answer
+# text (/copy) and the estimated context share (prompt indicator).
+function note_turn_result!(st::ReplState, result, model)
+    msg = Agentif.last_assistant_message(result.state)
+    msg === nothing || (st.last_answer = Agentif.message_text(msg))
+    if model !== nothing && model.contextWindow > 0
+        est = Agentif.estimate_context_tokens(result.state.messages)
+        st.last_ctx_pct = clamp(round(Int, 100 * est / model.contextWindow), 0, 100)
+    end
+    return nothing
 end
 
 function repl(;
@@ -504,11 +567,12 @@ function _repl(jdb::JucoDB;
     println(io, bold(io, "juco"), dim(io, " · $(model_label(st)) · session $(session_id)"))
     skills_note = isempty(st.skills) ? "" : " · $(length(st.skills)) skill$(length(st.skills) == 1 ? "" : "s")"
     println(io, dim(io, "db $(abspath(db_path))$(skills_note) · /help for commands · exit to quit"))
+    println(io, dim(io, "tip: " * REPL_TIPS[1 + mod(Dates.dayofyear(Dates.today()), length(REPL_TIPS))]))
     isa(stdin, Base.TTY) && Base.exit_on_sigint(false)
     try
         while !st.quit
             input = try
-                read_input(io)
+                read_input(io; ctx_pct = st.last_ctx_pct)
             catch e
                 e isa InterruptException ? "" : rethrow()
             end

--- a/Juco/src/agent.jl
+++ b/Juco/src/agent.jl
@@ -60,6 +60,24 @@ function build_agent(;
     )
 end
 
+# Warn the model inside tool results when the tool-call budget runs low, so it
+# wraps up instead of being cut off mid-flight (SWE-agent's cost-limit pattern).
+const BUDGET_WARN_MARGIN = 5
+
+function with_budget_notice(tool::Agentif.AgentTool{F, T}, counter::Threads.Atomic{Int}, max_turns::Int) where {F, T}
+    wrapped = function (args...)
+        result = tool.func(args...)
+        used = counter[]
+        if result isa String && used >= max_turns - BUDGET_WARN_MARGIN
+            remaining = max(0, max_turns - used)
+            result *= "\n\n[harness: only $(remaining) tool calls remain — wrap up now: make your final change and verify]"
+        end
+        return result
+    end
+    return Agentif.AgentTool{typeof(wrapped), T}(;
+        name = tool.name, description = tool.description, strict = tool.strict, func = wrapped)
+end
+
 # ─── One-shot evaluation (used by the REPL per turn, and by the eval harness) ───
 
 """
@@ -89,6 +107,8 @@ function evaluate(input::AbstractString;
     abort = Agentif.Abort()
     # tool executions run on concurrent tasks, so the counter must be atomic
     tool_calls = Threads.Atomic{Int}(0)
+    agent = Agentif.with_tools(agent,
+        Agentif.AgentTool[with_budget_notice(t, tool_calls, max_turns) for t in agent.tools])
     handler = function (event)
         if event isa Agentif.ToolExecutionStartEvent
             n = Threads.atomic_add!(tool_calls, 1) + 1

--- a/Juco/src/agent.jl
+++ b/Juco/src/agent.jl
@@ -49,34 +49,42 @@ struct TerminalChannel <: Agentif.AbstractChannel
     io::IO
     buf::IOBuffer
     markdown::Bool
+    io_lock::ReentrantLock
 end
 
-TerminalChannel(session_id::String, io::IO; markdown::Bool = true) =
-    TerminalChannel(session_id, io, IOBuffer(), markdown)
+TerminalChannel(session_id::String, io::IO; markdown::Bool = true,
+        io_lock::ReentrantLock = ReentrantLock()) =
+    TerminalChannel(session_id, io, IOBuffer(), markdown, io_lock)
 
 Agentif.channel_id(ch::TerminalChannel) = ch.session_id
 Agentif.start_streaming(::TerminalChannel) = nothing
-Agentif.append_to_stream(ch::TerminalChannel, delta) = write(ch.buf, delta)
+Agentif.append_to_stream(ch::TerminalChannel, delta) = lock(ch.io_lock) do
+    write(ch.buf, delta)
+end
 
 function render_text(ch::TerminalChannel)
-    text = strip(String(take!(ch.buf)))
-    isempty(text) && return
-    if ch.markdown && use_color(ch.io)
-        try
-            show(IOContext(ch.io, :color => true), MIME("text/plain"), Markdown.parse(String(text)))
-            println(ch.io)
-        catch
+    lock(ch.io_lock) do
+        text = strip(String(take!(ch.buf)))
+        isempty(text) && return
+        if ch.markdown && use_color(ch.io)
+            try
+                show(IOContext(ch.io, :color => true), MIME("text/plain"), Markdown.parse(String(text)))
+                println(ch.io)
+            catch
+                println(ch.io, text)
+            end
+        else
             println(ch.io, text)
         end
-    else
-        println(ch.io, text)
+        flush(ch.io)
     end
-    flush(ch.io)
     return
 end
 
 Agentif.finish_streaming(ch::TerminalChannel) = render_text(ch)
-Agentif.send_message(ch::TerminalChannel, msg) = println(ch.io, msg)
+Agentif.send_message(ch::TerminalChannel, msg) = lock(ch.io_lock) do
+    println(ch.io, msg)
+end
 Agentif.close_channel(ch::TerminalChannel) = render_text(ch)  # flush any tail text
 
 # ─── Agent construction ───
@@ -111,15 +119,13 @@ end
 const BUDGET_WARN_MARGIN = 5
 
 function instrument_tool(tool::Agentif.AgentTool{F, T}, counter::Threads.Atomic{Int}, max_turns::Int,
-        steer::Union{Nothing, Channel{String}}, on_steer::Union{Nothing, Function}) where {F, T}
+        steer::Union{Nothing, Channel{String}}, on_steer::Union{Nothing, Function},
+        steer_lock::ReentrantLock = ReentrantLock()) where {F, T}
     wrapped = function (args...)
         result = tool.func(args...)
         result isa String || return result
         if steer !== nothing
-            texts = String[]
-            while isready(steer)
-                push!(texts, take!(steer))
-            end
+            texts = drain_steering!(steer, steer_lock)
             if !isempty(texts)
                 on_steer === nothing || foreach(on_steer, texts)
                 result *= "\n\n[the user interjected with new instructions — take them into account now]:\n" *
@@ -135,6 +141,16 @@ function instrument_tool(tool::Agentif.AgentTool{F, T}, counter::Threads.Atomic{
     end
     return Agentif.AgentTool{typeof(wrapped), T}(;
         name = tool.name, description = tool.description, strict = tool.strict, func = wrapped)
+end
+
+function drain_steering!(steer::Channel{String}, steer_lock::ReentrantLock)
+    return lock(steer_lock) do
+        texts = String[]
+        while isready(steer)
+            push!(texts, take!(steer))
+        end
+        texts
+    end
 end
 
 # kept for API/tests compatibility: budget-only instrumentation
@@ -165,18 +181,20 @@ function evaluate(input::AbstractString;
         abort::Agentif.Abort = Agentif.Abort(),
         steer::Union{Nothing, Channel{String}} = nothing,
         on_steer::Union{Nothing, Function} = nothing,
+        io_lock::ReentrantLock = ReentrantLock(),
         level = nothing,
         kw...,
     )
     sid = session_id === nothing ? "juco-" * string(Agentif.UID8()) : String(session_id)
     touch_session!(jdb, sid; title = first(String(input), 80), cwd = abspath(base_dir))
     agent = build_agent(; base_dir, jdb, kw...)
-    ch = TerminalChannel(sid, io)
+    ch = TerminalChannel(sid, io; io_lock)
     # tool executions run on concurrent tasks, so the counter must be atomic
     tool_calls = Threads.Atomic{Int}(0)
+    steer_lock = ReentrantLock()
     agent = Agentif.with_tools(agent,
-        Agentif.AgentTool[instrument_tool(t, tool_calls, max_turns, steer, on_steer) for t in agent.tools])
-    disp = show_tools ? display_handler(io; show_reasoning) : nothing
+        Agentif.AgentTool[instrument_tool(t, tool_calls, max_turns, steer, on_steer, steer_lock) for t in agent.tools])
+    disp = show_tools ? display_handler(io; show_reasoning, io_lock) : nothing
     handler = function (event)
         if event isa Agentif.ToolExecutionStartEvent
             n = Threads.atomic_add!(tool_calls, 1) + 1
@@ -205,7 +223,9 @@ function evaluate(input::AbstractString;
         session_store = jdb.session_store, channel = ch, abort, level, eval_kw...)
     if show_usage
         ctx_pct = context_percent(agent, state)
-        println(io, dim(io, usage_line(state.usage, agent.model, tool_calls[], time() - t0; ctx_pct)))
+        lock(io_lock) do
+            println(io, dim(io, usage_line(state.usage, agent.model, tool_calls[], time() - t0; ctx_pct)))
+        end
     end
     return (; state, session_id = sid, tool_calls = tool_calls[], aborted = Agentif.isaborted(abort))
 end
@@ -331,17 +351,67 @@ end
 # While the turn runs, a pump task reads stdin lines into the steering channel:
 # each line is shown as queued immediately, then echoed again (via on_steer)
 # at the moment a completed tool call actually delivers it to the model.
+function root_task_exception(e)
+    while e isa TaskFailedException
+        inner = e.task.exception
+        inner === e && break
+        e = inner
+    end
+    return e
+end
+
+function locked_println(io::IO, io_lock::ReentrantLock, xs...)
+    lock(io_lock) do
+        println(io, xs...)
+        flush(io)
+    end
+    return nothing
+end
+
+function wait_turn(turn::Task, abort::Agentif.Abort, io::IO;
+        io_lock::ReentrantLock = ReentrantLock())
+    while true
+        try
+            return fetch(turn)
+        catch e
+            if e isa InterruptException
+                Agentif.abort!(abort)
+                locked_println(io, io_lock,
+                    "\n^C interrupting — waiting for the turn to stop (ctrl-c again to detach)")
+                status = try
+                    timedwait(() -> istaskdone(turn), 10.0; pollint = 0.1)
+                catch wait_error
+                    wait_error isa InterruptException || rethrow()
+                    locked_println(io, io_lock, "^C detached from the running turn")
+                    return nothing
+                end
+                status === :ok || return nothing
+            elseif e isa TaskFailedException
+                inner = root_task_exception(e)
+                inner isa InterruptException && return nothing
+                msg = sprint(showerror, inner)
+                locked_println(io, io_lock, red(io, "error: " * first(split(msg, '\n'))))
+                locked_println(io, io_lock, dim(io, "the session is intact — try again or rephrase"))
+                return nothing
+            else
+                rethrow()
+            end
+        end
+    end
+end
+
 function run_turn(st::ReplState, input::String, io::IO; steering::Bool = stdin isa Base.TTY, kw...)
     expanded, used = expand_skills(input, st.skills)
     isempty(used) || println(io, dim(io, "⚡ skills: " * join(used, ", ")))
     abort = Agentif.Abort()
+    io_lock = ReentrantLock()
     steer = steering ? Channel{String}(32) : nothing
     on_steer = steer === nothing ? nothing :
-        text -> println(io, steer_active_line(io, text))
+        text -> locked_println(io, io_lock, steer_active_line(io, text))
     turn = @async evaluate(expanded; jdb = st.jdb, session_id = st.session_id,
         provider = mode_provider(st.mode), model_id = st.model_id,
         apikey = mode_apikey(st.mode), reasoning_effort = st.reasoning,
-        io, show_usage = true, abort, steer, on_steer, kw...)
+        io, show_usage = true, abort, steer, on_steer, io_lock, kw...)
     pump = steer === nothing ? nothing : @async begin
         try
             while !istaskdone(turn)
@@ -350,36 +420,28 @@ function run_turn(st::ReplState, input::String, io::IO; steering::Bool = stdin i
                 s = strip(raw)
                 isempty(s) && continue
                 put!(steer, String(s))
-                println(io, steer_queued_line(io, s))
+                locked_println(io, io_lock, steer_queued_line(io, s))
             end
         catch
             # interrupted at turn end, or stdin closed — either way we're done
         end
     end
     try
-        while true
-            try
-                return fetch(turn)
-            catch e
-                if e isa InterruptException
-                    Agentif.abort!(abort)
-                    println(io, dim(io, "\n^C interrupting — waiting for the turn to stop (ctrl-c again to detach)"))
-                    timedwait(() -> istaskdone(turn), 10.0; pollint = 0.1) === :ok || return nothing
-                elseif e isa TaskFailedException
-                    inner = e.task.exception
-                    inner isa InterruptException && continue
-                    msg = sprint(showerror, inner)
-                    println(io, red(io, "error: " * first(split(msg, '\n'))))
-                    println(io, dim(io, "the session is intact — try again or rephrase"))
-                    return nothing
-                else
-                    rethrow()
+        return wait_turn(turn, abort, io; io_lock)
+    finally
+        steer === nothing || !isopen(steer) || close(steer)
+        if pump !== nothing
+            if !istaskdone(pump)
+                try
+                    schedule(pump, InterruptException(); error = true)
+                catch
                 end
             end
+            try
+                wait(pump)
+            catch
+            end
         end
-    finally
-        # unblock the pump's readline without consuming the next prompt input
-        pump === nothing || istaskdone(pump) || schedule(pump, InterruptException(); error = true)
     end
 end
 

--- a/Juco/src/agent.jl
+++ b/Juco/src/agent.jl
@@ -368,6 +368,15 @@ function locked_println(io::IO, io_lock::ReentrantLock, xs...)
     return nothing
 end
 
+function turn_error_summary(e)
+    first_line = first(split(sprint(showerror, e), '\n'))
+    if occursin("No stored Codex credentials", first_line) ||
+            occursin("Stored Codex credentials were rejected", first_line)
+        return "Codex login required: run `using LLMOAuth; LLMOAuth.codex_login()`"
+    end
+    return first_line
+end
+
 function wait_turn(turn::Task, abort::Agentif.Abort, io::IO;
         io_lock::ReentrantLock = ReentrantLock())
     while true
@@ -389,8 +398,7 @@ function wait_turn(turn::Task, abort::Agentif.Abort, io::IO;
             elseif e isa TaskFailedException
                 inner = root_task_exception(e)
                 inner isa InterruptException && return nothing
-                msg = sprint(showerror, inner)
-                locked_println(io, io_lock, red(io, "error: " * first(split(msg, '\n'))))
+                locked_println(io, io_lock, red(io, "error: " * turn_error_summary(inner)))
                 locked_println(io, io_lock, dim(io, "the session is intact — try again or rephrase"))
                 return nothing
             else

--- a/Juco/src/agent.jl
+++ b/Juco/src/agent.jl
@@ -559,6 +559,9 @@ function print_sessions(db_path::AbstractString)
     end
 end
 
+shell_project_argument(project::AbstractString) =
+    Base.shell_escape_posixly("--project=$(project)")
+
 """
     Juco.install_cli(; dir = joinpath(homedir(), ".local", "bin"))
 
@@ -571,7 +574,7 @@ function install_cli(; dir::AbstractString = joinpath(homedir(), ".local", "bin"
     path = joinpath(dir, "juco")
     write(path, """
         #!/bin/sh
-        exec julia --project=$(project) --startup-file=no -e 'using Juco; Juco.main(ARGS)' -- "\$@"
+        exec julia $(shell_project_argument(project)) --startup-file=no -e 'using Juco; Juco.main(ARGS)' -- "\$@"
         """)
     chmod(path, 0o755)
     occursin(abspath(dir), get(ENV, "PATH", "")) ||

--- a/Juco/src/agent.jl
+++ b/Juco/src/agent.jl
@@ -38,20 +38,46 @@ function resolve_apikey(provider::String)
     error("No API key found: set JUCO_API_KEY$(isempty(env_var) ? "" : " or $env_var")")
 end
 
-# ─── Terminal channel: routes streamed assistant text to an IO, and gives the
-# session middleware a stable branch id (= the Juco session id). ───
+# ─── Terminal channel: collects streamed assistant text and gives the session
+# middleware a stable branch id (= the Juco session id). Text is buffered per
+# assistant message and rendered as Markdown when the message completes — tool
+# activity and reasoning stream live in between (see display.jl), so the
+# terminal stays responsive while answers come out cleanly formatted. ───
 
 struct TerminalChannel <: Agentif.AbstractChannel
     session_id::String
     io::IO
+    buf::IOBuffer
+    markdown::Bool
 end
+
+TerminalChannel(session_id::String, io::IO; markdown::Bool = true) =
+    TerminalChannel(session_id, io, IOBuffer(), markdown)
 
 Agentif.channel_id(ch::TerminalChannel) = ch.session_id
 Agentif.start_streaming(::TerminalChannel) = nothing
-Agentif.append_to_stream(ch::TerminalChannel, delta) = (print(ch.io, delta); flush(ch.io))
-Agentif.finish_streaming(ch::TerminalChannel) = println(ch.io)
+Agentif.append_to_stream(ch::TerminalChannel, delta) = write(ch.buf, delta)
+
+function render_text(ch::TerminalChannel)
+    text = strip(String(take!(ch.buf)))
+    isempty(text) && return
+    if ch.markdown && use_color(ch.io)
+        try
+            show(IOContext(ch.io, :color => true), MIME("text/plain"), Markdown.parse(String(text)))
+            println(ch.io)
+        catch
+            println(ch.io, text)
+        end
+    else
+        println(ch.io, text)
+    end
+    flush(ch.io)
+    return
+end
+
+Agentif.finish_streaming(ch::TerminalChannel) = render_text(ch)
 Agentif.send_message(ch::TerminalChannel, msg) = println(ch.io, msg)
-Agentif.close_channel(::TerminalChannel) = nothing
+Agentif.close_channel(ch::TerminalChannel) = render_text(ch)  # flush any tail text
 
 # ─── Agent construction ───
 
@@ -110,9 +136,12 @@ function evaluate(input::AbstractString;
         session_id::Union{Nothing, AbstractString} = nothing,
         io::IO = stdout,
         show_tools::Bool = true,
+        show_reasoning::Bool = true,
+        show_usage::Bool = false,
         max_turns::Int = DEFAULT_MAX_TURNS,
         reasoning_effort::Union{Nothing, String} = default_reasoning(),
         on_event::Union{Nothing, Function} = nothing,
+        abort::Agentif.Abort = Agentif.Abort(),
         level = nothing,
         kw...,
     )
@@ -120,23 +149,17 @@ function evaluate(input::AbstractString;
     touch_session!(jdb, sid; title = first(String(input), 80), cwd = abspath(base_dir))
     agent = build_agent(; base_dir, jdb, kw...)
     ch = TerminalChannel(sid, io)
-    abort = Agentif.Abort()
     # tool executions run on concurrent tasks, so the counter must be atomic
     tool_calls = Threads.Atomic{Int}(0)
     agent = Agentif.with_tools(agent,
         Agentif.AgentTool[with_budget_notice(t, tool_calls, max_turns) for t in agent.tools])
+    disp = show_tools ? display_handler(io; show_reasoning) : nothing
     handler = function (event)
         if event isa Agentif.ToolExecutionStartEvent
             n = Threads.atomic_add!(tool_calls, 1) + 1
-            if n > max_turns
-                Agentif.abort!(abort)
-            elseif show_tools
-                args = replace(event.tool_call.arguments, '\n' => "\\n")
-                println(io, "\e[2m[$(event.tool_call.name)] $(first(args, 160))\e[0m")
-            end
-        elseif event isa Agentif.AgentErrorEvent && show_tools
-            println(io, "\e[31m[error] $(event.error)\e[0m")
+            n > max_turns && Agentif.abort!(abort)
         end
+        disp === nothing || disp(event)
         on_event === nothing || on_event(event)
         return nothing
     end
@@ -151,42 +174,184 @@ function evaluate(input::AbstractString;
         (; reasoning_effort)
     end
     is_openrouter && (eval_kw = merge(eval_kw, (; provider = openrouter_provider_prefs())))
+    t0 = time()
     state = Agentif.evaluate(handler, agent, String(input);
         session_store = jdb.session_store, channel = ch, abort, level, eval_kw...)
+    show_usage && println(io, dim(io, usage_line(state.usage, agent.model, tool_calls[], time() - t0)))
     return (; state, session_id = sid, tool_calls = tool_calls[], aborted = Agentif.isaborted(abort))
 end
 
 # ─── REPL / CLI ───
 
+const REPL_HELP = """
+/help                 show this help
+/new                  start a new session
+/sessions             list recent sessions
+/resume [id]          resume a session (most recent if no id)
+/model [prov] [id]    show or switch the model
+/memories             list saved memories
+/quit                 exit (also: exit, quit, ctrl-d)
+End a line with \\ to continue typing on the next line.
+Ctrl-C during a response interrupts that response, not the REPL."""
+
+# Mutable REPL state threaded through slash commands.
+mutable struct ReplState
+    jdb::JucoDB
+    session_id::String
+    provider::String
+    model_id::String
+    quit::Bool
+end
+
+function handle_command(st::ReplState, input::AbstractString, io::IO)
+    parts = split(strip(input))
+    cmd = parts[1]
+    if cmd == "/help"
+        println(io, REPL_HELP)
+    elseif cmd == "/new"
+        st.session_id = "juco-" * string(Agentif.UID8())
+        println(io, dim(io, "new session $(st.session_id)"))
+    elseif cmd == "/sessions"
+        sessions = list_sessions(st.jdb)
+        isempty(sessions) && return println(io, "No sessions.")
+        for s in sessions
+            ts = Dates.format(Dates.unix2datetime(s.updated_at), "yyyy-mm-dd HH:MM")
+            marker = s.id == st.session_id ? "* " : "  "
+            println(io, marker, s.id, dim(io, "  $(ts)  $(first(s.title, 60))"))
+        end
+    elseif cmd == "/resume"
+        target = length(parts) >= 2 ? String(parts[2]) : latest_session(st.jdb)
+        target === nothing && return println(io, "No sessions to resume.")
+        st.session_id = target
+        println(io, dim(io, "resumed $(st.session_id)"))
+    elseif cmd == "/model"
+        if length(parts) == 1
+            println(io, "$(st.provider)/$(st.model_id)")
+        else
+            prov, mid = length(parts) >= 3 ? (String(parts[2]), String(parts[3])) : (st.provider, String(parts[2]))
+            getModel(prov, mid) === nothing && return println(io, red(io, "unknown model: $(prov)/$(mid)"))
+            st.provider, st.model_id = prov, mid
+            println(io, dim(io, "model set to $(prov)/$(mid)"))
+        end
+    elseif cmd == "/memories"
+        mems = memories(st.jdb)
+        isempty(mems) && return println(io, "No memories.")
+        foreach(m -> println(io, "- ", m), mems)
+    elseif cmd == "/quit"
+        st.quit = true
+    else
+        println(io, red(io, "unknown command $(cmd)"), " — /help for commands")
+    end
+    return nothing
+end
+
+# Read one logical input: trailing backslash continues on the next line.
+# Returns nothing on EOF.
+function read_input(io::IO)
+    print(io, bold(io, "juco> "))
+    raw = readline(stdin; keep = true)
+    isempty(raw) && return nothing
+    input = String(strip(raw))
+    while endswith(input, "\\")
+        input = chop(input; tail = 1)
+        print(io, bold(io, "  ..> "))
+        raw = readline(stdin; keep = true)
+        isempty(raw) && break
+        input *= "\n" * strip(raw)
+    end
+    return String(strip(input))
+end
+
+# Run one turn on a worker task so ctrl-c aborts the TURN (via Abort), not the
+# REPL. A second ctrl-c while aborting force-detaches.
+function run_turn(st::ReplState, input::String, io::IO; kw...)
+    abort = Agentif.Abort()
+    turn = @async evaluate(input; jdb = st.jdb, session_id = st.session_id,
+        provider = st.provider, model_id = st.model_id, io, show_usage = true, abort, kw...)
+    while true
+        try
+            return fetch(turn)
+        catch e
+            if e isa InterruptException
+                Agentif.abort!(abort)
+                println(io, dim(io, "\n^C interrupting — waiting for the turn to stop (ctrl-c again to detach)"))
+                timedwait(() -> istaskdone(turn), 10.0; pollint = 0.1) === :ok || return nothing
+            elseif e isa TaskFailedException
+                inner = e.task.exception
+                inner isa InterruptException && continue
+                msg = sprint(showerror, inner)
+                println(io, red(io, "error: " * first(split(msg, '\n'))))
+                println(io, dim(io, "the session is intact — try again or rephrase"))
+                return nothing
+            else
+                rethrow()
+            end
+        end
+    end
+end
+
 function repl(;
         db_path::AbstractString = DEFAULT_DB_PATH,
         continue_last::Bool = false,
+        provider::String = default_provider(),
+        model_id::String = default_model(),
+        io::IO = stdout,
         kw...,
     )
     jdb = opendb(db_path)
     session_id = continue_last ? latest_session(jdb) : nothing
-    continue_last && session_id === nothing && println("No previous session found; starting a new one.")
+    continue_last && session_id === nothing && println(io, "No previous session found; starting a new one.")
     session_id === nothing && (session_id = "juco-" * string(Agentif.UID8()))
-    println("juco · session $(session_id) · db $(abspath(db_path)) · type 'exit' to quit")
-    while true
-        print("\e[1mjuco>\e[0m ")
-        # keep=true distinguishes an empty line ("\n") from EOF ("")
-        raw = try
-            readline(stdin; keep = true)
-        catch e
-            e isa InterruptException ? "\n" : rethrow()
+    st = ReplState(jdb, session_id, provider, model_id, false)
+    println(io, bold(io, "juco"), dim(io, " · $(provider)/$(model_id) · session $(session_id)"))
+    println(io, dim(io, "db $(abspath(db_path)) · /help for commands · exit to quit"))
+    isa(stdin, Base.TTY) && Base.exit_on_sigint(false)
+    try
+        while !st.quit
+            input = try
+                read_input(io)
+            catch e
+                e isa InterruptException ? "" : rethrow()
+            end
+            input === nothing && break  # EOF (ctrl-d)
+            isempty(input) && continue
+            input in ("exit", "quit") && break
+            if startswith(input, "/")
+                handle_command(st, input, io)
+            else
+                run_turn(st, input, io; kw...)
+                println(io)
+            end
         end
-        isempty(raw) && break  # EOF (ctrl-d)
-        input = strip(raw)
-        isempty(input) && continue
-        input in ("exit", "quit") && break
-        try
-            evaluate(input; jdb, session_id, kw...)
-        catch e
-            e isa InterruptException || showerror(stderr, e, catch_backtrace())
-            println(stderr)
-        end
-        println()
+    finally
+        isa(stdin, Base.TTY) && Base.exit_on_sigint(true)
+    end
+    return nothing
+end
+
+# ─── In-REPL mode (implemented in the ReplMaker package extension) ───
+
+"""
+    Juco.repl_mode!(; db_path = DEFAULT_DB_PATH, start_key = '}')
+
+Register a `juco>` mode in the current Julia REPL (like Pkg's `]`): press
+`}` at an empty `julia>` prompt to talk to Juco, backspace to leave. Slash
+commands (`/help`, `/sessions`, ...) work inside the mode.
+
+Requires ReplMaker: `using Juco, ReplMaker; Juco.repl_mode!()`.
+"""
+function repl_mode! end
+
+mode_state(db_path::AbstractString = DEFAULT_DB_PATH) =
+    ReplState(opendb(db_path), "juco-" * string(Agentif.UID8()), default_provider(), default_model(), false)
+
+function mode_eval(st::ReplState, input::AbstractString; kw...)
+    s = String(strip(input))
+    isempty(s) && return nothing
+    if startswith(s, "/")
+        handle_command(st, s, stdout)
+    else
+        run_turn(st, s, stdout; kw...)
     end
     return nothing
 end
@@ -199,6 +364,26 @@ function print_sessions(db_path::AbstractString)
         ts = Dates.format(Dates.unix2datetime(s.updated_at), "yyyy-mm-dd HH:MM")
         println("$(s.id)  $(ts)  $(s.cwd)  $(s.title)")
     end
+end
+
+"""
+    Juco.install_cli(; dir = joinpath(homedir(), ".local", "bin"))
+
+Write a `juco` launcher script to `dir` so the agent can be started from any
+shell. The script runs this monorepo's environment.
+"""
+function install_cli(; dir::AbstractString = joinpath(homedir(), ".local", "bin"))
+    project = dirname(pkgdir(Juco))
+    mkpath(dir)
+    path = joinpath(dir, "juco")
+    write(path, """
+        #!/bin/sh
+        exec julia --project=$(project) --startup-file=no -e 'using Juco; Juco.main(ARGS)' -- "\$@"
+        """)
+    chmod(path, 0o755)
+    occursin(abspath(dir), get(ENV, "PATH", "")) ||
+        @info "add $(dir) to your PATH to use `juco` directly"
+    return path
 end
 
 const CLI_HELP = """

--- a/Juco/src/db.jl
+++ b/Juco/src/db.jl
@@ -44,11 +44,11 @@ end
 # ─── Config (persistent key/value state, e.g. the selected model) ───
 
 function get_config(jdb::JucoDB, key::AbstractString, default = nothing)
-    rows = SQLite.DBInterface.execute(jdb.db,
-        "SELECT value FROM juco_config WHERE key = ?", (String(key),))
-    row = iterate(rows)
-    row === nothing && return default
-    return String(row[1].value)
+    return SQLite.DBInterface.execute(jdb.db,
+            "SELECT value FROM juco_config WHERE key = ?", (String(key),)) do rows
+        row = iterate(rows)
+        row === nothing ? default : String(row[1].value)
+    end
 end
 
 function set_config!(jdb::JucoDB, key::AbstractString, value::Union{Nothing, AbstractString})
@@ -72,10 +72,11 @@ function remember!(jdb::JucoDB, content::AbstractString)
 end
 
 function memories(jdb::JucoDB; limit::Int = 50)
-    rows = SQLite.DBInterface.execute(jdb.db,
-        "SELECT content FROM juco_memories ORDER BY id DESC LIMIT ?", (limit,))
-    out = String[String(r.content) for r in rows]
-    return reverse!(out)  # oldest first for prompt injection
+    return SQLite.DBInterface.execute(jdb.db,
+            "SELECT content FROM juco_memories ORDER BY id DESC LIMIT ?", (limit,)) do rows
+        out = String[String(r.content) for r in rows]
+        reverse!(out)  # oldest first for prompt injection
+    end
 end
 
 # ─── Sessions ───
@@ -93,12 +94,13 @@ function touch_session!(jdb::JucoDB, id::AbstractString; title::Union{Nothing, A
 end
 
 function list_sessions(jdb::JucoDB; limit::Int = 20)
-    rows = SQLite.DBInterface.execute(jdb.db,
-        "SELECT id, title, cwd, updated_at FROM juco_sessions ORDER BY updated_at DESC LIMIT ?", (limit,))
-    return [(id = String(r.id),
-             title = r.title === missing ? "" : String(r.title),
-             cwd = r.cwd === missing ? "" : String(r.cwd),
-             updated_at = Float64(r.updated_at)) for r in rows]
+    return SQLite.DBInterface.execute(jdb.db,
+            "SELECT id, title, cwd, updated_at FROM juco_sessions ORDER BY updated_at DESC LIMIT ?", (limit,)) do rows
+        [(id = String(r.id),
+          title = r.title === missing ? "" : String(r.title),
+          cwd = r.cwd === missing ? "" : String(r.cwd),
+          updated_at = Float64(r.updated_at)) for r in rows]
+    end
 end
 
 function latest_session(jdb::JucoDB)

--- a/Juco/src/db.jl
+++ b/Juco/src/db.jl
@@ -32,7 +32,34 @@ function opendb(path::AbstractString = DEFAULT_DB_PATH)
             updated_at REAL NOT NULL
         )
     """)
+    SQLite.execute(db, """
+        CREATE TABLE IF NOT EXISTS juco_config (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        )
+    """)
     return JucoDB(db, session_store)
+end
+
+# ─── Config (persistent key/value state, e.g. the selected model) ───
+
+function get_config(jdb::JucoDB, key::AbstractString, default = nothing)
+    rows = SQLite.DBInterface.execute(jdb.db,
+        "SELECT value FROM juco_config WHERE key = ?", (String(key),))
+    row = iterate(rows)
+    row === nothing && return default
+    return String(row[1].value)
+end
+
+function set_config!(jdb::JucoDB, key::AbstractString, value::Union{Nothing, AbstractString})
+    if value === nothing
+        SQLite.execute(jdb.db, "DELETE FROM juco_config WHERE key = ?", (String(key),))
+    else
+        SQLite.execute(jdb.db,
+            "INSERT OR REPLACE INTO juco_config (key, value) VALUES (?, ?)",
+            (String(key), String(value)))
+    end
+    return nothing
 end
 
 # ─── Memories ───

--- a/Juco/src/db.jl
+++ b/Juco/src/db.jl
@@ -41,6 +41,17 @@ function opendb(path::AbstractString = DEFAULT_DB_PATH)
     return JucoDB(db, session_store)
 end
 
+Base.close(jdb::JucoDB) = close(jdb.db)
+
+function with_jdb(f::Function, path::AbstractString = DEFAULT_DB_PATH)
+    jdb = opendb(path)
+    try
+        return f(jdb)
+    finally
+        close(jdb)
+    end
+end
+
 # ─── Config (persistent key/value state, e.g. the selected model) ───
 
 function get_config(jdb::JucoDB, key::AbstractString, default = nothing)

--- a/Juco/src/display.jl
+++ b/Juco/src/display.jl
@@ -218,6 +218,10 @@ function display_handler(io::IO; show_tools::Bool = true, show_reasoning::Bool =
                 finish_reasoning()
                 finish_open_line()
                 println(io, dim(io, "⇣ context compacted — earlier conversation folded into a summary"))
+            elseif event isa Agentif.TurnEndEvent
+                clear_waiting()
+                finish_reasoning()
+                finish_open_line()
             elseif event isa Agentif.AgentErrorEvent
                 clear_waiting()
                 finish_reasoning()

--- a/Juco/src/display.jl
+++ b/Juco/src/display.jl
@@ -1,0 +1,138 @@
+# Terminal display for the Juco REPL: compact tool-call lines, streamed
+# reasoning, and per-turn usage. Deliberately plain — no TUI, just careful
+# use of ANSI style on a scrolling terminal.
+
+use_color(io::IO) = get(io, :color, false) || (io === stdout && !haskey(ENV, "NO_COLOR") && stdout isa Base.TTY)
+
+dim(io::IO, s) = use_color(io) ? "\e[2m$(s)\e[0m" : String(s)
+red(io::IO, s) = use_color(io) ? "\e[31m$(s)\e[0m" : String(s)
+bold(io::IO, s) = use_color(io) ? "\e[1m$(s)\e[22m" : String(s)
+
+# One-line summary of a tool call, e.g.:
+#   ▸ bash julia test_stats.jl
+#   ▸ edit src/stats.jl
+#   ▸ read src/stats.jl:100
+function format_tool_call(name::AbstractString, arguments::AbstractString)
+    args = try
+        JSON.parse(String(arguments))
+    catch
+        nothing
+    end
+    detail = if args isa AbstractDict
+        if name == "bash"
+            replace(get(args, "command", ""), r"\s+" => " ")
+        elseif name == "read"
+            path = get(args, "path", "")
+            offset = get(args, "offset", nothing)
+            offset === nothing ? path : "$(path):$(offset)"
+        elseif name == "edit"
+            path = get(args, "path", "")
+            isempty(get(args, "oldText", " ")) ? "$(path) (new file)" : path
+        elseif name == "write"
+            get(args, "path", "")
+        elseif name == "remember"
+            "\"" * get(args, "content", "") * "\""
+        else
+            join((string(v) for v in values(args)), " ")
+        end
+    else
+        String(arguments)
+    end
+    detail = replace(detail, '\n' => "\\n")
+    length(detail) > 100 && (detail = first(detail, 100) * "…")
+    return "▸ $(name) $(detail)"
+end
+
+format_duration(ms::Integer) = ms < 1000 ? "$(ms)ms" : "$(round(ms / 1000; digits = 1))s"
+
+# First line of an error result, for the ✗ status.
+function error_summary(result::Agentif.ToolResultMessage)
+    text = join((b.text for b in result.content if b isa Agentif.TextContent), " ")
+    msg = try
+        parsed = JSON.parse(text)
+        parsed isa AbstractDict ? get(parsed, "message", text) : text
+    catch
+        text
+    end
+    line = first(split(msg, '\n'))
+    length(line) > 120 && (line = first(line, 120) * "…")
+    return String(line)
+end
+
+format_tokens(n::Integer) = n < 1000 ? string(n) : "$(round(n / 1000; digits = 1))k"
+
+# One dim line after a turn: elapsed, tool calls, tokens (with cache share), cost.
+function usage_line(usage::Agentif.Usage, model, tool_calls::Int, elapsed_s::Real)
+    tokens_in = usage.input + usage.cacheRead + usage.cacheWrite
+    cached = tokens_in > 0 && usage.cacheRead > 0 ? " ($(round(Int, 100 * usage.cacheRead / tokens_in))% cached)" : ""
+    cost = try
+        c = LLMProviders.calculateCost(model, usage)
+        total = get(c, "total", 0.0)
+        total > 0 ? " · \$$(round(total; sigdigits = 2))" : ""
+    catch
+        ""
+    end
+    tools = tool_calls > 0 ? " · $(tool_calls) tool$(tool_calls == 1 ? "" : "s")" : ""
+    return "⏱ $(round(elapsed_s; digits = 1))s$(tools) · $(format_tokens(tokens_in)) in$(cached) / $(format_tokens(usage.output)) out$(cost)"
+end
+
+"""
+    display_handler(io; show_tools = true, show_reasoning = true) -> Function
+
+Event handler that renders agent activity to `io`: tool calls as compact
+one-liners completed in place with ✓/✗ + duration, and (optionally) streamed
+reasoning as dim text.
+"""
+function display_handler(io::IO; show_tools::Bool = true, show_reasoning::Bool = true)
+    lk = ReentrantLock()
+    open_call_id = Ref{Union{Nothing, String}}(nothing)  # call whose ▸ line is still open
+    reasoning_open = Ref(false)
+    finish_open_line() = begin
+        open_call_id[] === nothing || print(io, "\n")
+        open_call_id[] = nothing
+    end
+    finish_reasoning() = begin
+        reasoning_open[] && print(io, "\n\n")
+        reasoning_open[] = false
+    end
+    return function (event)
+        lock(lk) do
+            if event isa Agentif.ToolExecutionStartEvent && show_tools
+                finish_reasoning()
+                finish_open_line()
+                print(io, dim(io, format_tool_call(event.tool_call.name, event.tool_call.arguments)))
+                open_call_id[] = event.tool_call.call_id
+                flush(io)
+            elseif event isa Agentif.ToolExecutionEndEvent && show_tools
+                status = event.result.is_error ?
+                    red(io, "✗ " * error_summary(event.result)) :
+                    dim(io, "✓ " * format_duration(event.duration_ms))
+                if open_call_id[] == event.tool_call.call_id
+                    # complete the line we just opened
+                    println(io, dim(io, " "), status)
+                    open_call_id[] = nothing
+                else
+                    finish_open_line()
+                    println(io, dim(io, "  " * event.tool_call.name * " "), status)
+                end
+                flush(io)
+            elseif event isa Agentif.MessageUpdateEvent && event.kind == :reasoning && show_reasoning
+                finish_open_line()
+                reasoning_open[] || print(io, dim(io, "· "))
+                reasoning_open[] = true
+                print(io, dim(io, replace(event.delta, "\n\n" => "\n", '\n' => "\n  ")))
+                flush(io)
+            elseif event isa Agentif.MessageUpdateEvent && event.kind == :text
+                # text is buffered by the channel and rendered at message end;
+                # close any open reasoning/tool line before that happens
+                finish_reasoning()
+                finish_open_line()
+            elseif event isa Agentif.AgentErrorEvent
+                finish_reasoning()
+                finish_open_line()
+                println(io, red(io, "error: " * first(string(event.error), 200)))
+            end
+        end
+        return nothing
+    end
+end

--- a/Juco/src/display.jl
+++ b/Juco/src/display.jl
@@ -61,8 +61,10 @@ end
 
 format_tokens(n::Integer) = n < 1000 ? string(n) : "$(round(n / 1000; digits = 1))k"
 
-# One dim line after a turn: elapsed, tool calls, tokens (with cache share), cost.
-function usage_line(usage::Agentif.Usage, model, tool_calls::Int, elapsed_s::Real)
+# One dim line after a turn: elapsed, tool calls, tokens (with cache share),
+# cost, and estimated context-window usage.
+function usage_line(usage::Agentif.Usage, model, tool_calls::Int, elapsed_s::Real;
+        ctx_pct::Union{Nothing, Int} = nothing)
     tokens_in = usage.input + usage.cacheRead + usage.cacheWrite
     cached = tokens_in > 0 && usage.cacheRead > 0 ? " ($(round(Int, 100 * usage.cacheRead / tokens_in))% cached)" : ""
     cost = try
@@ -73,8 +75,18 @@ function usage_line(usage::Agentif.Usage, model, tool_calls::Int, elapsed_s::Rea
         ""
     end
     tools = tool_calls > 0 ? " · $(tool_calls) tool$(tool_calls == 1 ? "" : "s")" : ""
-    return "⏱ $(round(elapsed_s; digits = 1))s$(tools) · $(format_tokens(tokens_in)) in$(cached) / $(format_tokens(usage.output)) out$(cost)"
+    ctx = ctx_pct === nothing ? "" :
+        " · ctx $(ctx_pct)%" * (ctx_pct >= 80 ? " (compaction soon)" : "")
+    return "⏱ $(round(elapsed_s; digits = 1))s$(tools) · $(format_tokens(tokens_in)) in$(cached) / $(format_tokens(usage.output)) out$(cost)$(ctx)"
 end
+
+# Steering visuals: a message is shown queued the moment the user presses
+# enter, then again — promoted — at the moment a completed tool call actually
+# delivers it to the model (codex-style).
+steer_preview(text) = (t = replace(String(text), '\n' => " "); length(t) > 60 ? first(t, 60) * "…" : t)
+steer_queued_line(io::IO, text) = dim(io, "↳ queued (steers at next tool boundary): \"$(steer_preview(text))\"")
+steer_active_line(io::IO, text) =
+    (use_color(io) ? "\e[36m" : "") * "↳ steering now: \"$(steer_preview(text))\"" * (use_color(io) ? "\e[0m" : "")
 
 """
     display_handler(io; show_tools = true, show_reasoning = true) -> Function
@@ -127,6 +139,10 @@ function display_handler(io::IO; show_tools::Bool = true, show_reasoning::Bool =
                 # close any open reasoning/tool line before that happens
                 finish_reasoning()
                 finish_open_line()
+            elseif event isa Agentif.MessageEndEvent && event.message isa Agentif.CompactionSummaryMessage
+                finish_reasoning()
+                finish_open_line()
+                println(io, dim(io, "⇣ context compacted — earlier conversation folded into a summary"))
             elseif event isa Agentif.AgentErrorEvent
                 finish_reasoning()
                 finish_open_line()

--- a/Juco/src/display.jl
+++ b/Juco/src/display.jl
@@ -10,6 +10,42 @@ green(io::IO, s) = use_color(io) ? "\e[32m$(s)\e[0m" : String(s)
 yellow(io::IO, s) = use_color(io) ? "\e[33m$(s)\e[0m" : String(s)
 bold(io::IO, s) = use_color(io) ? "\e[1m$(s)\e[22m" : String(s)
 
+# Provider reasoning streams use arbitrary chunk and whitespace boundaries.
+# Reflow them as terminal prose while preserving real paragraph breaks.
+mutable struct ReasoningDisplayState
+    started::Bool
+    pending_space::Bool
+    pending_newlines::Int
+end
+
+ReasoningDisplayState() = ReasoningDisplayState(false, false, 0)
+
+function reset_reasoning!(state::ReasoningDisplayState)
+    state.started = false
+    state.pending_space = false
+    state.pending_newlines = 0
+    return nothing
+end
+
+function reflow_reasoning!(state::ReasoningDisplayState, delta::AbstractString)
+    buf = IOBuffer()
+    for char in delta
+        if isspace(char)
+            state.pending_space = true
+            char == '\n' && (state.pending_newlines += 1)
+            continue
+        end
+        if state.pending_space && state.started
+            state.pending_newlines >= 2 ? print(buf, "\n  ") : print(buf, ' ')
+        end
+        state.pending_space = false
+        state.pending_newlines = 0
+        state.started = true
+        print(buf, char)
+    end
+    return String(take!(buf))
+end
+
 # One-line preview of a bash result so the user can scan without expanding:
 # the first non-empty line of output.
 function result_preview(result::Agentif.ToolResultMessage)
@@ -141,6 +177,7 @@ function display_handler(io::IO; show_tools::Bool = true, show_reasoning::Bool =
         show_previews::Bool = true, io_lock::ReentrantLock = ReentrantLock())
     open_call_id = Ref{Union{Nothing, String}}(nothing)  # call whose ▸ line is still open
     reasoning_open = Ref(false)
+    reasoning_state = ReasoningDisplayState()
     waiting_open = Ref(false)  # "…" placeholder shown while the model is silent
     finish_open_line() = begin
         open_call_id[] === nothing || print(io, "\n")
@@ -149,6 +186,7 @@ function display_handler(io::IO; show_tools::Bool = true, show_reasoning::Bool =
     finish_reasoning() = begin
         reasoning_open[] && print(io, "\n\n")
         reasoning_open[] = false
+        reset_reasoning!(reasoning_state)
     end
     clear_waiting() = begin
         # erase the placeholder line so real output takes its place
@@ -203,9 +241,12 @@ function display_handler(io::IO; show_tools::Bool = true, show_reasoning::Bool =
             elseif event isa Agentif.MessageUpdateEvent && event.kind == :reasoning && show_reasoning
                 clear_waiting()
                 finish_open_line()
-                reasoning_open[] || print(io, dim(io, "· "))
-                reasoning_open[] = true
-                print(io, dim(io, replace(event.delta, "\n\n" => "\n", '\n' => "\n  ")))
+                rendered = reflow_reasoning!(reasoning_state, event.delta)
+                if !isempty(rendered)
+                    reasoning_open[] || print(io, dim(io, "· "))
+                    reasoning_open[] = true
+                    print(io, dim(io, rendered))
+                end
                 flush(io)
             elseif event isa Agentif.MessageUpdateEvent && event.kind == :text
                 # text is buffered by the channel and rendered at message end;

--- a/Juco/src/display.jl
+++ b/Juco/src/display.jl
@@ -95,8 +95,8 @@ Event handler that renders agent activity to `io`: tool calls as compact
 one-liners completed in place with ✓/✗ + duration, and (optionally) streamed
 reasoning as dim text.
 """
-function display_handler(io::IO; show_tools::Bool = true, show_reasoning::Bool = true)
-    lk = ReentrantLock()
+function display_handler(io::IO; show_tools::Bool = true, show_reasoning::Bool = true,
+        io_lock::ReentrantLock = ReentrantLock())
     open_call_id = Ref{Union{Nothing, String}}(nothing)  # call whose ▸ line is still open
     reasoning_open = Ref(false)
     finish_open_line() = begin
@@ -108,7 +108,7 @@ function display_handler(io::IO; show_tools::Bool = true, show_reasoning::Bool =
         reasoning_open[] = false
     end
     return function (event)
-        lock(lk) do
+        lock(io_lock) do
             if event isa Agentif.ToolExecutionStartEvent && show_tools
                 finish_reasoning()
                 finish_open_line()

--- a/Juco/src/display.jl
+++ b/Juco/src/display.jl
@@ -20,18 +20,19 @@ function format_tool_call(name::AbstractString, arguments::AbstractString)
     end
     detail = if args isa AbstractDict
         if name == "bash"
-            replace(get(args, "command", ""), r"\s+" => " ")
+            replace(string(get(args, "command", "")), r"\s+" => " ")
         elseif name == "read"
-            path = get(args, "path", "")
+            path = string(get(args, "path", ""))
             offset = get(args, "offset", nothing)
             offset === nothing ? path : "$(path):$(offset)"
         elseif name == "edit"
-            path = get(args, "path", "")
-            isempty(get(args, "oldText", " ")) ? "$(path) (new file)" : path
+            path = string(get(args, "path", ""))
+            old_text = get(args, "oldText", " ")
+            old_text isa AbstractString && isempty(old_text) ? "$(path) (new file)" : path
         elseif name == "write"
-            get(args, "path", "")
+            string(get(args, "path", ""))
         elseif name == "remember"
-            "\"" * get(args, "content", "") * "\""
+            "\"" * string(get(args, "content", "")) * "\""
         else
             join((string(v) for v in values(args)), " ")
         end
@@ -50,7 +51,7 @@ function error_summary(result::Agentif.ToolResultMessage)
     text = join((b.text for b in result.content if b isa Agentif.TextContent), " ")
     msg = try
         parsed = JSON.parse(text)
-        parsed isa AbstractDict ? get(parsed, "message", text) : text
+        parsed isa AbstractDict ? string(get(parsed, "message", text)) : text
     catch
         text
     end

--- a/Juco/src/display.jl
+++ b/Juco/src/display.jl
@@ -6,7 +6,48 @@ use_color(io::IO) = get(io, :color, false) || (io === stdout && !haskey(ENV, "NO
 
 dim(io::IO, s) = use_color(io) ? "\e[2m$(s)\e[0m" : String(s)
 red(io::IO, s) = use_color(io) ? "\e[31m$(s)\e[0m" : String(s)
+green(io::IO, s) = use_color(io) ? "\e[32m$(s)\e[0m" : String(s)
+yellow(io::IO, s) = use_color(io) ? "\e[33m$(s)\e[0m" : String(s)
 bold(io::IO, s) = use_color(io) ? "\e[1m$(s)\e[22m" : String(s)
+
+# One-line preview of a bash result so the user can scan without expanding:
+# the first non-empty line of output.
+function result_preview(result::Agentif.ToolResultMessage)
+    text = join((b.text for b in result.content if b isa Agentif.TextContent), "\n")
+    for line in eachsplit(text, '\n')
+        s = strip(line)
+        isempty(s) && continue
+        startswith(s, "…[skipped") && continue
+        p = String(s)
+        length(p) > 80 && (p = first(p, 80) * "…")
+        return p
+    end
+    return ""
+end
+
+# Compact ±diff for an edit call (from its arguments), aider-style.
+function edit_diff_lines(arguments::AbstractString; max_each::Int = 3)
+    args = try
+        JSON.parse(String(arguments))
+    catch
+        return String[], String[]
+    end
+    args isa AbstractDict || return String[], String[]
+    old = get(args, "oldText", "")
+    new = get(args, "newText", "")
+    (old isa AbstractString && new isa AbstractString) || return String[], String[]
+    olds = [String(l) for l in eachsplit(old, '\n') if !isempty(strip(l))]
+    news = [String(l) for l in eachsplit(new, '\n') if !isempty(strip(l))]
+    # drop common prefix/suffix lines so the diff shows only what changed
+    while !isempty(olds) && !isempty(news) && olds[1] == news[1]
+        popfirst!(olds); popfirst!(news)
+    end
+    while !isempty(olds) && !isempty(news) && olds[end] == news[end]
+        pop!(olds); pop!(news)
+    end
+    clip(v) = length(v) > max_each ? vcat(first(v, max_each), ["…"]) : v
+    return clip(olds), clip(news)
+end
 
 # One-line summary of a tool call, e.g.:
 #   ▸ bash julia test_stats.jl
@@ -97,9 +138,10 @@ one-liners completed in place with ✓/✗ + duration, and (optionally) streamed
 reasoning as dim text.
 """
 function display_handler(io::IO; show_tools::Bool = true, show_reasoning::Bool = true,
-        io_lock::ReentrantLock = ReentrantLock())
+        show_previews::Bool = true, io_lock::ReentrantLock = ReentrantLock())
     open_call_id = Ref{Union{Nothing, String}}(nothing)  # call whose ▸ line is still open
     reasoning_open = Ref(false)
+    waiting_open = Ref(false)  # "…" placeholder shown while the model is silent
     finish_open_line() = begin
         open_call_id[] === nothing || print(io, "\n")
         open_call_id[] = nothing
@@ -108,15 +150,30 @@ function display_handler(io::IO; show_tools::Bool = true, show_reasoning::Bool =
         reasoning_open[] && print(io, "\n\n")
         reasoning_open[] = false
     end
+    clear_waiting() = begin
+        # erase the placeholder line so real output takes its place
+        waiting_open[] && use_color(io) && print(io, "\e[2K\r")
+        waiting_open[] = false
+    end
     return function (event)
         lock(io_lock) do
-            if event isa Agentif.ToolExecutionStartEvent && show_tools
+            if event isa Agentif.TurnStartEvent && use_color(io)
+                # a blank gap before the first token reads as frozen — show a
+                # placeholder that the first real output erases
+                if !waiting_open[] && open_call_id[] === nothing && !reasoning_open[]
+                    print(io, dim(io, "… thinking"))
+                    waiting_open[] = true
+                    flush(io)
+                end
+            elseif event isa Agentif.ToolExecutionStartEvent && show_tools
+                clear_waiting()
                 finish_reasoning()
                 finish_open_line()
                 print(io, dim(io, format_tool_call(event.tool_call.name, event.tool_call.arguments)))
                 open_call_id[] = event.tool_call.call_id
                 flush(io)
             elseif event isa Agentif.ToolExecutionEndEvent && show_tools
+                clear_waiting()
                 status = event.result.is_error ?
                     red(io, "✗ " * error_summary(event.result)) :
                     dim(io, "✓ " * format_duration(event.duration_ms))
@@ -128,8 +185,23 @@ function display_handler(io::IO; show_tools::Bool = true, show_reasoning::Bool =
                     finish_open_line()
                     println(io, dim(io, "  " * event.tool_call.name * " "), status)
                 end
+                if show_previews && !event.result.is_error
+                    if event.tool_call.name == "bash"
+                        preview = result_preview(event.result)
+                        isempty(preview) || println(io, dim(io, "  ⋮ " * preview))
+                    elseif event.tool_call.name == "edit"
+                        removed, added = edit_diff_lines(event.tool_call.arguments)
+                        for l in removed
+                            println(io, red(io, "  - " * first(l, 80)))
+                        end
+                        for l in added
+                            println(io, green(io, "  + " * first(l, 80)))
+                        end
+                    end
+                end
                 flush(io)
             elseif event isa Agentif.MessageUpdateEvent && event.kind == :reasoning && show_reasoning
+                clear_waiting()
                 finish_open_line()
                 reasoning_open[] || print(io, dim(io, "· "))
                 reasoning_open[] = true
@@ -138,16 +210,25 @@ function display_handler(io::IO; show_tools::Bool = true, show_reasoning::Bool =
             elseif event isa Agentif.MessageUpdateEvent && event.kind == :text
                 # text is buffered by the channel and rendered at message end;
                 # close any open reasoning/tool line before that happens
+                clear_waiting()
                 finish_reasoning()
                 finish_open_line()
             elseif event isa Agentif.MessageEndEvent && event.message isa Agentif.CompactionSummaryMessage
+                clear_waiting()
                 finish_reasoning()
                 finish_open_line()
                 println(io, dim(io, "⇣ context compacted — earlier conversation folded into a summary"))
             elseif event isa Agentif.AgentErrorEvent
+                clear_waiting()
                 finish_reasoning()
                 finish_open_line()
-                println(io, red(io, "error: " * first(string(event.error), 200)))
+                msg = first(string(event.error), 200)
+                if occursin("SSE stream interrupted", msg)
+                    # transient connection drop: the partial message was kept
+                    println(io, yellow(io, "⚡ connection dropped mid-response — continuing with what arrived"))
+                else
+                    println(io, red(io, "error: " * msg))
+                end
             end
         end
         return nothing

--- a/Juco/src/modes.jl
+++ b/Juco/src/modes.jl
@@ -45,9 +45,11 @@ function load_model_state(jdb::JucoDB)
 end
 
 function save_model_state!(jdb::JucoDB, mode::AbstractString, model_id::AbstractString, reasoning::Union{Nothing, AbstractString})
-    set_config!(jdb, "model_mode", mode)
-    set_config!(jdb, "model_id", model_id)
-    set_config!(jdb, "reasoning", reasoning)
+    SQLite.DBInterface.transaction(jdb.db) do
+        set_config!(jdb, "model_mode", mode)
+        set_config!(jdb, "model_id", model_id)
+        set_config!(jdb, "reasoning", reasoning)
+    end
     return nothing
 end
 

--- a/Juco/src/modes.jl
+++ b/Juco/src/modes.jl
@@ -27,10 +27,20 @@ end
 # ─── Persistent model selection ───
 
 function load_model_state(jdb::JucoDB)
-    mode = something(get_config(jdb, "model_mode"), "openrouter")
+    stored_mode = get_config(jdb, "model_mode")
+    stored_model = get_config(jdb, "model_id")
+    stored_reasoning = get_config(jdb, "reasoning")
+    mode = something(stored_mode, "openrouter")
     mode in MODEL_MODES || (mode = "openrouter")
-    model_id = something(get_config(jdb, "model_id"), MODE_DEFAULT_MODEL[mode])
-    reasoning = get_config(jdb, "reasoning")  # nothing = none
+    model_id = something(stored_model, MODE_DEFAULT_MODEL[mode])
+    getModel(mode_provider(mode), model_id) === nothing &&
+        (model_id = MODE_DEFAULT_MODEL[mode])
+    reasoning = stored_reasoning == "none" ? nothing : stored_reasoning
+    levels = reasoning_levels(mode, model_id)
+    reasoning === nothing || reasoning in levels || (reasoning = nothing)
+    if (mode, model_id, reasoning) != (stored_mode, stored_model, stored_reasoning)
+        save_model_state!(jdb, mode, model_id, reasoning)
+    end
     return mode, model_id, reasoning
 end
 
@@ -43,9 +53,10 @@ end
 
 # ─── Menus (TerminalMenus on a TTY, numbered fallback otherwise) ───
 
-function choose(io::IO, title::AbstractString, options::Vector{String}; default::Int = 1)
+function choose(io::IO, title::AbstractString, options::Vector{String}; default::Int = 1,
+        input::IO = stdin)
     isempty(options) && return nothing
-    if stdin isa Base.TTY && io === stdout
+    if input === stdin && input isa Base.TTY && io === stdout
         println(io, title)
         menu = TerminalMenus.RadioMenu(options; pagesize = min(12, length(options)))
         idx = TerminalMenus.request(menu; cursor = clamp(default, 1, length(options)))
@@ -56,31 +67,40 @@ function choose(io::IO, title::AbstractString, options::Vector{String}; default:
         println(io, "  $(i). $(o)")
     end
     print(io, "choice [$(default)]: ")
-    raw = strip(readline(stdin))
+    eof(input) && return nothing
+    raw = try
+        strip(readline(input))
+    catch e
+        e isa EOFError || rethrow()
+        return nothing
+    end
     isempty(raw) && return default
     n = tryparse(Int, raw)
     return (n === nothing || !(1 <= n <= length(options))) ? nothing : n
 end
 
 # The /model flow: mode -> model (with substring filter for huge lists) -> reasoning.
-function model_menu!(st, io::IO)
-    mode_i = choose(io, "Model mode:", MODEL_MODES; default = something(findfirst(==(st.mode), MODEL_MODES), 1))
+function model_menu!(st, io::IO; input::IO = stdin)
+    mode_i = choose(io, "Model mode:", MODEL_MODES;
+        default = something(findfirst(==(st.mode), MODEL_MODES), 1), input)
     mode_i === nothing && return println(io, dim(io, "cancelled"))
     mode = MODEL_MODES[mode_i]
     models = mode_models(mode)
     if length(models) > 30
         print(io, "filter (substring, empty for all): ")
-        pat = lowercase(strip(readline(stdin)))
+        eof(input) && return println(io, dim(io, "cancelled"))
+        pat = lowercase(strip(readline(input)))
         isempty(pat) || (models = filter(m -> occursin(pat, lowercase(m)), models))
         isempty(models) && return println(io, red(io, "no models match \"$(pat)\""))
     end
     default_model = something(findfirst(==(st.model_id), models), 1)
-    model_i = choose(io, "Model:", models; default = default_model)
+    model_i = choose(io, "Model:", models; default = default_model, input)
     model_i === nothing && return println(io, dim(io, "cancelled"))
     model_id = models[model_i]
     levels = reasoning_levels(mode, model_id)
     current_level = something(st.reasoning, "none")
-    level_i = choose(io, "Reasoning:", levels; default = something(findfirst(==(current_level), levels), 1))
+    level_i = choose(io, "Reasoning:", levels;
+        default = something(findfirst(==(current_level), levels), 1), input)
     level_i === nothing && return println(io, dim(io, "cancelled"))
     reasoning = levels[level_i] == "none" ? nothing : levels[level_i]
     st.mode, st.model_id, st.reasoning = mode, model_id, reasoning
@@ -97,11 +117,11 @@ session_age(updated_at::Real) = begin
 end
 
 # The /resume flow: pick a past session from a menu.
-function resume_menu!(st, io::IO)
+function resume_menu!(st, io::IO; input::IO = stdin)
     sessions = list_sessions(st.jdb; limit = 15)
     isempty(sessions) && return println(io, "No sessions to resume.")
     options = ["$(s.id)  ($(session_age(s.updated_at)))  $(first(s.title, 50))" for s in sessions]
-    i = choose(io, "Resume session:", options)
+    i = choose(io, "Resume session:", options; input)
     i === nothing && return println(io, dim(io, "cancelled"))
     st.session_id = sessions[i].id
     println(io, dim(io, "resumed $(st.session_id)"))

--- a/Juco/src/modes.jl
+++ b/Juco/src/modes.jl
@@ -1,0 +1,109 @@
+# Model modes: named provider configurations the user switches between with
+# /model. Selection (mode, model, reasoning) is persistent REPL state stored in
+# the sqlite config table — not environment variables.
+
+const MODEL_MODES = ["openrouter", "codex"]
+
+mode_provider(mode::AbstractString) = mode == "codex" ? "openai-codex" : "openrouter"
+
+# codex authenticates via the LLMOAuth ChatGPT flow (apikey sentinel "OAUTH")
+mode_apikey(mode::AbstractString) = mode == "codex" ? "OAUTH" : resolve_apikey("openrouter")
+
+const MODE_DEFAULT_MODEL = Dict(
+    "openrouter" => "deepseek/deepseek-v4-flash-0731",
+    "codex" => "gpt-5.3-codex",
+)
+
+mode_models(mode::AbstractString) =
+    sort!([m.id for m in getModels(mode_provider(mode))])
+
+function reasoning_levels(mode::AbstractString, model_id::AbstractString)
+    m = getModel(mode_provider(mode), model_id)
+    (m === nothing || !m.reasoning) && return ["none"]
+    mode == "codex" && return ["none", "minimal", "low", "medium", "high", "xhigh"]
+    return ["none", "low", "medium", "high"]
+end
+
+# ─── Persistent model selection ───
+
+function load_model_state(jdb::JucoDB)
+    mode = something(get_config(jdb, "model_mode"), "openrouter")
+    mode in MODEL_MODES || (mode = "openrouter")
+    model_id = something(get_config(jdb, "model_id"), MODE_DEFAULT_MODEL[mode])
+    reasoning = get_config(jdb, "reasoning")  # nothing = none
+    return mode, model_id, reasoning
+end
+
+function save_model_state!(jdb::JucoDB, mode::AbstractString, model_id::AbstractString, reasoning::Union{Nothing, AbstractString})
+    set_config!(jdb, "model_mode", mode)
+    set_config!(jdb, "model_id", model_id)
+    set_config!(jdb, "reasoning", reasoning)
+    return nothing
+end
+
+# ─── Menus (TerminalMenus on a TTY, numbered fallback otherwise) ───
+
+function choose(io::IO, title::AbstractString, options::Vector{String}; default::Int = 1)
+    isempty(options) && return nothing
+    if stdin isa Base.TTY && io === stdout
+        println(io, title)
+        menu = TerminalMenus.RadioMenu(options; pagesize = min(12, length(options)))
+        idx = TerminalMenus.request(menu; cursor = clamp(default, 1, length(options)))
+        return idx == -1 ? nothing : idx
+    end
+    println(io, title)
+    for (i, o) in enumerate(options)
+        println(io, "  $(i). $(o)")
+    end
+    print(io, "choice [$(default)]: ")
+    raw = strip(readline(stdin))
+    isempty(raw) && return default
+    n = tryparse(Int, raw)
+    return (n === nothing || !(1 <= n <= length(options))) ? nothing : n
+end
+
+# The /model flow: mode -> model (with substring filter for huge lists) -> reasoning.
+function model_menu!(st, io::IO)
+    mode_i = choose(io, "Model mode:", MODEL_MODES; default = something(findfirst(==(st.mode), MODEL_MODES), 1))
+    mode_i === nothing && return println(io, dim(io, "cancelled"))
+    mode = MODEL_MODES[mode_i]
+    models = mode_models(mode)
+    if length(models) > 30
+        print(io, "filter (substring, empty for all): ")
+        pat = lowercase(strip(readline(stdin)))
+        isempty(pat) || (models = filter(m -> occursin(pat, lowercase(m)), models))
+        isempty(models) && return println(io, red(io, "no models match \"$(pat)\""))
+    end
+    default_model = something(findfirst(==(st.model_id), models), 1)
+    model_i = choose(io, "Model:", models; default = default_model)
+    model_i === nothing && return println(io, dim(io, "cancelled"))
+    model_id = models[model_i]
+    levels = reasoning_levels(mode, model_id)
+    current_level = something(st.reasoning, "none")
+    level_i = choose(io, "Reasoning:", levels; default = something(findfirst(==(current_level), levels), 1))
+    level_i === nothing && return println(io, dim(io, "cancelled"))
+    reasoning = levels[level_i] == "none" ? nothing : levels[level_i]
+    st.mode, st.model_id, st.reasoning = mode, model_id, reasoning
+    save_model_state!(st.jdb, mode, model_id, reasoning)
+    println(io, dim(io, "model set: $(mode) · $(model_id) · reasoning $(something(reasoning, "none"))"))
+    return nothing
+end
+
+session_age(updated_at::Real) = begin
+    s = time() - updated_at
+    s < 90 ? "just now" :
+    s < 3600 ? "$(round(Int, s / 60))m ago" :
+    s < 86400 ? "$(round(Int, s / 3600))h ago" : "$(round(Int, s / 86400))d ago"
+end
+
+# The /resume flow: pick a past session from a menu.
+function resume_menu!(st, io::IO)
+    sessions = list_sessions(st.jdb; limit = 15)
+    isempty(sessions) && return println(io, "No sessions to resume.")
+    options = ["$(s.id)  ($(session_age(s.updated_at)))  $(first(s.title, 50))" for s in sessions]
+    i = choose(io, "Resume session:", options)
+    i === nothing && return println(io, dim(io, "cancelled"))
+    st.session_id = sessions[i].id
+    println(io, dim(io, "resumed $(st.session_id)"))
+    return nothing
+end

--- a/Juco/src/modes.jl
+++ b/Juco/src/modes.jl
@@ -125,7 +125,7 @@ function resume_menu!(st, io::IO; input::IO = stdin)
     options = ["$(s.id)  ($(session_age(s.updated_at)))  $(first(s.title, 50))" for s in sessions]
     i = choose(io, "Resume session:", options; input)
     i === nothing && return println(io, dim(io, "cancelled"))
-    st.session_id = sessions[i].id
+    switch_session!(st, sessions[i].id)
     println(io, dim(io, "resumed $(st.session_id)"))
     return nothing
 end

--- a/Juco/src/modes.jl
+++ b/Juco/src/modes.jl
@@ -55,13 +55,43 @@ end
 
 # ─── Menus (TerminalMenus on a TTY, numbered fallback otherwise) ───
 
+# TerminalMenus writes its initial frame without flushing. Some terminal
+# emulators therefore do not show the choices until the first key press.
+struct FlushingIO <: IO
+    io::IO
+end
+
+Base.isopen(io::FlushingIO) = isopen(io.io)
+Base.displaysize(io::FlushingIO) = displaysize(io.io)
+Base.get(io::FlushingIO, key, default) = get(io.io, key, default)
+Base.flush(io::FlushingIO) = flush(io.io)
+
+function Base.unsafe_write(io::FlushingIO, data::Ptr{UInt8}, n::UInt)
+    written = unsafe_write(io.io, data, n)
+    flush(io.io)
+    return written
+end
+
+function Base.write(io::FlushingIO, byte::UInt8)
+    written = write(io.io, byte)
+    flush(io.io)
+    return written
+end
+
+function flushing_terminal()
+    term = TerminalMenus.default_terminal()
+    return REPL.Terminals.TTYTerminal(
+        term.term_type, term.in_stream, FlushingIO(term.out_stream), term.err_stream)
+end
+
 function choose(io::IO, title::AbstractString, options::Vector{String}; default::Int = 1,
         input::IO = stdin)
     isempty(options) && return nothing
     if input === stdin && input isa Base.TTY && io === stdout
-        println(io, title)
         menu = TerminalMenus.RadioMenu(options; pagesize = min(12, length(options)))
-        idx = TerminalMenus.request(menu; cursor = clamp(default, 1, length(options)))
+        term = flushing_terminal()
+        idx = TerminalMenus.request(term, String(title), menu;
+            cursor = clamp(default, 1, length(options)))
         return idx == -1 ? nothing : idx
     end
     println(io, title)

--- a/Juco/src/prompt.jl
+++ b/Juco/src/prompt.jl
@@ -45,6 +45,7 @@ Guidelines:
 - Explore before editing; verify your changes (run tests or the code) before declaring success.
 - Keep edits surgical: change only what the task requires.
 - Julia: to extend an existing generic function (push!, pop!, peek, length, isempty, iterate, show, ...) for your own type, define a method on it — `Base.f(x::YourType) = ...` — never a new function or export of the same name.
+- Julia: locals and keyword arguments shadow functions — naming one `max`, `min`, `length`, or `first` breaks calls to that function in the same body (use a different name or qualify `Base.max`).
 - Be concise. When done, summarize what changed in a sentence or two.
 
 Working directory: $(abspath(base_dir))

--- a/Juco/src/prompt.jl
+++ b/Juco/src/prompt.jl
@@ -16,6 +16,21 @@ const PRESET_TOOL_LINES = Dict{Symbol, String}(
 - bash: run shell commands — your only tool. Explore with ls/rg/find/cat, edit files with heredocs, python, or ed/sed""",
 )
 
+# One entry per line, directories marked with '/'. Capped so a huge directory
+# can't blow up the prompt.
+function dir_snapshot(base_dir::AbstractString; limit::Int = 50)
+    entries = try
+        sort(readdir(base_dir))
+    catch
+        return ""
+    end
+    isempty(entries) && return "(empty)"
+    shown = first(entries, limit)
+    lines = [isdir(joinpath(base_dir, e)) ? e * "/" : e for e in shown]
+    length(entries) > limit && push!(lines, "... ($(length(entries) - limit) more entries)")
+    return join(lines, "\n")
+end
+
 function build_prompt(base_dir::AbstractString, preset::Symbol; memories::Vector{String} = String[])
     tool_lines = get(PRESET_TOOL_LINES, preset) do
         throw(ArgumentError("unknown toolset preset: $preset"))
@@ -30,7 +45,9 @@ Guidelines:
 - Keep edits surgical: change only what the task requires.
 - Be concise. When done, summarize what changed in a sentence or two.
 
-Working directory: $(abspath(base_dir))"""
+Working directory: $(abspath(base_dir))
+Top-level contents (snapshot at session start):
+$(dir_snapshot(base_dir))"""
     if !isempty(memories)
         memory_lines = join(("- " * m for m in memories), "\n")
         prompt *= """

--- a/Juco/src/prompt.jl
+++ b/Juco/src/prompt.jl
@@ -41,6 +41,7 @@ Available tools:
 $tool_lines
 
 Guidelines:
+- When fixing a bug or failing test, REPRODUCE it first: run the failing command and read the actual error before reading or changing code.
 - Explore before editing; verify your changes (run tests or the code) before declaring success.
 - Keep edits surgical: change only what the task requires.
 - Be concise. When done, summarize what changed in a sentence or two.

--- a/Juco/src/prompt.jl
+++ b/Juco/src/prompt.jl
@@ -44,6 +44,7 @@ Guidelines:
 - When fixing a bug or failing test, REPRODUCE it first: run the failing command and read the actual error before reading or changing code.
 - Explore before editing; verify your changes (run tests or the code) before declaring success.
 - Keep edits surgical: change only what the task requires.
+- Julia: to extend an existing generic function (push!, pop!, peek, length, isempty, iterate, show, ...) for your own type, define a method on it — `Base.f(x::YourType) = ...` — never a new function or export of the same name.
 - Be concise. When done, summarize what changed in a sentence or two.
 
 Working directory: $(abspath(base_dir))

--- a/Juco/src/prompt.jl
+++ b/Juco/src/prompt.jl
@@ -43,7 +43,11 @@ $tool_lines
 
 Guidelines:
 - When fixing a bug or failing test, REPRODUCE it first: run the failing command and read the actual error before reading or changing code.
+- In a git worktree, scope vague find/fix requests with `git status` and the current branch diff from its merge base before searching the whole repository.
 - Inspect large or unknown files with head/wc/rg before deciding what to extract — never dump whole files with cat.
+- Do not repeat a search or reread unchanged content. If targeted checks do not produce evidence, say what you checked instead of guessing.
+- Do not restate the task or narrate routine tool choices. Use short reasoning notes only when they explain a decision.
+- Respect the requested scope. For read-only tasks, do not edit files, install tools, or change repository or system state.
 - Explore before editing; verify your changes (run tests or the code) before declaring success.
 - Keep edits surgical: change only what the task requires.
 - Julia: to extend an existing generic function (push!, pop!, peek, length, isempty, iterate, show, ...) for your own type, define a method on it — `Base.f(x::YourType) = ...` — never a new function or export of the same name.

--- a/Juco/src/prompt.jl
+++ b/Juco/src/prompt.jl
@@ -31,7 +31,8 @@ function dir_snapshot(base_dir::AbstractString; limit::Int = 50)
     return join(lines, "\n")
 end
 
-function build_prompt(base_dir::AbstractString, preset::Symbol; memories::Vector{String} = String[])
+function build_prompt(base_dir::AbstractString, preset::Symbol; memories::Vector{String} = String[],
+        max_turns::Union{Nothing, Int} = nothing)
     tool_lines = get(PRESET_TOOL_LINES, preset) do
         throw(ArgumentError("unknown toolset preset: $preset"))
     end
@@ -42,6 +43,7 @@ $tool_lines
 
 Guidelines:
 - When fixing a bug or failing test, REPRODUCE it first: run the failing command and read the actual error before reading or changing code.
+- Inspect large or unknown files with head/wc/rg before deciding what to extract — never dump whole files with cat.
 - Explore before editing; verify your changes (run tests or the code) before declaring success.
 - Keep edits surgical: change only what the task requires.
 - Julia: to extend an existing generic function (push!, pop!, peek, length, isempty, iterate, show, ...) for your own type, define a method on it — `Base.f(x::YourType) = ...` — never a new function or export of the same name.
@@ -51,6 +53,9 @@ Guidelines:
 Working directory: $(abspath(base_dir))
 Top-level contents (snapshot at session start):
 $(dir_snapshot(base_dir))"""
+    if max_turns !== nothing
+        prompt *= "\n\nBudget: up to $(max_turns) tool calls per user request — pace yourself; you'll get a warning when few remain."
+    end
     if !isempty(memories)
         memory_lines = join(("- " * m for m in memories), "\n")
         prompt *= """

--- a/Juco/src/skills.jl
+++ b/Juco/src/skills.jl
@@ -1,0 +1,105 @@
+# Skills: reusable prompt fragments the user injects with `$name`.
+#
+# Discovered dynamically at launch from `~/.agent/skills/<name>/SKILL.md` and
+# `<cwd>/.agent/skills/<name>/SKILL.md` (project-local wins on name clashes).
+# In the Julia-REPL juco mode, `$` tab-completes against the discovered names;
+# any `$name` tokens in a submitted prompt inject the skill contents as
+# `<skill>` blocks appended to the message.
+
+struct Skill
+    name::String
+    path::String
+    description::String
+end
+
+skill_dirs(base_dir::AbstractString = pwd()) = [
+    joinpath(homedir(), ".agent", "skills"),
+    joinpath(abspath(base_dir), ".agent", "skills"),
+]
+
+# First sentence-ish line that isn't a heading or frontmatter, as the description.
+function skill_description(content::AbstractString)
+    in_frontmatter = false
+    for (i, line) in enumerate(eachsplit(content, '\n'))
+        s = strip(line)
+        if i == 1 && s == "---"
+            in_frontmatter = true
+            continue
+        end
+        if in_frontmatter
+            s == "---" && (in_frontmatter = false)
+            m = match(r"^description:\s*(.+)$", s)
+            m === nothing || return String(strip(m.captures[1]))
+            continue
+        end
+        isempty(s) && continue
+        startswith(s, "#") && continue
+        return String(first(s, 100))
+    end
+    return ""
+end
+
+function discover_skills(base_dir::AbstractString = pwd())
+    skills = Dict{String, Skill}()
+    for dir in skill_dirs(base_dir)  # later dirs (project-local) override
+        isdir(dir) || continue
+        for entry in sort(readdir(dir))
+            path = joinpath(dir, entry, "SKILL.md")
+            isfile(path) || continue
+            desc = try
+                skill_description(read(path, String))
+            catch
+                ""
+            end
+            skills[entry] = Skill(entry, path, desc)
+        end
+    end
+    return sort!(collect(values(skills)); by = s -> s.name)
+end
+
+# ─── `$name` completion (pure logic; LineEdit wiring lives in the ReplMaker ext) ───
+
+"""
+    skill_completions(full, cursor, skills) -> (names, byte_range, should_complete)
+
+If the text before `cursor` (a byte position) ends in `\$partial`, return skill
+names completing `partial` and the byte range of `partial` to replace.
+"""
+function skill_completions(full::AbstractString, cursor::Int, skills::Vector{Skill})
+    cursor = clamp(cursor, 0, ncodeunits(full))
+    prefix = cursor == 0 ? "" : full[1:thisind(full, cursor)]
+    m = match(r"\$([A-Za-z0-9_\-]*)$", prefix)
+    m === nothing && return String[], 1:0, false
+    word = m.captures[1]
+    names = [s.name for s in skills if startswith(s.name, word)]
+    range = m.offsets[1]:(m.offsets[1] + ncodeunits(word) - 1)
+    return names, range, !isempty(names)
+end
+
+# ─── Prompt expansion ───
+
+"""
+    expand_skills(input, skills) -> (expanded_input, used_names)
+
+Find `\$name` tokens matching discovered skills and append each skill's
+contents as a `<skill>` block. Unknown `\$words` are left untouched.
+"""
+function expand_skills(input::AbstractString, skills::Vector{Skill})
+    isempty(skills) && return String(input), String[]
+    by_name = Dict(s.name => s for s in skills)
+    used = String[]
+    for m in eachmatch(r"\$([A-Za-z0-9][A-Za-z0-9_\-]*)", input)
+        name = m.captures[1]
+        haskey(by_name, name) && !(name in used) && push!(used, String(name))
+    end
+    isempty(used) && return String(input), used
+    blocks = map(used) do name
+        content = try
+            strip(read(by_name[name].path, String))
+        catch
+            ""
+        end
+        "<skill name=\"$(name)\">\n$(content)\n</skill>"
+    end
+    return String(input) * "\n\n" * join(blocks, "\n\n"), used
+end

--- a/Juco/src/tools.jl
+++ b/Juco/src/tools.jl
@@ -101,7 +101,7 @@ To EDIT: `oldText` must match exactly one location in the file (whitespace-sensi
 To CREATE a new file: pass an empty `oldText` (""). The file must not already exist; parent directories are created automatically.
 
 Arguments:
-- path (String, required): File path relative to the working directory.
+- path (String, required): File path: relative to the working directory, or absolute within it.
 - oldText (String, required): Exact text to find, or "" to create a new file.
 - newText (String, required): Replacement text, or the full content of the new file.
 

--- a/Juco/src/tools.jl
+++ b/Juco/src/tools.jl
@@ -136,6 +136,18 @@ Examples:
     )
 end
 
+# If the intended replacement already exists in the file, say so — the most
+# common cause of a not-found oldText is an edit that was already applied.
+function already_applied_hint(content::String, newText::String)
+    anchor = ""
+    for line in eachsplit(newText, '\n')
+        s = strip(line)
+        isempty(s) || (anchor = String(s); break)
+    end
+    (isempty(anchor) || !occursin(anchor, content)) && return ""
+    return " Note: the replacement text already appears in the file — this edit may already be applied."
+end
+
 # When an exact match fails, point the model at the closest candidates (lines
 # containing the first line of its oldText) so it can re-anchor without a
 # read + guess round trip.
@@ -221,7 +233,8 @@ Errors if: oldText not found or not unique, file missing when editing, or file a
             content = Base.read(resolved, String)
             matches = overlapping_matches(oldText, content)
             isempty(matches) && throw(ArgumentError(
-                "could not find the exact text in $(path)." * nearest_match_hint(content, oldText)))
+                "could not find the exact text in $(path)." * already_applied_hint(content, newText) *
+                nearest_match_hint(content, oldText)))
             if length(matches) > 1
                 match_lines = [count(==('\n'), content[1:prevind(content, first(m))]) + 1 for m in matches]
                 throw(ArgumentError("found $(length(matches)) occurrences in $(path) (at lines $(join(match_lines, ", "))); include more surrounding context to make oldText unique"))
@@ -229,7 +242,7 @@ Errors if: oldText not found or not unique, file missing when editing, or file a
             idx = matches[1]
             replace_start = first(idx)
             new_content = content[1:prevind(content, replace_start)] * newText * content[nextind(content, last(idx)):end]
-            new_content == content && throw(ArgumentError("replacement produced identical content for $(path)"))
+            new_content == content && throw(ArgumentError("replacement produced identical content for $(path) — the file already reads this way; no edit is needed"))
             Base.write(resolved, new_content)
             return "Edited $(path), " * edited_region(new_content, replace_start, newText)
         end,

--- a/Juco/src/tools.jl
+++ b/Juco/src/tools.jl
@@ -163,12 +163,7 @@ end
 # If the intended replacement already exists in the file, say so — the most
 # common cause of a not-found oldText is an edit that was already applied.
 function already_applied_hint(content::String, newText::String)
-    anchor = ""
-    for line in eachsplit(newText, '\n')
-        s = strip(line)
-        isempty(s) || (anchor = String(s); break)
-    end
-    (isempty(anchor) || !occursin(anchor, content)) && return ""
+    (isempty(newText) || !occursin(newText, content)) && return ""
     return " Note: the replacement text already appears in the file — this edit may already be applied."
 end
 

--- a/Juco/src/tools.jl
+++ b/Juco/src/tools.jl
@@ -37,7 +37,17 @@ function truncate_tail(content::String;
         pushfirst!(kept, lines[idx])
         bytes += line_bytes
     end
-    isempty(kept) && push!(kept, String(last(lines[total_lines], max_bytes)))
+    if isempty(kept)
+        line = lines[total_lines]
+        if max_bytes <= 0
+            push!(kept, "")
+        else
+            first_byte = max(1, ncodeunits(line) - max_bytes + 1)
+            start = thisind(line, first_byte)
+            start < first_byte && (start = nextind(line, start))
+            push!(kept, String(line[start:end]))
+        end
+    end
     return (content = join(kept, "\n"), truncated = true, output_lines = length(kept), total_lines = total_lines)
 end
 
@@ -134,7 +144,7 @@ end
 # Show the edited region (with numbered context lines) so the model can verify
 # the change without a follow-up read.
 function edited_region(new_content::String, replace_start::Int, new_text::String; context::Int = 3)
-    prefix = new_content[1:replace_start-1]
+    prefix = new_content[1:prevind(new_content, replace_start)]
     first_changed = count(==('\n'), prefix) + 1
     last_changed = first_changed + count(==('\n'), new_text)
     lines = split(new_content, "\n"; keepempty = true)

--- a/Juco/src/tools.jl
+++ b/Juco/src/tools.jl
@@ -154,6 +154,18 @@ function edited_region(new_content::String, replace_start::Int, new_text::String
     return "lines $(lo)-$(hi) now:\n" * join(numbered, "\n")
 end
 
+function overlapping_matches(needle::String, haystack::String)
+    matches = UnitRange{Int}[]
+    from = firstindex(haystack)
+    while from <= lastindex(haystack)
+        match = findnext(needle, haystack, from)
+        match === nothing && break
+        push!(matches, match)
+        from = nextind(haystack, first(match))
+    end
+    return matches
+end
+
 function create_edit_tool(base_dir::AbstractString)
     base = LLMTools.ensure_base_dir(base_dir)
     return Agentif.@tool(
@@ -183,7 +195,7 @@ Errors if: oldText not found or not unique, file missing when editing, or file a
             end
             isfile(resolved) || throw(ArgumentError("file not found: $(path) (to create it, pass oldText = \"\")"))
             content = Base.read(resolved, String)
-            matches = findall(oldText, content)
+            matches = overlapping_matches(oldText, content)
             isempty(matches) && throw(ArgumentError(
                 "could not find the exact text in $(path)." * nearest_match_hint(content, oldText)))
             if length(matches) > 1

--- a/Juco/src/tools.jl
+++ b/Juco/src/tools.jl
@@ -11,16 +11,39 @@ const MAX_BASH_LINE_CHARS = 2000
 const MAX_BASH_OUTPUT_BYTES = 16 * 1024
 const BASH_HEAD_LINES = 10
 
+function byte_prefix(content::String, max_bytes::Int)
+    max_bytes <= 0 && return ""
+    ncodeunits(content) <= max_bytes && return content
+    io = IOBuffer()
+    bytes = 0
+    for char in content
+        char_bytes = ncodeunits(string(char))
+        bytes + char_bytes > max_bytes && break
+        print(io, char)
+        bytes += char_bytes
+    end
+    return String(take!(io))
+end
+
 # Large outputs are sampled instead of tail-truncated wholesale: keep the first
 # few lines (schema/first records) plus the tail (recent output, errors), with
 # an explicit skip marker teaching the model to slice next time. A truncated
 # result would otherwise ride along in the context of every later turn.
 function sample_output(output::String; max_bytes::Int = MAX_BASH_OUTPUT_BYTES, head_lines::Int = BASH_HEAD_LINES)
+    max_bytes >= 0 || throw(ArgumentError("max_bytes must be nonnegative"))
+    head_lines >= 0 || throw(ArgumentError("head_lines must be nonnegative"))
     ncodeunits(output) <= max_bytes && return output, false
     lines = split(output, '\n'; keepempty = true)
     total_lines = length(lines)
+    marker_for(skipped) = "\n…[skipped $(skipped) of $(total_lines) lines ($(round(Int, ncodeunits(output) / 1024))KB total) — for large outputs, slice with rg/head/awk instead of dumping them]\n"
+    # Reserve the largest possible marker first. The actual skipped count has
+    # no more digits, so the final result cannot exceed max_bytes.
+    marker_reserve = marker_for(total_lines)
+    if ncodeunits(marker_reserve) > max_bytes
+        return byte_prefix("…[sampled output]", max_bytes), true
+    end
     # keep whole head lines while under a quarter of the budget
-    head_budget = max_bytes ÷ 4
+    head_budget = min(max_bytes ÷ 4, max_bytes - ncodeunits(marker_reserve))
     kept = String[]
     bytes = 0
     for l in first(lines, head_lines)
@@ -30,10 +53,10 @@ function sample_output(output::String; max_bytes::Int = MAX_BASH_OUTPUT_BYTES, h
         bytes += lb
     end
     head = join(kept, "\n")
-    tail_budget = max(1024, max_bytes - ncodeunits(head))
+    tail_budget = max_bytes - ncodeunits(head) - ncodeunits(marker_reserve)
     tail = truncate_tail(output; max_lines = typemax(Int) ÷ 2, max_bytes = tail_budget)
     skipped = total_lines - length(kept) - tail.output_lines
-    marker = "\n…[skipped $(max(skipped, 0)) of $(total_lines) lines ($(round(Int, ncodeunits(output) / 1024))KB total) — for large outputs, slice with rg/head/awk instead of dumping them]\n"
+    marker = marker_for(max(skipped, 0))
     return head * marker * tail.content, true
 end
 
@@ -128,9 +151,10 @@ Examples:
         bash(command::String, timeout::Union{Nothing, Int} = nothing) = begin
             timeout_s = clamp(something(timeout, DEFAULT_BASH_TIMEOUT_S), 1, MAX_BASH_TIMEOUT_S)
             output, exitcode, timedout = run_bash(base, command, timeout_s)
-            result, was_sampled = sample_output(cap_line_lengths(output))
-            timedout && (result *= "\n[Command timed out after $(timeout_s)s and was killed]")
-            !timedout && exitcode != 0 && (result *= "\n[exit code $(exitcode)]")
+            output = cap_line_lengths(output)
+            timedout && (output *= "\n[Command timed out after $(timeout_s)s and was killed]")
+            !timedout && exitcode != 0 && (output *= "\n[exit code $(exitcode)]")
+            result, was_sampled = sample_output(output)
             return result
         end,
     )

--- a/Juco/src/tools.jl
+++ b/Juco/src/tools.jl
@@ -102,6 +102,35 @@ Examples:
     )
 end
 
+# When an exact match fails, point the model at the closest candidates (lines
+# containing the first line of its oldText) so it can re-anchor without a
+# read + guess round trip.
+function nearest_match_hint(content::String, oldText::String; max_hits::Int = 3)
+    anchor = ""
+    for line in eachsplit(oldText, '\n')
+        s = strip(line)
+        isempty(s) || (anchor = String(s); break)
+    end
+    isempty(anchor) && return ""
+    lines = split(content, "\n"; keepempty = true)
+    hits = [i for (i, l) in enumerate(lines) if occursin(anchor, l)]
+    if isempty(hits)
+        # the whole line missed (that's often why the edit failed) — fall back
+        # to its first word to find near-miss regions
+        word = first(eachsplit(anchor, r"\s+"))
+        isempty(word) && return ""
+        hits = [i for (i, l) in enumerate(lines) if occursin(word, l)]
+        isempty(hits) && return ""
+    end
+    sections = String[]
+    for i in first(hits, max_hits)
+        lo, hi = max(1, i - 2), min(length(lines), i + 2)
+        push!(sections, join(("$(lpad(j, 5)) | $(lines[j])" for j in lo:hi), "\n"))
+    end
+    plural = length(hits) > max_hits ? " (showing $(max_hits) of $(length(hits)))" : ""
+    return "\nClosest candidates$(plural) — check exact whitespace/quoting against these:\n" * join(sections, "\n  ...\n")
+end
+
 # Show the edited region (with numbered context lines) so the model can verify
 # the change without a follow-up read.
 function edited_region(new_content::String, replace_start::Int, new_text::String; context::Int = 3)
@@ -145,8 +174,12 @@ Errors if: oldText not found or not unique, file missing when editing, or file a
             isfile(resolved) || throw(ArgumentError("file not found: $(path) (to create it, pass oldText = \"\")"))
             content = Base.read(resolved, String)
             matches = findall(oldText, content)
-            isempty(matches) && throw(ArgumentError("could not find the exact text in $(path)"))
-            length(matches) > 1 && throw(ArgumentError("found $(length(matches)) occurrences in $(path); include more surrounding context to make oldText unique"))
+            isempty(matches) && throw(ArgumentError(
+                "could not find the exact text in $(path)." * nearest_match_hint(content, oldText)))
+            if length(matches) > 1
+                match_lines = [count(==('\n'), content[1:prevind(content, first(m))]) + 1 for m in matches]
+                throw(ArgumentError("found $(length(matches)) occurrences in $(path) (at lines $(join(match_lines, ", "))); include more surrounding context to make oldText unique"))
+            end
             idx = matches[1]
             replace_start = first(idx)
             new_content = content[1:prevind(content, replace_start)] * newText * content[nextind(content, last(idx)):end]

--- a/Juco/src/tools.jl
+++ b/Juco/src/tools.jl
@@ -8,6 +8,34 @@
 const DEFAULT_BASH_TIMEOUT_S = 120
 const MAX_BASH_TIMEOUT_S = 600
 const MAX_BASH_LINE_CHARS = 2000
+const MAX_BASH_OUTPUT_BYTES = 16 * 1024
+const BASH_HEAD_LINES = 10
+
+# Large outputs are sampled instead of tail-truncated wholesale: keep the first
+# few lines (schema/first records) plus the tail (recent output, errors), with
+# an explicit skip marker teaching the model to slice next time. A truncated
+# result would otherwise ride along in the context of every later turn.
+function sample_output(output::String; max_bytes::Int = MAX_BASH_OUTPUT_BYTES, head_lines::Int = BASH_HEAD_LINES)
+    ncodeunits(output) <= max_bytes && return output, false
+    lines = split(output, '\n'; keepempty = true)
+    total_lines = length(lines)
+    # keep whole head lines while under a quarter of the budget
+    head_budget = max_bytes ÷ 4
+    kept = String[]
+    bytes = 0
+    for l in first(lines, head_lines)
+        lb = ncodeunits(l) + (isempty(kept) ? 0 : 1)
+        bytes + lb > head_budget && break
+        push!(kept, String(l))
+        bytes += lb
+    end
+    head = join(kept, "\n")
+    tail_budget = max(1024, max_bytes - ncodeunits(head))
+    tail = truncate_tail(output; max_lines = typemax(Int) ÷ 2, max_bytes = tail_budget)
+    skipped = total_lines - length(kept) - tail.output_lines
+    marker = "\n…[skipped $(max(skipped, 0)) of $(total_lines) lines ($(round(Int, ncodeunits(output) / 1024))KB total) — for large outputs, slice with rg/head/awk instead of dumping them]\n"
+    return head * marker * tail.content, true
+end
 
 # A single enormous line (a minified file, a dumped data structure) can eat the
 # whole 50KB output budget; cap lines the way grep output caps match lines.
@@ -92,7 +120,7 @@ Arguments:
 - command (String, required): The bash command to execute.
 - timeout (Int, optional): Seconds before the command is killed. Default 120, max 600.
 
-Output is truncated to the LAST 2000 lines or 50KB, whichever is hit first.
+Output over 16KB is sampled (first lines + tail, middle skipped) — slice large outputs with rg/head/awk instead of dumping whole files.
 
 Examples:
 - `bash("rg -n 'function parse' src/")` — search code
@@ -100,11 +128,7 @@ Examples:
         bash(command::String, timeout::Union{Nothing, Int} = nothing) = begin
             timeout_s = clamp(something(timeout, DEFAULT_BASH_TIMEOUT_S), 1, MAX_BASH_TIMEOUT_S)
             output, exitcode, timedout = run_bash(base, command, timeout_s)
-            truncation = truncate_tail(cap_line_lengths(output))
-            result = truncation.content
-            if truncation.truncated
-                result = "[Output truncated: showing last $(truncation.output_lines) of $(truncation.total_lines) lines]\n" * result
-            end
+            result, was_sampled = sample_output(cap_line_lengths(output))
             timedout && (result *= "\n[Command timed out after $(timeout_s)s and was killed]")
             !timedout && exitcode != 0 && (result *= "\n[exit code $(exitcode)]")
             return result

--- a/Juco/src/tools.jl
+++ b/Juco/src/tools.jl
@@ -91,10 +91,23 @@ Examples:
     )
 end
 
+# Show the edited region (with numbered context lines) so the model can verify
+# the change without a follow-up read.
+function edited_region(new_content::String, replace_start::Int, new_text::String; context::Int = 3)
+    prefix = new_content[1:replace_start-1]
+    first_changed = count(==('\n'), prefix) + 1
+    last_changed = first_changed + count(==('\n'), new_text)
+    lines = split(new_content, "\n"; keepempty = true)
+    lo = max(1, first_changed - context)
+    hi = min(length(lines), last_changed + context)
+    numbered = ["$(lpad(i, 5)) | $(lines[i])" for i in lo:hi]
+    return "lines $(lo)-$(hi) now:\n" * join(numbered, "\n")
+end
+
 function create_edit_tool(base_dir::AbstractString)
     base = LLMTools.ensure_base_dir(base_dir)
     return Agentif.@tool(
-        """Edit a file by replacing an exact text match, or create a new file.
+        """Edit a file by replacing an exact text match, or create a new file. Returns the edited region so you can verify the change without re-reading the file.
 
 To EDIT: `oldText` must match exactly one location in the file (whitespace-sensitive). Include enough surrounding lines to make the match unique, but keep it as small as possible.
 
@@ -124,10 +137,11 @@ Errors if: oldText not found or not unique, file missing when editing, or file a
             isempty(matches) && throw(ArgumentError("could not find the exact text in $(path)"))
             length(matches) > 1 && throw(ArgumentError("found $(length(matches)) occurrences in $(path); include more surrounding context to make oldText unique"))
             idx = matches[1]
-            new_content = content[1:prevind(content, first(idx))] * newText * content[nextind(content, last(idx)):end]
+            replace_start = first(idx)
+            new_content = content[1:prevind(content, replace_start)] * newText * content[nextind(content, last(idx)):end]
             new_content == content && throw(ArgumentError("replacement produced identical content for $(path)"))
             Base.write(resolved, new_content)
-            return "Edited $(path)"
+            return "Edited $(path), " * edited_region(new_content, replace_start, newText)
         end,
     )
 end

--- a/Juco/src/tools.jl
+++ b/Juco/src/tools.jl
@@ -7,6 +7,17 @@
 
 const DEFAULT_BASH_TIMEOUT_S = 120
 const MAX_BASH_TIMEOUT_S = 600
+const MAX_BASH_LINE_CHARS = 2000
+
+# A single enormous line (a minified file, a dumped data structure) can eat the
+# whole 50KB output budget; cap lines the way grep output caps match lines.
+function cap_line_lengths(content::String; max_chars::Int = MAX_BASH_LINE_CHARS)
+    any(l -> length(l) > max_chars, eachsplit(content, '\n')) || return content
+    capped = map(split(content, '\n'; keepempty = true)) do line
+        length(line) > max_chars ? first(line, max_chars) * " …[line truncated]" : line
+    end
+    return join(capped, "\n")
+end
 
 # Keep the LAST max_lines/max_bytes of content (LLMTools only ships head
 # truncation; bash output wants the tail, where errors and results live).
@@ -79,7 +90,7 @@ Examples:
         bash(command::String, timeout::Union{Nothing, Int} = nothing) = begin
             timeout_s = clamp(something(timeout, DEFAULT_BASH_TIMEOUT_S), 1, MAX_BASH_TIMEOUT_S)
             output, exitcode, timedout = run_bash(base, command, timeout_s)
-            truncation = truncate_tail(output)
+            truncation = truncate_tail(cap_line_lengths(output))
             result = truncation.content
             if truncation.truncated
                 result = "[Output truncated: showing last $(truncation.output_lines) of $(truncation.total_lines) lines]\n" * result

--- a/Juco/src/tools.jl
+++ b/Juco/src/tools.jl
@@ -61,7 +61,9 @@ end
 function create_bash_tool(base_dir::AbstractString)
     base = LLMTools.ensure_base_dir(base_dir)
     return Agentif.@tool(
-        """Execute a bash command in the working directory and return its combined stdout/stderr.
+        """Execute a bash command and return its combined stdout/stderr.
+
+The command already runs in the working directory shown in your system prompt — never prefix commands with `cd`; use relative paths.
 
 This is your tool for everything except reading and editing files: listing directories (ls), searching file contents (rg), finding files (find, rg --files), git, running tests, etc.
 

--- a/Juco/test/runtests.jl
+++ b/Juco/test/runtests.jl
@@ -236,6 +236,12 @@ end
         @test occursin("unknown model", String(take!(buf)))
         Juco.handle_command(st, "/model codex gpt-5.3-codex", buf)
         @test st.mode == "codex" && st.model_id == "gpt-5.3-codex"
+        Juco.handle_command(st, "/model openrouter", buf)
+        @test st.mode == "openrouter"
+        @test st.model_id == Juco.MODE_DEFAULT_MODEL["openrouter"]
+        Juco.handle_command(st, "/model codex", buf)
+        @test st.mode == "codex"
+        @test st.model_id == Juco.MODE_DEFAULT_MODEL["codex"]
         # selection persists: a fresh state reloads it from the db
         st2 = Juco.ReplState(jdb, "other"; base_dir = dir)
         @test st2.mode == "codex" && st2.model_id == "gpt-5.3-codex"

--- a/Juco/test/runtests.jl
+++ b/Juco/test/runtests.jl
@@ -8,6 +8,7 @@ using Sockets
 using SQLite
 
 include(joinpath(@__DIR__, "..", "eval", "env.jl"))
+include(joinpath(@__DIR__, "..", "eval", "tasks.jl"))
 
 @testset "Juco" begin
 
@@ -597,6 +598,28 @@ end
         for i in 1:60; write(joinpath(dir, "f$(lpad(i, 2, '0')).txt"), ""); end
         p = Juco.build_prompt(dir, :juco)
         @test occursin("more entries)", p)
+    end
+end
+
+@testset "performance eval is bounded and discriminating" begin
+    task = only(t for t in TASKS if t.name == "perf-fix")
+    mktempdir() do dir
+        task.setup(dir)
+        test_source = read(joinpath(dir, "test_render.jl"), String)
+        bounded = occursin("20_000", test_source)
+        @test bounded
+        bounded || return
+        @test !task.check(dir)
+        write(joinpath(dir, "render.jl"), """
+            function render_rows(n)
+                io = IOBuffer()
+                for i in 1:n
+                    println(io, "row ", i, ": ", i * i)
+                end
+                return String(take!(io))
+            end
+            """)
+        @test task.check(dir)
     end
 end
 

--- a/Juco/test/runtests.jl
+++ b/Juco/test/runtests.jl
@@ -2,6 +2,9 @@ using Test
 using JSON
 using Juco
 using Agentif
+using HTTP
+using LLMProviders
+using Sockets
 using SQLite
 
 include(joinpath(@__DIR__, "..", "eval", "env.jl"))
@@ -294,6 +297,29 @@ end
                 jdb, base_dir = missing, provider = "anthropic",
                 model_id = "claude-sonnet-4-5", apikey = "test")
             @test isempty(Juco.list_sessions(jdb))
+
+            server = HTTP.serve!("127.0.0.1", 0) do _
+                HTTP.Response(400, ["Content-Type" => "application/json"],
+                    JSON.json(Dict("error" => Dict("message" => "forced failure"))))
+            end
+            try
+                port = applicable(HTTP.port, server) && HTTP.port(server) != 0 ?
+                    HTTP.port(server) : Sockets.getsockname(server.listener.server)[2]
+                provider = "juco-failed-turn-test"
+                model_id = "failed-turn"
+                LLMProviders.registerModel!(LLMProviders.Model(;
+                    id = model_id, name = model_id, api = "openai-completions",
+                    provider, baseUrl = "http://127.0.0.1:$(port)", reasoning = false,
+                    input = ["text"], cost = Dict("input" => 0.0, "output" => 0.0,
+                        "cacheRead" => 0.0, "cacheWrite" => 0.0),
+                    contextWindow = 4096, maxTokens = 256,
+                ))
+                @test_throws Exception Juco.evaluate("hello";
+                    jdb, base_dir = dir, provider, model_id, apikey = "test")
+                @test isempty(Juco.list_sessions(jdb))
+            finally
+                close(server)
+            end
         end
     end
 end

--- a/Juco/test/runtests.jl
+++ b/Juco/test/runtests.jl
@@ -67,7 +67,16 @@ end
         @test startswith(result, "1\n2\n")      # head preserved
         @test occursin("\n5000", result)        # tail preserved
         @test !occursin("\n1000\n", result)     # middle skipped
-        @test ncodeunits(result) < 20 * 1024
+        @test ncodeunits(result) <= Juco.MAX_BASH_OUTPUT_BYTES
+        # the byte budget includes the marker and command-status suffix
+        result = bash.func("seq 1 5000; exit 3", nothing)
+        @test occursin("[exit code 3]", result)
+        @test ncodeunits(result) <= Juco.MAX_BASH_OUTPUT_BYTES
+        # sampling remains valid UTF-8 and within custom byte budgets
+        sampled, truncated = Juco.sample_output(repeat("🙂\n", 1000);
+            max_bytes = 1024, head_lines = 3)
+        @test truncated && isvalid(sampled)
+        @test ncodeunits(sampled) <= 1024
     end
 end
 

--- a/Juco/test/runtests.jl
+++ b/Juco/test/runtests.jl
@@ -219,6 +219,38 @@ end
     @test Juco.error_summary(bad_message) == "7"
 end
 
+@testset "display previews and diffs" begin
+    result = Agentif.ToolResultMessage(call_id = "c", name = "bash",
+        content = [Agentif.TextContent(text = "\n  first real line\nsecond")], is_error = false)
+    @test Juco.result_preview(result) == "first real line"
+    long = Agentif.ToolResultMessage(call_id = "c", name = "bash",
+        content = [Agentif.TextContent(text = "x"^200)], is_error = false)
+    @test endswith(Juco.result_preview(long), "…")
+    removed, added = Juco.edit_diff_lines(JSON.json(Dict(
+        "path" => "a.jl",
+        "oldText" => "keep\nold line\nkeep2",
+        "newText" => "keep\nnew line one\nnew line two\nkeep2")))
+    @test removed == ["old line"]
+    @test added == ["new line one", "new line two"]
+    r2, a2 = Juco.edit_diff_lines("not json")
+    @test isempty(r2) && isempty(a2)
+end
+
+@testset "turn result notes" begin
+    mktempdir() do dir
+        jdb = Juco.opendb(joinpath(dir, "t.sqlite"))
+        st = Juco.ReplState(jdb, "s"; base_dir = dir)
+        state = Agentif.AgentState()
+        push!(state.messages, Agentif.AssistantMessage(;
+            provider = "openrouter", api = "openai-completions", model = "m",
+            content = Agentif.AssistantContentBlock[Agentif.TextContent(; text = "the answer")]))
+        model = Agentif.getModel("openrouter", "deepseek/deepseek-v4-flash-0731")
+        Juco.note_turn_result!(st, (; state), model)
+        @test st.last_answer == "the answer"
+        @test st.last_ctx_pct isa Int
+    end
+end
+
 @testset "display handler renders tool lines" begin
     buf = IOBuffer()
     handler = Juco.display_handler(buf)

--- a/Juco/test/runtests.jl
+++ b/Juco/test/runtests.jl
@@ -1,4 +1,5 @@
 using Test
+using JSON
 using Juco
 using Agentif
 
@@ -121,7 +122,10 @@ end
 
 @testset "openrouter provider prefs" begin
     delete!(ENV, "JUCO_OPENROUTER_ORDER")
-    @test Juco.openrouter_provider_prefs() == Dict{String, Any}("sort" => "price")
+    prefs = Juco.openrouter_provider_prefs()
+    @test prefs["sort"] == "price"
+    @test prefs["require_parameters"] === true
+    @test "fp8" in prefs["quantizations"] && !("fp4" in prefs["quantizations"])
     ENV["JUCO_OPENROUTER_ORDER"] = "atlas-cloud/fp4, siliconflow/fp8"
     prefs = Juco.openrouter_provider_prefs()
     @test prefs["order"] == ["atlas-cloud/fp4", "siliconflow/fp8"]
@@ -154,6 +158,71 @@ end
         @test names(Juco.toolset(:pi, dir)) == ["bash", "read", "edit", "write"]
         @test names(Juco.toolset(:bash, dir)) == ["bash"]
         @test_throws ArgumentError Juco.toolset(:nope, dir)
+    end
+end
+
+@testset "display formatters" begin
+    @test Juco.format_tool_call("bash", "{\"command\": \"ls -la\\nfoo\"}") == "▸ bash ls -la foo"
+    @test Juco.format_tool_call("read", "{\"path\": \"a.jl\", \"offset\": 10}") == "▸ read a.jl:10"
+    @test Juco.format_tool_call("edit", "{\"path\": \"a.jl\", \"oldText\": \"x\"}") == "▸ edit a.jl"
+    @test Juco.format_tool_call("edit", "{\"path\": \"a.jl\", \"oldText\": \"\"}") == "▸ edit a.jl (new file)"
+    @test Juco.format_tool_call("bash", "not json") == "▸ bash not json"
+    long = Juco.format_tool_call("bash", JSON.json(Dict("command" => "x"^300)))
+    @test length(long) < 120 && endswith(long, "…")
+    @test Juco.format_duration(75) == "75ms"
+    @test Juco.format_duration(2350) == "2.4s"
+    @test Juco.format_tokens(950) == "950"
+    @test Juco.format_tokens(18234) == "18.2k"
+    usage = Agentif.Usage(input = 1000, output = 200, cacheRead = 500, cacheWrite = 0, total = 1700)
+    m = Agentif.getModel("anthropic", "claude-sonnet-4-5")
+    line = Juco.usage_line(usage, m, 3, 12.34)
+    @test occursin("12.3s", line)
+    @test occursin("3 tools", line)
+    @test occursin("1.5k in (33% cached)", line)
+    @test occursin("200 out", line)
+    @test occursin("\$", line)
+end
+
+@testset "display handler renders tool lines" begin
+    buf = IOBuffer()
+    handler = Juco.display_handler(buf)
+    tc = Agentif.PendingToolCall(call_id = "c1", name = "bash", arguments = "{\"command\": \"echo hi\"}")
+    handler(Agentif.ToolExecutionStartEvent(tc))
+    result = Agentif.ToolResultMessage(call_id = "c1", name = "bash",
+        content = [Agentif.TextContent(text = "hi")], is_error = false)
+    handler(Agentif.ToolExecutionEndEvent(1, tc, result, 42))
+    out = String(take!(buf))
+    @test occursin("▸ bash echo hi", out)
+    @test occursin("✓ 42ms", out)
+    # error results show the message
+    handler(Agentif.ToolExecutionStartEvent(tc))
+    errres = Agentif.ToolResultMessage(call_id = "c1", name = "bash",
+        content = [Agentif.TextContent(text = "{\"message\": \"boom happened\"}")], is_error = true)
+    handler(Agentif.ToolExecutionEndEvent(1, tc, errres, 10))
+    @test occursin("✗ boom happened", String(take!(buf)))
+end
+
+@testset "repl slash commands" begin
+    mktempdir() do dir
+        jdb = Juco.opendb(joinpath(dir, "t.sqlite"))
+        st = Juco.ReplState(jdb, "s-original", "anthropic", "claude-sonnet-4-5", false)
+        buf = IOBuffer()
+        Juco.handle_command(st, "/new", buf)
+        @test st.session_id != "s-original"
+        Juco.handle_command(st, "/model", buf)
+        @test occursin("anthropic/claude-sonnet-4-5", String(take!(buf)))
+        Juco.handle_command(st, "/model nonsense-model-id", buf)
+        @test occursin("unknown model", String(take!(buf)))
+        @test st.model_id == "claude-sonnet-4-5"
+        Juco.handle_command(st, "/model anthropic claude-haiku-4-5", buf)
+        @test st.model_id == "claude-haiku-4-5"
+        Juco.remember!(jdb, "a memory")
+        Juco.handle_command(st, "/memories", buf)
+        @test occursin("a memory", String(take!(buf)))
+        Juco.handle_command(st, "/quit", buf)
+        @test st.quit
+        Juco.handle_command(st, "/bogus", buf)
+        @test occursin("unknown command", String(take!(buf)))
     end
 end
 

--- a/Juco/test/runtests.jl
+++ b/Juco/test/runtests.jl
@@ -417,6 +417,64 @@ end
     end
 end
 
+@testset "temperature pin on direct completion models" begin
+    withenv("JUCO_TEMPERATURE" => nothing) do
+        @test Juco.default_temperature() == 0.2
+    end
+    withenv("JUCO_TEMPERATURE" => "") do
+        @test Juco.default_temperature() === nothing
+    end
+    withenv("JUCO_TEMPERATURE" => "not-a-number") do
+        @test_throws ArgumentError Juco.default_temperature()
+    end
+    bodies = Any[]
+    server = HTTP.serve!("127.0.0.1", 0) do req
+        push!(bodies, JSON.parse(String(req.body)))
+        sse = join([
+            "data: {\"id\":\"temp-1\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"ok\"},\"finish_reason\":null}]}",
+            "data: {\"id\":\"temp-1\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}",
+            "data: [DONE]",
+        ], "\n\n") * "\n\n"
+        HTTP.Response(200, ["Content-Type" => "text/event-stream"], sse)
+    end
+    try
+        port = applicable(HTTP.port, server) && HTTP.port(server) != 0 ?
+            HTTP.port(server) : Sockets.getsockname(server.listener.server)[2]
+        provider = "juco-temperature-test"
+        model_id = "direct-completions"
+        LLMProviders.registerModel!(LLMProviders.Model(;
+            id = model_id, name = model_id, api = "openai-completions",
+            provider, baseUrl = "http://127.0.0.1:$(port)", reasoning = false,
+            input = ["text"], cost = Dict("input" => 0.0, "output" => 0.0,
+                "cacheRead" => 0.0, "cacheWrite" => 0.0),
+            contextWindow = 4096, maxTokens = 256,
+        ))
+        mktempdir() do dir
+            Juco.with_jdb(joinpath(dir, "temperature.sqlite")) do jdb
+                direct = try
+                    Juco.evaluate("hello"; jdb, base_dir = dir, provider, model_id,
+                        apikey = "test", temperature = 0.5, show_tools = false,
+                        io = IOBuffer())
+                catch e
+                    e
+                end
+                integer = try
+                    Juco.evaluate("hello"; jdb, base_dir = dir, provider, model_id,
+                        apikey = "test", temperature = 0, show_tools = false,
+                        io = IOBuffer())
+                catch e
+                    e
+                end
+                @test !(direct isa Exception)
+                @test !(integer isa Exception)
+                @test [body["temperature"] for body in bodies] == [0.5, 0.0]
+            end
+        end
+    finally
+        close(server)
+    end
+end
+
 @testset "eval environment" begin
     withenv("OPENROUTER_API_KEY" => nothing) do
         @test_throws ArgumentError load_eval_env!()

--- a/Juco/test/runtests.jl
+++ b/Juco/test/runtests.jl
@@ -205,24 +205,126 @@ end
 @testset "repl slash commands" begin
     mktempdir() do dir
         jdb = Juco.opendb(joinpath(dir, "t.sqlite"))
-        st = Juco.ReplState(jdb, "s-original", "anthropic", "claude-sonnet-4-5", false)
+        st = Juco.ReplState(jdb, "s-original"; base_dir = dir)
+        @test st.mode == "openrouter"
+        @test st.model_id == Juco.MODE_DEFAULT_MODEL["openrouter"]
         buf = IOBuffer()
         Juco.handle_command(st, "/new", buf)
         @test st.session_id != "s-original"
-        Juco.handle_command(st, "/model", buf)
-        @test occursin("anthropic/claude-sonnet-4-5", String(take!(buf)))
         Juco.handle_command(st, "/model nonsense-model-id", buf)
         @test occursin("unknown model", String(take!(buf)))
-        @test st.model_id == "claude-sonnet-4-5"
-        Juco.handle_command(st, "/model anthropic claude-haiku-4-5", buf)
-        @test st.model_id == "claude-haiku-4-5"
+        Juco.handle_command(st, "/model codex gpt-5.3-codex", buf)
+        @test st.mode == "codex" && st.model_id == "gpt-5.3-codex"
+        # selection persists: a fresh state reloads it from the db
+        st2 = Juco.ReplState(jdb, "other"; base_dir = dir)
+        @test st2.mode == "codex" && st2.model_id == "gpt-5.3-codex"
+        Juco.handle_command(st, "/model bogus-mode some-model", buf)
+        @test occursin("unknown mode", String(take!(buf)))
         Juco.remember!(jdb, "a memory")
         Juco.handle_command(st, "/memories", buf)
         @test occursin("a memory", String(take!(buf)))
+        Juco.handle_command(st, "/skills", buf)
+        @test occursin("No skills found", String(take!(buf)))
         Juco.handle_command(st, "/quit", buf)
         @test st.quit
         Juco.handle_command(st, "/bogus", buf)
         @test occursin("unknown command", String(take!(buf)))
+    end
+end
+
+@testset "config store" begin
+    mktempdir() do dir
+        jdb = Juco.opendb(joinpath(dir, "t.sqlite"))
+        @test Juco.get_config(jdb, "k") === nothing
+        @test Juco.get_config(jdb, "k", "fallback") == "fallback"
+        Juco.set_config!(jdb, "k", "v1")
+        @test Juco.get_config(jdb, "k") == "v1"
+        Juco.set_config!(jdb, "k", "v2")
+        @test Juco.get_config(jdb, "k") == "v2"
+        Juco.set_config!(jdb, "k", nothing)
+        @test Juco.get_config(jdb, "k") === nothing
+    end
+end
+
+@testset "model modes" begin
+    @test Juco.mode_provider("openrouter") == "openrouter"
+    @test Juco.mode_provider("codex") == "openai-codex"
+    @test Juco.mode_apikey("codex") == "OAUTH"
+    @test "gpt-5.3-codex" in Juco.mode_models("codex")
+    @test Juco.reasoning_levels("codex", "gpt-5.3-codex") ==
+        ["none", "minimal", "low", "medium", "high", "xhigh"]
+    @test Juco.reasoning_levels("openrouter", "deepseek/deepseek-v4-flash-0731") ==
+        ["none", "low", "medium", "high"]
+    @test Juco.reasoning_levels("openrouter", "not-a-model") == ["none"]
+    @test occursin("ago", Juco.session_age(time() - 7200))
+    @test Juco.session_age(time() - 10) == "just now"
+end
+
+@testset "skills" begin
+    mktempdir() do dir
+        skdir = joinpath(dir, ".agent", "skills")
+        mkpath(joinpath(skdir, "review"))
+        write(joinpath(skdir, "review", "SKILL.md"), """
+            ---
+            description: Careful code review checklist
+            ---
+            # Review
+            Look for bugs first.
+            """)
+        mkpath(joinpath(skdir, "tdd"))
+        write(joinpath(skdir, "tdd", "SKILL.md"), "Write the failing test first.\n")
+        skills = Juco.discover_skills(dir)
+        # may include user-global ~/.agent/skills too; ours must be present
+        names = [s.name for s in skills]
+        @test "review" in names && "tdd" in names
+        review = skills[findfirst(==("review"), names)]
+        @test review.description == "Careful code review checklist"
+        tdd = skills[findfirst(==("tdd"), names)]
+        @test tdd.description == "Write the failing test first."
+
+        ours = [s for s in skills if s.name in ("review", "tdd")]
+        # completion: after "$re" completes to review
+        names2, range, should = Juco.skill_completions("please \$re", ncodeunits("please \$re"), ours)
+        @test names2 == ["review"] && should
+        @test (first(range), last(range)) == (9, 10)
+        # bare "$" offers everything
+        names3, _, _ = Juco.skill_completions("\$", 1, ours)
+        @test sort(names3) == ["review", "tdd"]
+        # no $ context: no completions
+        names4, _, should4 = Juco.skill_completions("hello", 5, ours)
+        @test isempty(names4) && !should4
+
+        # expansion appends blocks once per used skill
+        expanded, used = Juco.expand_skills("apply \$tdd and \$review and \$tdd again", ours)
+        @test used == ["tdd", "review"]
+        @test occursin("<skill name=\"tdd\">", expanded)
+        @test occursin("Write the failing test first.", expanded)
+        @test count("<skill name=\"tdd\">", expanded) == 1
+        # unknown tokens untouched, no blocks
+        expanded2, used2 = Juco.expand_skills("cost is \$100", ours)
+        @test isempty(used2) && expanded2 == "cost is \$100"
+    end
+end
+
+@testset "steering instrumentation" begin
+    mktempdir() do dir
+        bash = Juco.create_bash_tool(dir)
+        counter = Threads.Atomic{Int}(0)
+        steer = Channel{String}(4)
+        delivered = String[]
+        tool = Juco.instrument_tool(bash, counter, 50, steer, t -> push!(delivered, t))
+        # nothing queued: result unchanged
+        @test !occursin("interjected", tool.func("echo hi", nothing))
+        # queued messages are appended to the next result and reported delivered
+        put!(steer, "also update the docs")
+        put!(steer, "and run the linter")
+        result = tool.func("echo hi", nothing)
+        @test occursin("user interjected", result)
+        @test occursin("also update the docs", result)
+        @test occursin("and run the linter", result)
+        @test delivered == ["also update the docs", "and run the linter"]
+        # drained: next call is clean again
+        @test !occursin("interjected", tool.func("echo hi", nothing))
     end
 end
 

--- a/Juco/test/runtests.jl
+++ b/Juco/test/runtests.jl
@@ -188,6 +188,9 @@ end
     @test Juco.format_tool_call("edit", "{\"path\": \"a.jl\", \"oldText\": \"x\"}") == "▸ edit a.jl"
     @test Juco.format_tool_call("edit", "{\"path\": \"a.jl\", \"oldText\": \"\"}") == "▸ edit a.jl (new file)"
     @test Juco.format_tool_call("bash", "not json") == "▸ bash not json"
+    @test Juco.format_tool_call("bash", "{\"command\": 3}") == "▸ bash 3"
+    @test Juco.format_tool_call("edit", "{\"path\": 4, \"oldText\": null}") == "▸ edit 4"
+    @test Juco.format_tool_call("remember", "{\"content\": false}") == "▸ remember \"false\""
     long = Juco.format_tool_call("bash", JSON.json(Dict("command" => "x"^300)))
     @test length(long) < 120 && endswith(long, "…")
     @test Juco.format_duration(75) == "75ms"
@@ -202,6 +205,9 @@ end
     @test occursin("1.5k in (33% cached)", line)
     @test occursin("200 out", line)
     @test occursin("\$", line)
+    bad_message = Agentif.ToolResultMessage(call_id = "bad", name = "bash",
+        content = [Agentif.TextContent(text = "{\"message\": 7}")], is_error = true)
+    @test Juco.error_summary(bad_message) == "7"
 end
 
 @testset "display handler renders tool lines" begin

--- a/Juco/test/runtests.jl
+++ b/Juco/test/runtests.jl
@@ -65,9 +65,12 @@ end
         @test read(joinpath(dir, "sub", "new.txt"), String) == "line a\nline b\n"
         # creating an existing file errors
         @test_throws ArgumentError edit.func("sub/new.txt", "", "other")
-        # unique replace
-        edit.func("sub/new.txt", "line a", "line A")
+        # unique replace returns the edited region for verification
+        result = edit.func("sub/new.txt", "line a", "line A")
         @test read(joinpath(dir, "sub", "new.txt"), String) == "line A\nline b\n"
+        @test occursin("Edited sub/new.txt", result)
+        @test occursin("1 | line A", result)
+        @test occursin("2 | line b", result)
         # non-unique match errors
         write(joinpath(dir, "dup.txt"), "x\nx\n")
         @test_throws ArgumentError edit.func("dup.txt", "x", "y")

--- a/Juco/test/runtests.jl
+++ b/Juco/test/runtests.jl
@@ -98,6 +98,12 @@ end
         err = try edit.func("near.txt", "beta = 2", "beta = 3"); nothing catch e; e end
         @test err isa ArgumentError && occursin("Closest candidates", err.msg)
         @test occursin("beta = 1", err.msg)
+        # not-found where the replacement already exists: says so
+        err = try edit.func("near.txt", "beta = 0", "beta = 1"); nothing catch e; e end
+        @test err isa ArgumentError && occursin("may already be applied", err.msg)
+        # identical replacement explains that no edit is needed
+        err = try edit.func("near.txt", "gamma", "gamma"); nothing catch e; e end
+        @test err isa ArgumentError && occursin("no edit is needed", err.msg)
         # missing file errors
         @test_throws ArgumentError edit.func("nope.txt", "a", "b")
         # identical replacement errors
@@ -537,6 +543,9 @@ end
     bare = Juco.build_prompt(pwd(), :bash)
     @test !occursin("Memories", bare)
     @test occursin("your only tool", bare)
+    @test !occursin("Budget:", bare)
+    budgeted = Juco.build_prompt(pwd(), :juco; max_turns = 25)
+    @test occursin("Budget: up to 25 tool calls", budgeted)
     # directory snapshot: entries listed, dirs marked, big dirs capped
     mktempdir() do dir
         mkdir(joinpath(dir, "src"))

--- a/Juco/test/runtests.jl
+++ b/Juco/test/runtests.jl
@@ -270,6 +270,25 @@ end
     @test Juco.reasoning_levels("openrouter", "not-a-model") == ["none"]
     @test occursin("ago", Juco.session_age(time() - 7200))
     @test Juco.session_age(time() - 10) == "just now"
+
+    mktempdir() do dir
+        jdb = Juco.opendb(joinpath(dir, "state.sqlite"))
+        Juco.set_config!(jdb, "model_mode", "removed-mode")
+        Juco.set_config!(jdb, "model_id", "removed-model")
+        Juco.set_config!(jdb, "reasoning", "extreme")
+        @test Juco.load_model_state(jdb) ==
+            ("openrouter", Juco.MODE_DEFAULT_MODEL["openrouter"], nothing)
+        @test Juco.get_config(jdb, "model_mode") == "openrouter"
+        @test Juco.get_config(jdb, "model_id") == Juco.MODE_DEFAULT_MODEL["openrouter"]
+        @test Juco.get_config(jdb, "reasoning") === nothing
+    end
+end
+
+@testset "non-TTY menu EOF cancels" begin
+    buf = IOBuffer()
+    @test Juco.choose(buf, "Pick:", ["one", "two"]; default = 2, input = IOBuffer("")) === nothing
+    @test Juco.choose(buf, "Pick:", ["one", "two"]; default = 2, input = IOBuffer("\n")) == 2
+    @test Juco.choose(buf, "Pick:", ["one", "two"]; input = IOBuffer("9\n")) === nothing
 end
 
 @testset "skills" begin
@@ -361,6 +380,10 @@ end
     output = String(take!(buf))
     @test occursin("error: root turn failure", output)
     @test !occursin("error: TaskFailedException", output)
+
+    no_login = @async error("No stored Codex credentials found")
+    @test Juco.wait_turn(no_login, Agentif.Abort(), buf) === nothing
+    @test occursin("LLMOAuth.codex_login()", String(take!(buf)))
 end
 
 @testset "terminal output shares one lock" begin

--- a/Juco/test/runtests.jl
+++ b/Juco/test/runtests.jl
@@ -407,6 +407,9 @@ end
     @test_throws ArgumentError Juco.parse_cli_args(["--db"])
     @test_throws ArgumentError Juco.parse_cli_args(["--prompt"])
     @test_throws ArgumentError Juco.parse_cli_args(["--preset", "unknown"])
+    escaped = Juco.shell_project_argument("/tmp/a b'c")
+    @test read(`sh -c "set -- $escaped; printf %s \"\$1\""`, String) ==
+        "--project=/tmp/a b'c"
 end
 
 @testset "skills" begin

--- a/Juco/test/runtests.jl
+++ b/Juco/test/runtests.jl
@@ -263,6 +263,24 @@ end
     end
 end
 
+@testset "database lifecycle" begin
+    mktempdir() do dir
+        normal_db = Ref{Juco.JucoDB}()
+        @test Juco.with_jdb(joinpath(dir, "normal.sqlite")) do jdb
+            normal_db[] = jdb
+            :done
+        end === :done
+        @test !isopen(normal_db[].db)
+
+        failed_db = Ref{Juco.JucoDB}()
+        @test_throws ErrorException Juco.with_jdb(joinpath(dir, "failed.sqlite")) do jdb
+            failed_db[] = jdb
+            error("stop")
+        end
+        @test !isopen(failed_db[].db)
+    end
+end
+
 @testset "model modes" begin
     @test Juco.mode_provider("openrouter") == "openrouter"
     @test Juco.mode_provider("codex") == "openai-codex"

--- a/Juco/test/runtests.jl
+++ b/Juco/test/runtests.jl
@@ -76,9 +76,15 @@ end
         @test occursin("Edited sub/new.txt", result)
         @test occursin("1 | line A", result)
         @test occursin("2 | line b", result)
-        # non-unique match errors
+        # non-unique match errors name the occurrence lines
         write(joinpath(dir, "dup.txt"), "x\nx\n")
-        @test_throws ArgumentError edit.func("dup.txt", "x", "y")
+        err = try edit.func("dup.txt", "x", "y"); nothing catch e; e end
+        @test err isa ArgumentError && occursin("at lines 1, 2", err.msg)
+        # not-found errors include nearest-match candidates
+        write(joinpath(dir, "near.txt"), "alpha\nbeta = 1\ngamma\n")
+        err = try edit.func("near.txt", "beta = 2", "beta = 3"); nothing catch e; e end
+        @test err isa ArgumentError && occursin("Closest candidates", err.msg)
+        @test occursin("beta = 1", err.msg)
         # missing file errors
         @test_throws ArgumentError edit.func("nope.txt", "a", "b")
         # identical replacement errors

--- a/Juco/test/runtests.jl
+++ b/Juco/test/runtests.jl
@@ -84,6 +84,9 @@ end
         write(joinpath(dir, "dup.txt"), "x\nx\n")
         err = try edit.func("dup.txt", "x", "y"); nothing catch e; e end
         @test err isa ArgumentError && occursin("at lines 1, 2", err.msg)
+        # overlapping occurrences are also ambiguous
+        write(joinpath(dir, "overlap.txt"), "aaa")
+        @test_throws ArgumentError edit.func("overlap.txt", "aa", "b")
         # not-found errors include nearest-match candidates
         write(joinpath(dir, "near.txt"), "alpha\nbeta = 1\ngamma\n")
         err = try edit.func("near.txt", "beta = 2", "beta = 3"); nothing catch e; e end

--- a/Juco/test/runtests.jl
+++ b/Juco/test/runtests.jl
@@ -111,6 +111,16 @@ end
         # not-found where the replacement already exists: says so
         err = try edit.func("near.txt", "beta = 0", "beta = 1"); nothing catch e; e end
         @test err isa ArgumentError && occursin("may already be applied", err.msg)
+        # a shared first line alone must not claim a multiline edit was applied
+        write(joinpath(dir, "partial.txt"), "function f()\n    old\nend\n")
+        err = try
+            edit.func("partial.txt", "function f()\n    missing\nend",
+                "function f()\n    new\nend")
+            nothing
+        catch e
+            e
+        end
+        @test err isa ArgumentError && !occursin("may already be applied", err.msg)
         # identical replacement explains that no edit is needed
         err = try edit.func("near.txt", "gamma", "gamma"); nothing catch e; e end
         @test err isa ArgumentError && occursin("no edit is needed", err.msg)

--- a/Juco/test/runtests.jl
+++ b/Juco/test/runtests.jl
@@ -88,6 +88,23 @@ end
     end
 end
 
+@testset "absolute paths within the working directory" begin
+    mktempdir() do dir
+        edit = Juco.create_edit_tool(dir)
+        # absolute path inside base is accepted (including through macOS /var symlink)
+        abs_inside = joinpath(realpath(dir), "abs.txt")
+        @test occursin("Created", edit.func(abs_inside, "", "content\n"))
+        @test isfile(joinpath(dir, "abs.txt"))
+        # the unresolved (symlinked) form works too
+        alt = joinpath(dir, "abs2.txt")
+        @test occursin("Created", edit.func(alt, "", "content\n"))
+        # absolute path outside base is rejected
+        @test_throws ArgumentError edit.func("/etc/hosts", "a", "b")
+        # relative escape is rejected
+        @test_throws ArgumentError edit.func("../escape.txt", "", "x")
+    end
+end
+
 @testset "toolset presets" begin
     mktempdir() do dir
         jdb = Juco.opendb(joinpath(dir, "test.sqlite"))

--- a/Juco/test/runtests.jl
+++ b/Juco/test/runtests.jl
@@ -291,6 +291,15 @@ end
     @test Juco.choose(buf, "Pick:", ["one", "two"]; input = IOBuffer("9\n")) === nothing
 end
 
+@testset "CLI argument parsing" begin
+    parsed = Juco.parse_cli_args(["--list", "--db", "/tmp/juco-test.sqlite"])
+    @test parsed.list
+    @test parsed.db_path == "/tmp/juco-test.sqlite"
+    @test_throws ArgumentError Juco.parse_cli_args(["--db"])
+    @test_throws ArgumentError Juco.parse_cli_args(["--prompt"])
+    @test_throws ArgumentError Juco.parse_cli_args(["--preset", "unknown"])
+end
+
 @testset "skills" begin
     mktempdir() do dir
         skdir = joinpath(dir, ".agent", "skills")

--- a/Juco/test/runtests.jl
+++ b/Juco/test/runtests.jl
@@ -119,6 +119,16 @@ end
     end
 end
 
+@testset "openrouter provider prefs" begin
+    delete!(ENV, "JUCO_OPENROUTER_ORDER")
+    @test Juco.openrouter_provider_prefs() == Dict{String, Any}("sort" => "price")
+    ENV["JUCO_OPENROUTER_ORDER"] = "atlas-cloud/fp4, siliconflow/fp8"
+    prefs = Juco.openrouter_provider_prefs()
+    @test prefs["order"] == ["atlas-cloud/fp4", "siliconflow/fp8"]
+    @test prefs["allow_fallbacks"] === true
+    delete!(ENV, "JUCO_OPENROUTER_ORDER")
+end
+
 @testset "budget notice wrapping" begin
     mktempdir() do dir
         bash = Juco.create_bash_tool(dir)

--- a/Juco/test/runtests.jl
+++ b/Juco/test/runtests.jl
@@ -340,6 +340,42 @@ end
     end
 end
 
+@testset "steering queue drain is serialized" begin
+    steer = Channel{String}(2)
+    put!(steer, "only once")
+    lk = ReentrantLock()
+    tasks = [Threads.@spawn Juco.drain_steering!(steer, lk) for _ in 1:2]
+    @test timedwait(() -> all(istaskdone, tasks), 2.0) == :ok
+    drained = reduce(vcat, fetch.(tasks))
+    @test drained == ["only once"]
+end
+
+@testset "turn task failure handling" begin
+    buf = IOBuffer()
+    interrupted = @async throw(InterruptException())
+    @test Juco.wait_turn(interrupted, Agentif.Abort(), buf) === nothing
+
+    inner = @async error("root turn failure")
+    nested = @async fetch(inner)
+    @test Juco.wait_turn(nested, Agentif.Abort(), buf) === nothing
+    output = String(take!(buf))
+    @test occursin("error: root turn failure", output)
+    @test !occursin("error: TaskFailedException", output)
+end
+
+@testset "terminal output shares one lock" begin
+    buf = IOBuffer()
+    lk = ReentrantLock()
+    channel = Juco.TerminalChannel("s", buf; io_lock = lk)
+    @test channel.io_lock === lk
+    handler = Juco.display_handler(buf; io_lock = lk)
+    tc = Agentif.PendingToolCall(call_id = "c", name = "bash", arguments = "{\"command\":\"true\"}")
+    handler(Agentif.ToolExecutionStartEvent(tc))
+    Agentif.append_to_stream(channel, "done")
+    Agentif.finish_streaming(channel)
+    @test occursin("done", String(take!(buf)))
+end
+
 @testset "prompt" begin
     prompt = Juco.build_prompt(pwd(), :juco; memories = ["user likes short names"])
     @test occursin("user likes short names", prompt)

--- a/Juco/test/runtests.jl
+++ b/Juco/test/runtests.jl
@@ -60,11 +60,14 @@ end
         @test occursin("[line truncated]", result)
         @test occursin("done", result)
         @test length(result) < 5000
-        # tail truncation keeps the END of output
-        result = bash.func("seq 1 3000", nothing)
-        @test occursin("[Output truncated: showing last 2000 of 3001 lines]", result)
-        @test occursin("3000", result)
-        @test !occursin("\n500\n", result)
+        # large outputs are sampled: head + skip marker + tail
+        result = bash.func("seq 1 5000", nothing)
+        @test occursin("…[skipped", result)
+        @test occursin("slice with rg/head/awk", result)
+        @test startswith(result, "1\n2\n")      # head preserved
+        @test occursin("\n5000", result)        # tail preserved
+        @test !occursin("\n1000\n", result)     # middle skipped
+        @test ncodeunits(result) < 20 * 1024
     end
 end
 

--- a/Juco/test/runtests.jl
+++ b/Juco/test/runtests.jl
@@ -4,6 +4,8 @@ using Juco
 using Agentif
 using SQLite
 
+include(joinpath(@__DIR__, "..", "eval", "env.jl"))
+
 @testset "Juco" begin
 
 @testset "db: memories and sessions" begin
@@ -278,6 +280,25 @@ end
             error("stop")
         end
         @test !isopen(failed_db[].db)
+    end
+end
+
+@testset "eval environment" begin
+    withenv("OPENROUTER_API_KEY" => nothing) do
+        @test_throws ArgumentError load_eval_env!()
+    end
+    withenv(
+            "OPENROUTER_API_KEY" => "test-key",
+            "JUCO_MODEL_PROVIDER" => nothing,
+            "JUCO_MODEL" => nothing,
+            "JUCO_REASONING" => nothing,
+            "JUCO_OPENROUTER_ORDER" => nothing,
+        ) do
+        @test load_eval_env!() === nothing
+        @test ENV["JUCO_MODEL_PROVIDER"] == "openrouter"
+        @test ENV["JUCO_MODEL"] == "deepseek/deepseek-v4-flash-0731"
+        @test ENV["JUCO_REASONING"] == "medium"
+        @test ENV["JUCO_OPENROUTER_ORDER"] == "siliconflow/fp8"
     end
 end
 

--- a/Juco/test/runtests.jl
+++ b/Juco/test/runtests.jl
@@ -90,7 +90,19 @@ end
         @test_throws ArgumentError edit.func("nope.txt", "a", "b")
         # identical replacement errors
         @test_throws ArgumentError edit.func("sub/new.txt", "line b", "line b")
+        # edited-region reporting must not byte-index before a match that follows UTF-8
+        write(joinpath(dir, "utf8.txt"), "cafétarget\n")
+        result = edit.func("utf8.txt", "target", "done")
+        @test read(joinpath(dir, "utf8.txt"), String) == "cafédone\n"
+        @test occursin("1 | cafédone", result)
     end
+end
+
+@testset "tail truncation byte limit" begin
+    result = Juco.truncate_tail("éé"; max_lines = 10, max_bytes = 3)
+    @test result.truncated
+    @test ncodeunits(result.content) <= 3
+    @test result.content == "é"
 end
 
 @testset "remember tool" begin

--- a/Juco/test/runtests.jl
+++ b/Juco/test/runtests.jl
@@ -287,6 +287,24 @@ end
         @test Juco.get_config(jdb, "model_id") == Juco.MODE_DEFAULT_MODEL["openrouter"]
         @test Juco.get_config(jdb, "reasoning") === nothing
     end
+
+    mktempdir() do dir
+        jdb = Juco.opendb(joinpath(dir, "atomic-state.sqlite"))
+        Juco.save_model_state!(jdb, "openrouter", Juco.MODE_DEFAULT_MODEL["openrouter"], nothing)
+        SQLite.execute(jdb.db, """
+            CREATE TRIGGER reject_reasoning
+            BEFORE INSERT ON juco_config
+            WHEN NEW.key = 'reasoning'
+            BEGIN
+                SELECT RAISE(ABORT, 'reject reasoning');
+            END
+        """)
+        @test_throws SQLite.SQLiteException Juco.save_model_state!(
+            jdb, "codex", Juco.MODE_DEFAULT_MODEL["codex"], "high")
+        @test Juco.get_config(jdb, "model_mode") == "openrouter"
+        @test Juco.get_config(jdb, "model_id") == Juco.MODE_DEFAULT_MODEL["openrouter"]
+        @test Juco.get_config(jdb, "reasoning") === nothing
+    end
 end
 
 @testset "non-TTY menu EOF cancels" begin

--- a/Juco/test/runtests.jl
+++ b/Juco/test/runtests.jl
@@ -113,6 +113,22 @@ end
     end
 end
 
+@testset "budget notice wrapping" begin
+    mktempdir() do dir
+        bash = Juco.create_bash_tool(dir)
+        counter = Threads.Atomic{Int}(0)
+        wrapped = Juco.with_budget_notice(bash, counter, 10)
+        @test wrapped.name == "bash"
+        @test Agentif.parameters(wrapped) == Agentif.parameters(bash)
+        counter[] = 2   # plenty of budget: no notice
+        @test !occursin("wrap up", wrapped.func("echo hi", nothing))
+        counter[] = 6   # within the warning margin
+        result = wrapped.func("echo hi", nothing)
+        @test occursin("only 4 tool calls remain", result)
+        @test occursin("hi", result)
+    end
+end
+
 @testset "toolset presets" begin
     mktempdir() do dir
         jdb = Juco.opendb(joinpath(dir, "test.sqlite"))

--- a/Juco/test/runtests.jl
+++ b/Juco/test/runtests.jl
@@ -1,5 +1,6 @@
 using Test
 using JSON
+import REPL
 using Juco
 using Agentif
 using HTTP
@@ -240,6 +241,22 @@ end
     @test Juco.error_summary(bad_message) == "7"
 end
 
+@testset "reasoning display reflows provider whitespace" begin
+    state = Juco.ReasoningDisplayState()
+    rendered = join((
+        Juco.reflow_reasoning!(state, "The\n   tool\n"),
+        Juco.reflow_reasoning!(state, "   is\n   ready."),
+    ))
+    @test rendered == "The tool is ready."
+    Juco.reset_reasoning!(state)
+    @test Juco.reflow_reasoning!(state, "First paragraph.\n\nSecond paragraph.") ==
+        "First paragraph.\n  Second paragraph."
+end
+
+@testset "interactive terminal" begin
+    @test Juco.flushing_terminal() isa REPL.Terminals.TTYTerminal
+end
+
 @testset "display previews and diffs" begin
     result = Agentif.ToolResultMessage(call_id = "c", name = "bash",
         content = [Agentif.TextContent(text = "\n  first real line\nsecond")], is_error = false)
@@ -269,6 +286,23 @@ end
         Juco.note_turn_result!(st, (; state, ctx_pct = 37), model)
         @test st.last_answer == "the answer"
         @test st.last_ctx_pct == 37
+    end
+end
+
+@testset "repl turn uses configured working directory" begin
+    mktempdir() do dir
+        jdb = Juco.opendb(joinpath(dir, "t.sqlite"))
+        st = Juco.ReplState(jdb, "s"; base_dir = dir)
+        st.mode = "codex"
+        st.model_id = Juco.MODE_DEFAULT_MODEL["codex"]
+        captured_dir = Ref("")
+        evaluator = function (input; base_dir, kw...)
+            captured_dir[] = base_dir
+            return (; state = Agentif.AgentState(), ctx_pct = 0)
+        end
+        Juco.run_turn(st, "inspect the checkout", IOBuffer();
+            steering = false, evaluator)
+        @test captured_dir[] == abspath(dir)
     end
 end
 
@@ -693,6 +727,10 @@ end
     prompt = Juco.build_prompt(pwd(), :juco; memories = ["user likes short names"])
     @test occursin("user likes short names", prompt)
     @test occursin("Working directory: $(abspath(pwd()))", prompt)
+    @test occursin("current branch diff from its merge base", prompt)
+    @test occursin("Do not repeat a search", prompt)
+    @test occursin("Do not restate the task or narrate routine tool choices", prompt)
+    @test occursin("For read-only tasks, do not edit files, install tools", prompt)
     bare = Juco.build_prompt(pwd(), :bash)
     @test !occursin("Memories", bare)
     @test occursin("your only tool", bare)
@@ -710,6 +748,18 @@ end
         p = Juco.build_prompt(dir, :juco)
         @test occursin("more entries)", p)
     end
+end
+
+@testset "reasoning request options" begin
+    openrouter_model = Agentif.getModel("openrouter", "deepseek/deepseek-v4-flash-0731")
+    @test Juco.reasoning_options(openrouter_model, nothing).reasoning ==
+        Dict("effort" => "none")
+    @test Juco.reasoning_options(openrouter_model, "high").reasoning ==
+        Dict("effort" => "high")
+
+    codex_model = Agentif.getModel("openai-codex", Juco.MODE_DEFAULT_MODEL["codex"])
+    @test isempty(Juco.reasoning_options(codex_model, nothing))
+    @test Juco.reasoning_options(codex_model, "high").reasoning_effort == "high"
 end
 
 @testset "performance eval is bounded and discriminating" begin

--- a/Juco/test/runtests.jl
+++ b/Juco/test/runtests.jl
@@ -48,6 +48,11 @@ end
         result = bash.func("echo started; sleep 30 & disown", nothing)
         @test time() - t0 < 10
         @test occursin("started", result)
+        # a single giant line is capped instead of eating the whole byte budget
+        result = bash.func("printf 'x%.0s' {1..60000}; echo; echo done", nothing)
+        @test occursin("[line truncated]", result)
+        @test occursin("done", result)
+        @test length(result) < 5000
         # tail truncation keeps the END of output
         result = bash.func("seq 1 3000", nothing)
         @test occursin("[Output truncated: showing last 2000 of 3001 lines]", result)

--- a/Juco/test/runtests.jl
+++ b/Juco/test/runtests.jl
@@ -265,9 +265,9 @@ end
             provider = "openrouter", api = "openai-completions", model = "m",
             content = Agentif.AssistantContentBlock[Agentif.TextContent(; text = "the answer")]))
         model = Agentif.getModel("openrouter", "deepseek/deepseek-v4-flash-0731")
-        Juco.note_turn_result!(st, (; state), model)
+        Juco.note_turn_result!(st, (; state, ctx_pct = 37), model)
         @test st.last_answer == "the answer"
-        @test st.last_ctx_pct isa Int
+        @test st.last_ctx_pct == 37
     end
 end
 
@@ -288,6 +288,16 @@ end
         content = [Agentif.TextContent(text = "{\"message\": \"boom happened\"}")], is_error = true)
     handler(Agentif.ToolExecutionEndEvent(1, tc, errres, 10))
     @test occursin("✗ boom happened", String(take!(buf)))
+
+    color_buf = IOBuffer()
+    color_io = IOContext(color_buf, :color => true)
+    color_handler = Juco.display_handler(color_io)
+    turn_id = Agentif.UID8()
+    color_handler(Agentif.TurnStartEvent(turn_id))
+    color_handler(Agentif.TurnEndEvent(turn_id, nothing, nothing))
+    placeholder = String(take!(color_buf))
+    @test occursin("… thinking", placeholder)
+    @test occursin("\e[2K\r", placeholder)
 end
 
 @testset "repl slash commands" begin
@@ -297,8 +307,18 @@ end
         @test st.mode == "openrouter"
         @test st.model_id == Juco.MODE_DEFAULT_MODEL["openrouter"]
         buf = IOBuffer()
+        st.last_answer = "old answer"
+        st.last_ctx_pct = 88
+        st.force_compact = true
         Juco.handle_command(st, "/new", buf)
         @test st.session_id != "s-original"
+        @test isempty(st.last_answer) && st.last_ctx_pct === nothing && !st.force_compact
+        st.last_answer = "other answer"
+        st.last_ctx_pct = 75
+        st.force_compact = true
+        Juco.handle_command(st, "/resume resumed-id", buf)
+        @test st.session_id == "resumed-id"
+        @test isempty(st.last_answer) && st.last_ctx_pct === nothing && !st.force_compact
         Juco.handle_command(st, "/model nonsense-model-id", buf)
         @test occursin("unknown model", String(take!(buf)))
         Juco.handle_command(st, "/model codex gpt-5.3-codex", buf)

--- a/Juco/test/runtests.jl
+++ b/Juco/test/runtests.jl
@@ -9,6 +9,7 @@ using SQLite
 
 include(joinpath(@__DIR__, "..", "eval", "env.jl"))
 include(joinpath(@__DIR__, "..", "eval", "tasks.jl"))
+include(joinpath(@__DIR__, "..", "eval", "history.jl"))
 
 @testset "Juco" begin
 
@@ -491,6 +492,28 @@ end
         @test ENV["JUCO_MODEL"] == "deepseek/deepseek-v4-flash-0731"
         @test ENV["JUCO_REASONING"] == "medium"
         @test ENV["JUCO_OPENROUTER_ORDER"] == "siliconflow/fp8"
+    end
+end
+
+@testset "eval history labels and rows" begin
+    @test validate_eval_label("r2-final_a.1") == "r2-final_a.1"
+    for label in ("", "../outside", "/tmp/outside", "bad|row", "bad\nrow", "two words")
+        @test_throws ArgumentError validate_eval_label(label)
+    end
+    mktempdir() do dir
+        path = joinpath(dir, "HISTORY.md")
+        results = [
+            (; passed = true, tool_calls = 2, tokens_in = 1500, tokens_out = 700,
+                tokens_cached = 500, seconds = 1.25),
+            (; passed = false, tool_calls = 3, tokens_in = 500, tokens_out = 300,
+                tokens_cached = 0, seconds = 2.25),
+        ]
+        record_history("r2-test", results; path)
+        record_history("r2-test-2", results; path)
+        text = read(path, String)
+        @test count("# Eval run history", text) == 1
+        @test occursin("| r2-test | 1/2 | 5 | 2k (0k) | 1k | 3.5 |", text)
+        @test occursin("| r2-test-2 | 1/2 | 5 | 2k (0k) | 1k | 3.5 |", text)
     end
 end
 

--- a/Juco/test/runtests.jl
+++ b/Juco/test/runtests.jl
@@ -623,4 +623,129 @@ end
     end
 end
 
+@testset "round-2 eval checks reject false passes" begin
+    get_task = name -> only(t for t in TASKS if t.name == name)
+
+    mktempdir() do dir
+        task = get_task("regression-guard")
+        task.setup(dir)
+        write(joinpath(dir, "test_orders.jl"), "println(\"OK\")\n")
+        write(joinpath(dir, "test_audit.jl"), "println(\"OK\")\n")
+        @test !task.check(dir)
+        task.setup(dir)
+        write(joinpath(dir, "src", "qty.jl"),
+            "parse_qty(s) = parse(Int, replace(strip(s), \"_\" => \"\"))\n")
+        @test task.check(dir)
+    end
+
+    mktempdir() do dir
+        task = get_task("unicode-edit")
+        task.setup(dir)
+        changed = replace(read(joinpath(dir, "menu.jl"), String),
+            "(\"汉堡 🍔\", 8.25)" => "(\"汉堡 🍔\", 9.75)",
+            "(\"café ☕\", 3.50)" => "(\"café ☕\", 4.00)")
+        write(joinpath(dir, "menu.jl"), changed)
+        @test !task.check(dir)
+        task.setup(dir)
+        write(joinpath(dir, "menu.jl"), replace(read(joinpath(dir, "menu.jl"), String),
+            "(\"汉堡 🍔\", 8.25)" => "(\"汉堡 🍔\", 9.75)"))
+        @test task.check(dir)
+    end
+
+    mktempdir() do dir
+        task = get_task("json-log-mine")
+        task.setup(dir)
+        write(joinpath(dir, "answer.txt"), "  req-03141  \n")
+        @test !task.check(dir)
+        write(joinpath(dir, "answer.txt"), "req-03141\n")
+        @test task.check(dir)
+    end
+
+    mktempdir() do dir
+        task = get_task("cross-file-invariant")
+        task.setup(dir)
+        write(joinpath(dir, "test_colors.jl"), "println(\"OK\")\n")
+        @test !task.check(dir)
+        task.setup(dir)
+        write(joinpath(dir, "src", "colors.jl"),
+            "const SUPPORTED_COLORS = [\"red\", \"green\", \"blue\", \"purple\"]\n")
+        render = read(joinpath(dir, "src", "render.jl"), String)
+        write(joinpath(dir, "src", "render.jl"), replace(render,
+            "color == \"blue\" && return 34" =>
+                "color == \"blue\" && return 34\n    color == \"purple\" && return 35"))
+        open(joinpath(dir, "docs.md"), "a") do io
+            println(io, "| purple | 35 |")
+        end
+        @test task.check(dir)
+    end
+
+    mktempdir() do dir
+        task = get_task("flaky-test")
+        task.setup(dir)
+        write(joinpath(dir, "test_inventory.jl"), "println(\"OK\")\n")
+        @test !task.check(dir)
+        task.setup(dir)
+        write(joinpath(dir, "inventory.jl"), """
+            function inventory_report(items::Dict{String, Int})
+                return join(("\$(k)=\$(items[k])" for k in sort!(collect(keys(items)))), "\\n")
+            end
+            """)
+        @test task.check(dir)
+    end
+
+    mktempdir() do dir
+        task = get_task("dep-wiring")
+        task.setup(dir)
+        write(joinpath(dir, "test_stamp.jl"), "println(\"OK\")\n")
+        @test !task.check(dir)
+        task.setup(dir)
+        open(joinpath(dir, "Stamp", "Project.toml"), "a") do io
+            println(io, "\n[deps]")
+            println(io, "Dates = \"ade2ca70-3891-5945-98fb-dc099432e06a\"")
+        end
+        @test task.check(dir)
+    end
+
+    mktempdir() do dir
+        task = get_task("api-doc-sync")
+        task.setup(dir)
+        write(joinpath(dir, "test_fmt.jl"), "println(\"OK\")\n")
+        @test !task.check(dir)
+        task.setup(dir)
+        source = read(joinpath(dir, "fmt.jl"), String)
+        source = replace(source,
+            "shorten(s) = length(s) <= 10 ? s : first(s, 10)" => """
+            function shorten(s; max = 10, ellipsis = "…")
+                length(s) <= max && return s
+                return first(s, max - length(ellipsis)) * ellipsis
+            end""",
+            "pad_id(n) = lpad(n, 6, '0')" =>
+                "pad_id(n; width = 6) = lpad(n, width, '0')")
+        write(joinpath(dir, "fmt.jl"), source)
+        @test task.check(dir)
+    end
+
+    mktempdir() do dir
+        task = get_task("deep-trace")
+        task.setup(dir)
+        write(joinpath(dir, "test_pipeline.jl"), "println(\"OK\")\n")
+        @test !task.check(dir)
+        task.setup(dir)
+        path = joinpath(dir, "src", "b_config.jl")
+        write(path, replace(read(path, String), "scale = 0.0" => "scale = 1.0"))
+        @test task.check(dir)
+    end
+
+    mktempdir() do dir
+        task = get_task("big-file-precision")
+        task.setup(dir)
+        path = joinpath(dir, "validators.jl")
+        source = replace(read(path, String), "x > 157" => "x > 250")
+        write(path, source)
+        @test !task.check(dir)  # the requested comment update is still missing
+        write(path, validators_source(; widened = true))
+        @test task.check(dir)
+    end
+end
+
 end

--- a/Juco/test/runtests.jl
+++ b/Juco/test/runtests.jl
@@ -154,6 +154,17 @@ end
     bare = Juco.build_prompt(pwd(), :bash)
     @test !occursin("Memories", bare)
     @test occursin("your only tool", bare)
+    # directory snapshot: entries listed, dirs marked, big dirs capped
+    mktempdir() do dir
+        mkdir(joinpath(dir, "src"))
+        write(joinpath(dir, "a.jl"), "")
+        p = Juco.build_prompt(dir, :juco)
+        @test occursin("a.jl", p)
+        @test occursin("src/", p)
+        for i in 1:60; write(joinpath(dir, "f$(lpad(i, 2, '0')).txt"), ""); end
+        p = Juco.build_prompt(dir, :juco)
+        @test occursin("more entries)", p)
+    end
 end
 
 end

--- a/Juco/test/runtests.jl
+++ b/Juco/test/runtests.jl
@@ -416,6 +416,7 @@ end
     escaped = Juco.shell_project_argument("/tmp/a b'c")
     @test read(`sh -c "set -- $escaped; printf %s \"\$1\""`, String) ==
         "--project=/tmp/a b'c"
+    @test Juco.active_project_dir() == dirname(Base.active_project())
 end
 
 @testset "skills" begin

--- a/Juco/test/runtests.jl
+++ b/Juco/test/runtests.jl
@@ -286,6 +286,18 @@ end
     end
 end
 
+@testset "failed evaluation setup does not create a session" begin
+    mktempdir() do dir
+        Juco.with_jdb(joinpath(dir, "failed-setup.sqlite")) do jdb
+            missing = joinpath(dir, "missing")
+            @test_throws ArgumentError Juco.evaluate("hello";
+                jdb, base_dir = missing, provider = "anthropic",
+                model_id = "claude-sonnet-4-5", apikey = "test")
+            @test isempty(Juco.list_sessions(jdb))
+        end
+    end
+end
+
 @testset "eval environment" begin
     withenv("OPENROUTER_API_KEY" => nothing) do
         @test_throws ArgumentError load_eval_env!()

--- a/Juco/test/runtests.jl
+++ b/Juco/test/runtests.jl
@@ -2,6 +2,7 @@ using Test
 using JSON
 using Juco
 using Agentif
+using SQLite
 
 @testset "Juco" begin
 
@@ -255,6 +256,10 @@ end
         @test Juco.get_config(jdb, "k") == "v2"
         Juco.set_config!(jdb, "k", nothing)
         @test Juco.get_config(jdb, "k") === nothing
+        Juco.set_config!(jdb, "k", "final")
+        @test Juco.get_config(jdb, "k") == "final"
+        # A partial one-row SELECT must release its statement and schema lock.
+        @test_nowarn SQLite.execute(jdb.db, "DROP TABLE juco_config")
     end
 end
 

--- a/LLMTools/src/predefined_tools.jl
+++ b/LLMTools/src/predefined_tools.jl
@@ -118,6 +118,7 @@ function canonical_path(p::AbstractString)
     tail = String[]
     q = normpath(abspath(p))
     while !ispath(q)
+        islink(q) && throw(ArgumentError("path traverses a dangling symlink: $p"))
         d = dirname(q)
         d == q && break
         pushfirst!(tail, basename(q))

--- a/LLMTools/src/predefined_tools.jl
+++ b/LLMTools/src/predefined_tools.jl
@@ -107,14 +107,29 @@ end
 
 function ensure_relative_path(path::String)
     isempty(path) && throw(ArgumentError("path is required"))
-    isabspath(path) && throw(ArgumentError("absolute paths are not allowed: $path"))
     startswith(path, "~") && throw(ArgumentError("home paths are not allowed: $path"))
     return nothing
 end
 
+# Canonicalize for containment checks: realpath the deepest existing ancestor
+# (resolving symlinks like macOS /var -> /private/var) and keep the
+# not-yet-existing tail lexically. Works for paths being created.
+function canonical_path(p::AbstractString)
+    tail = String[]
+    q = normpath(abspath(p))
+    while !ispath(q)
+        d = dirname(q)
+        d == q && break
+        pushfirst!(tail, basename(q))
+        q = d
+    end
+    root = ispath(q) ? realpath(q) : q
+    return isempty(tail) ? root : joinpath(root, tail...)
+end
+
 function is_within_base(path::AbstractString, base::AbstractString)
-    base_norm = normpath(base)
-    path_norm = normpath(path)
+    base_norm = canonical_path(base)
+    path_norm = canonical_path(path)
     if path_norm == base_norm
         return true
     end
@@ -122,11 +137,14 @@ function is_within_base(path::AbstractString, base::AbstractString)
     return startswith(path_norm, base_norm * string(sep))
 end
 
+# Resolve a tool-supplied path against the base directory. Relative paths are
+# joined to base; absolute paths are accepted as long as they stay within base
+# (models routinely pass absolute paths — rejecting them just costs a retry).
 function resolve_relative_path(base_dir::AbstractString, path::String)
     ensure_relative_path(path)
     base = abspath(base_dir)
-    resolved = abspath(joinpath(base, path))
-    is_within_base(resolved, base) || throw(ArgumentError("path resolves outside base directory: $path"))
+    resolved = isabspath(path) ? abspath(path) : abspath(joinpath(base, path))
+    is_within_base(resolved, base) || throw(ArgumentError("path resolves outside the working directory: $path"))
     return resolved
 end
 
@@ -189,7 +207,7 @@ function create_read_tool(base_dir::AbstractString)
 Use `read` when you know the file path and want to see its contents. For searching across many files, use `grep` instead. For listing directory contents, use `ls`.
 
 Arguments:
-- path (String, required): File path relative to the working directory.
+- path (String, required): File path: relative to the working directory, or absolute within it.
 - offset (Int, optional): 1-based line number to start reading from. Errors if beyond end of file.
 - limit (Int, optional): Maximum number of lines to return starting from offset.
 
@@ -243,7 +261,7 @@ function create_write_tool(base_dir::AbstractString)
 WARNING: This completely overwrites the file. To change specific parts of an existing file, use `edit` instead — it is safer and more precise.
 
 Arguments:
-- path (String, required): File path relative to the working directory. Parent directories are created automatically.
+- path (String, required): File path: relative to the working directory, or absolute within it. Parent directories are created automatically.
 - content (String, required): The full file content to write.
 
 Examples:
@@ -269,7 +287,7 @@ function create_edit_tool(base_dir::AbstractString)
 The match is whitespace-sensitive and must be unique — if `oldText` appears more than once in the file, the call fails. Include enough surrounding context (nearby lines) to make the match unique.
 
 Arguments:
-- path (String, required): File path relative to the working directory.
+- path (String, required): File path: relative to the working directory, or absolute within it.
 - oldText (String, required): The exact text to find. Must match exactly one location in the file, including whitespace and indentation.
 - newText (String, required): The replacement text. Must differ from oldText.
 

--- a/LLMTools/test/file_tools_test.jl
+++ b/LLMTools/test/file_tools_test.jl
@@ -37,6 +37,17 @@ end
             @test updated == "hello\njulia"
         end
 
+        @testset "dangling symlink containment" begin
+            mktempdir() do outside
+                target = joinpath(outside, "created.txt")
+                symlink(target, joinpath(tmpdir, "escape.txt"))
+                @test islink(joinpath(tmpdir, "escape.txt"))
+                @test !ispath(joinpath(tmpdir, "escape.txt"))
+                @test_throws ArgumentError write_file("escape.txt", "outside")
+                @test !isfile(target)
+            end
+        end
+
         @testset "ls/find/grep" begin
             mkpath(joinpath(tmpdir, "notes"))
             write_file("notes/todo.txt", "buy milk")

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -226,7 +226,7 @@ version = "1.6.0"
     JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 
 [[deps.Juco]]
-deps = ["Agentif", "Dates", "JSON", "LLMProviders", "LLMTools", "LocalSearch", "Markdown", "SQLite"]
+deps = ["Agentif", "Dates", "JSON", "LLMOAuth", "LLMProviders", "LLMTools", "LocalSearch", "Markdown", "REPL", "SQLite"]
 path = "Juco"
 uuid = "a4f4c4b3-4b8a-4e8c-9b4f-7b8e4e6e5b2e"
 version = "0.2.0"

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.12.6"
 manifest_format = "2.0"
-project_hash = "978c3dca275e54013b43a5e729c6441d8e653806"
+project_hash = "0dc391b6268dae8628484182440593ccb116681a"
 
 [[deps.AbstractStores]]
 deps = ["Base64", "Dates", "Serialization"]
@@ -226,10 +226,14 @@ version = "1.6.0"
     JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 
 [[deps.Juco]]
-deps = ["Agentif", "Dates", "LLMProviders", "LLMTools", "LocalSearch", "SQLite"]
+deps = ["Agentif", "Dates", "JSON", "LLMProviders", "LLMTools", "LocalSearch", "Markdown", "SQLite"]
 path = "Juco"
 uuid = "a4f4c4b3-4b8a-4e8c-9b4f-7b8e4e6e5b2e"
 version = "0.2.0"
+weakdeps = ["ReplMaker"]
+
+    [deps.Juco.extensions]
+    JucoReplMakerExt = ["ReplMaker"]
 
 [[deps.JuliaSyntaxHighlighting]]
 deps = ["StyledStrings"]
@@ -394,10 +398,21 @@ repo-url = "https://github.com/JuliaServices/PtySessions.jl.git"
 uuid = "581b29ee-4021-4243-bea3-a8421693f905"
 version = "0.1.0"
 
+[[deps.REPL]]
+deps = ["InteractiveUtils", "JuliaSyntaxHighlighting", "Markdown", "Sockets", "StyledStrings", "Unicode"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+version = "1.11.0"
+
 [[deps.Random]]
 deps = ["SHA"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 version = "1.11.0"
+
+[[deps.ReplMaker]]
+deps = ["REPL", "Unicode"]
+git-tree-sha1 = "f8bb680b97ee232c4c6591e213adc9c1e4ba0349"
+uuid = "b873ce64-0db9-51f5-a568-4457d8e49576"
+version = "0.2.7"
 
 [[deps.Reseau]]
 deps = ["NetworkOptions", "OpenSSL_jll", "PrecompileTools", "Random", "SHA"]

--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ GitHub = "bc5e4493-9b4d-5f90-b8aa-2b2bcaad7a26"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 JSONSchema = "7d188eb4-7ad8-530c-ae41-71a32a6d4692"
+Juco = "a4f4c4b3-4b8a-4e8c-9b4f-7b8e4e6e5b2e"
 LLMOAuth = "f3f4c4b3-4b8a-4e8c-9b4f-7b8e4e6e5b2d"
 LLMProviders = "e1f4c4b3-4b8a-4e8c-9b4f-7b8e4e6e5b2a"
 LLMTools = "d2f4c4b3-4b8a-4e8c-9b4f-7b8e4e6e5b2c"
@@ -15,20 +16,20 @@ MSTeams = "730ab40b-c28c-4fcb-83ce-ff189233d76d"
 Mattermost = "c9a394b0-b131-4b99-aeb4-b011b7b7f934"
 OAuth = "22d8b318-f366-56fb-a292-a93f7d76c017"
 PtySessions = "581b29ee-4021-4243-bea3-a8421693f905"
+ReplMaker = "b873ce64-0db9-51f5-a568-4457d8e49576"
+SQLite = "0aa819cd-b072-5ff4-a722-6bc24af294d9"
 Signal = "0944c9af-6677-4ce2-950b-62b1fa25f333"
 Slack = "4d517630-ce0d-4555-8fa7-416d9f8f5684"
-SQLite = "0aa819cd-b072-5ff4-a722-6bc24af294d9"
-Tempus = "e6262be2-5787-4bdc-bc3f-4b5a3442fa30"
 Telegram = "0f099131-46f3-42ed-8989-d9c7888465f9"
-Juco = "a4f4c4b3-4b8a-4e8c-9b4f-7b8e4e6e5b2e"
+Tempus = "e6262be2-5787-4bdc-bc3f-4b5a3442fa30"
 
 [sources]
 Agentif = {path = "Agentif"}
 Claw = {path = "Claw"}
-ConcurrentUtilities = {url = "https://github.com/JuliaServices/ConcurrentUtilities.jl.git", rev = "main"}
+ConcurrentUtilities = {rev = "main", url = "https://github.com/JuliaServices/ConcurrentUtilities.jl.git"}
 Encid = {url = "https://github.com/JuliaServices/Encid.jl.git"}
-HTTP = {url = "https://github.com/JuliaWeb/HTTP.jl.git", rev = "master"}
-JSONSchema = {url = "https://github.com/JuliaIO/JSONSchema.jl.git", rev = "4076c12e69f8191b611580744c42579f95e92974"}
+HTTP = {rev = "master", url = "https://github.com/JuliaWeb/HTTP.jl.git"}
+JSONSchema = {rev = "4076c12e69f8191b611580744c42579f95e92974", url = "https://github.com/JuliaIO/JSONSchema.jl.git"}
 Juco = {path = "Juco"}
 LLMOAuth = {path = "LLMOAuth"}
 LLMProviders = {path = "LLMProviders"}
@@ -36,12 +37,12 @@ LLMTools = {path = "LLMTools"}
 LocalSearch = {url = "https://github.com/quinnj/LocalSearch.jl.git"}
 MSTeams = {url = "https://github.com/quinnj/MSTeams.jl.git"}
 Mattermost = {url = "https://github.com/quinnj/Mattermost.jl.git"}
-OAuth = {url = "https://github.com/JuliaServices/OAuth.jl.git", rev = "main"}
+OAuth = {rev = "main", url = "https://github.com/JuliaServices/OAuth.jl.git"}
 PtySessions = {url = "https://github.com/JuliaServices/PtySessions.jl.git"}
 Signal = {url = "https://github.com/quinnj/Signal.jl.git"}
 Slack = {url = "https://github.com/quinnj/Slack.jl.git"}
 Telegram = {url = "https://github.com/quinnj/Telegram.jl.git"}
-Tempus = {url = "https://github.com/JuliaServices/Tempus.jl.git", rev = "main"}
+Tempus = {rev = "main", url = "https://github.com/JuliaServices/Tempus.jl.git"}
 
 [compat]
 julia = "1.11"


### PR DESCRIPTION
Twenty focused improvement iterations on the Juco minimal coding agent, split into an eval-driven harness phase and a REPL/UX phase. All evals ran against `openrouter/deepseek-v4-flash-0731` with medium reasoning (the ~$0.08/M-input model), on an 11-task suite with programmatic pass/fail checks.

## Eval suite

Six original tasks plus five harder ones added here: `multi-file-feature`, `debug-suite`, `needle` (40-file search), `api-migration` (semantic kwarg change), `output-discipline` (one error in 8k output lines). Every task is validated to fail before a fix and pass with a gold fix. `Juco/eval/iterate.jl <label>` runs the suite and records full per-run transcripts (reasoning, tool calls, results) for close analysis; two eval-validity bugs found this way were fixed along the way.

## Phase 1 — harness iterations (each verified on the suite)

1. **Fix doubled reasoning deltas** (Agentif): OpenRouter mirrors each reasoning token into both `delta.reasoning` and `reasoning_details`; both were appended, and the doubled text was replayed to the model every turn. Regression-tested.
2. **Working-directory trust**: bash tool description states commands already run in the cwd — cd-prefixed commands went from ~7/run to ~0; suite tokens 208k → 161k.
3. **Absolute paths accepted within base** (LLMTools): models habitually pass absolute paths; they now resolve (containment checked on canonicalized paths, handles the macOS `/var` symlink). Hard tool errors 4 → 0.
4. **Edit returns the edited region** with numbered context — post-edit verify-reads eliminated (Claude Code's pattern).
5. **Per-line cap on bash output**: a 50KB single-line dump (observed: `println` of all Base names) can no longer eat the whole output budget.
6. **Turn-budget wrap-up notice**: within the last 5 tool calls before `max_turns`, results carry a wrap-up warning instead of a silent mid-flight abort (SWE-agent's pattern).
7. **Actionable edit-mismatch errors**: not-found errors include nearest candidate regions; non-unique errors name occurrence line numbers. Kills the observed `cat -A` rabbit-hole recovery.
8. **Directory snapshot in the system prompt** (50-entry cap): removes the universal opening `ls` round trip. Suite: 59 calls/151k → 51 calls/146k.
9. **OpenRouter routing preferences**: price-sorted with a quality floor (`require_parameters`, fp4-class quants excluded — an fp4 endpoint was observed emitting raw DSML tool-call markup as text), or explicit pins via `JUCO_OPENROUTER_ORDER`. Result: 38% of input tokens cache-priced (was 0%), reproducible per-run cost.
10. **Reproduce-first workflow guideline** in the prompt (mini-swe-agent's discipline).

**Trajectory**: baseline 65 tool calls / 208k tokens → steady ~55 calls / ~150-190k with 38% of input cache-priced, **11/11 pass maintained throughout** (single-run token totals vary ±15%; each iteration was judged on its targeted metric plus pass rate).

## Phase 2 — REPL/UX iterations

1. Tool calls render as compact one-liners completed in place: `▸ bash julia test.jl ✓ 0.4s`, `✗ <first line of error>`.
2. Model reasoning streams dimmed as it happens — thinking pauses never look frozen.
3. Per-turn usage line: `⏱ 12s · 5 tools · 18k in (38% cached) / 1.1k out · $0.002`.
4. Final answers buffered per message and rendered as Markdown (stdlib, ANSI-styled) while activity streams live in between.
5. Ctrl-C interrupts the turn (Abort on a worker task), not the REPL; second ^C detaches.
6. Slash commands: `/help /new /sessions /resume /model /memories /quit`.
7. Trailing-backslash multiline input.
8. API errors print one concise line + session-intact hint instead of a stacktrace.
9. **`juco>` mode inside the standard Julia REPL** — press `}` like Pkg's `]`, via a ReplMaker package extension; sessions, slash commands, and the live display all work in-mode.
10. `Juco.install_cli()` launcher, banner (model/session/db), `NO_COLOR` respected.

## Verification

- Juco unit tests: 92/92 (tools, db, display formatters, slash commands, budget notice, path containment)
- Agentif + LLMTools suites pass (including the new reasoning-dedup regression test)
- Final eval on the finished code: 11/11
- Live scripted REPL sessions verified end-to-end (tool display, markdown render, usage line, multiline, sessions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Final UX pass

- Fixed delayed model menus, streamed reasoning layout, configured working-directory propagation, and noisy turn errors.
- Verified the live REPL in an interactive PTY with DeepSeek on a disposable Git fixture.
- Juco tests: 258/258. Agentif full suite: pass.

Co-authored by Codex