### PR TITLE
Fix YAML skill frontmatter parsing

### DIFF
--- a/Agentif/Project.toml
+++ b/Agentif/Project.toml
@@ -17,6 +17,7 @@ LoggingExtras = "e6f89c97-d47a-5376-807f-9c37f3926c36"
 PtySessions = "581b29ee-4021-4243-bea3-a8421693f905"
 ScopedValues = "7e506255-f358-4e82-b7e4-beb19740aa63"
 StructUtils = "ec057cc2-7a8d-4b58-b3b3-92acb9f63b42"
+YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [weakdeps]
 LocalSearch = "3edf9609-13f2-4288-b0a3-8bd6d521158e"
@@ -50,6 +51,7 @@ LoggingExtras = "1"
 PtySessions = "0.1"
 ScopedValues = "1.5"
 StructUtils = "2.6"
+YAML = "0.4"
 julia = "1.8"
 
 [extras]

--- a/Agentif/src/Agentif.jl
+++ b/Agentif/src/Agentif.jl
@@ -1,6 +1,6 @@
 module Agentif
 
-using Base64, Dates, HTTP, InteractiveUtils, JSON, JSONSchema, Logging, LoggingExtras, PtySessions, ScopedValues, StructUtils
+using Base64, Dates, HTTP, InteractiveUtils, JSON, JSONSchema, Logging, LoggingExtras, PtySessions, ScopedValues, StructUtils, YAML
 using Encid: UID8
 using LLMProviders
 using LLMProviders: Model, getModel, getProviders, getModels, calculateCost, registerModel!, discover_models!

--- a/Agentif/src/skills.jl
+++ b/Agentif/src/skills.jl
@@ -181,55 +181,41 @@ function parse_frontmatter(content::AbstractString)
     lines = split(content, "\n"; keepempty = true)
     isempty(lines) && throw(ArgumentError("missing frontmatter"))
     strip(lines[1]) == "---" || throw(ArgumentError("missing frontmatter start delimiter"))
-    end_idx = nothing
-    for i in 2:length(lines)
-        if strip(lines[i]) == "---"
-            end_idx = i
-            break
-        end
-    end
+    end_idx = findnext(line -> strip(line) == "---", lines, 2)
     end_idx === nothing && throw(ArgumentError("missing frontmatter end delimiter"))
-    front_lines = lines[2:(end_idx - 1)]
-    return parse_frontmatter_lines(front_lines)
+    return parse_frontmatter_lines(lines[2:(end_idx - 1)])
 end
 
 function parse_frontmatter_lines(lines::AbstractVector{<:AbstractString})
-    fields = Dict{String, Any}()
-    metadata = Dict{String, String}()
-    i = 1
-    while i <= length(lines)
-        line = lines[i]
-        stripped = strip(line)
-        if isempty(stripped) || startswith(stripped, "#")
-            i += 1
-            continue
-        end
-        if stripped == "metadata:"
-            i += 1
-            while i <= length(lines)
-                meta_line = lines[i]
-                isempty(strip(meta_line)) && (i += 1; continue)
-                indent = length(meta_line) - length(lstrip(meta_line))
-                indent < 2 && break
-                meta_str = strip(meta_line)
-                m = match(r"^([A-Za-z0-9_.-]+)\s*:\s*(.*)$", meta_str)
-                if m !== nothing
-                    metadata[m.captures[1]] = unquote(m.captures[2])
-                end
-                i += 1
-            end
-            continue
-        end
-        m = match(r"^([A-Za-z0-9_-]+)\s*:\s*(.*)$", stripped)
-        if m !== nothing
-            fields[m.captures[1]] = unquote(m.captures[2])
-        end
-        i += 1
+    document = try
+        YAML.load(join(lines, "\n"))
+    catch e
+        message = first(sprint(showerror, e), 200)
+        throw(ArgumentError("invalid YAML frontmatter: $message"))
     end
-    if !isempty(metadata)
-        fields["metadata"] = metadata
+    document === nothing && return Dict{String, Any}()
+    document isa AbstractDict || throw(ArgumentError("frontmatter must be a mapping"))
+
+    fields = Dict{String, Any}()
+    for (key, value) in document
+        string_key = string(key)
+        fields[string_key] = if string_key == "metadata" && value isa AbstractDict
+            Dict{String, String}(
+                string(metadata_key) => flatten_yaml(metadata_value) for
+                (metadata_key, metadata_value) in value
+            )
+        else
+            flatten_yaml(value)
+        end
     end
     return fields
+end
+
+function flatten_yaml(value)
+    value === nothing && return ""
+    value isa AbstractString && return rstrip(String(value), ['\r', '\n'])
+    value isa AbstractVector && return join((flatten_yaml(item) for item in value), ", ")
+    return string(value)
 end
 
 function unquote(value::AbstractString)

--- a/Agentif/test/runtests.jl
+++ b/Agentif/test/runtests.jl
@@ -1924,6 +1924,60 @@ end
     end
 end
 
+@testset "skill frontmatter uses YAML semantics" begin
+    doc = """
+    ---
+    name: demo
+    description: >
+      first line
+      second line
+
+      new paragraph
+    metadata:
+      author: someone
+      created: 2026-08-21
+    ---
+
+    body text
+    """
+    fields = Agentif.parse_frontmatter(doc)
+    @test fields["name"] == "demo"
+    @test fields["description"] == "first line second line\nnew paragraph"
+    @test fields["metadata"] == Dict("author" => "someone", "created" => "2026-08-21")
+
+    description(doc) = Agentif.parse_frontmatter(doc)["description"]
+    @test description("---\nname: a\ndescription: just text\n---\n") == "just text"
+    @test description("---\nname: a\ndescription: \"quoted\"\n---\n") == "quoted"
+    @test description("---\nname: a\ndescription: |\n  one\n  two\n---\n") == "one\ntwo"
+    @test description("---\nname: a\ndescription: >-\n  one\n  two\n\n---\n") == "one two"
+    @test description("---\nname: a\ndescription: >\n  weird: value here\n---\n") == "weird: value here"
+    @test description("---\r\nname: a\r\ndescription: >\r\n  one\r\n  two\r\n---\r\n") == "one two"
+    @test description("---\n# a note\nname: a\ndescription: text\n---\n") == "text"
+
+    @test description("---\nname: a\ndescription: 2026\n---\n") == "2026"
+    @test description("---\nname: a\ndescription: [one, two]\n---\n") == "one, two"
+    @test Agentif.flatten_yaml(nothing) == ""
+
+    @test_throws ArgumentError Agentif.parse_frontmatter("---\nname: a\ndescription: > bad\n---\n")
+    @test_throws ArgumentError Agentif.parse_frontmatter("name: a\n")
+    @test_throws ArgumentError Agentif.parse_frontmatter("---\nname: a\n")
+    @test_throws ArgumentError Agentif.parse_frontmatter("---\n- a list\n---\n")
+    @test Agentif.parse_frontmatter("---\n---\n") == Dict{String, Any}()
+
+    dir = mktempdir()
+    mkpath(joinpath(dir, "demo-skill"))
+    write(
+        joinpath(dir, "demo-skill", "SKILL.md"),
+        "---\nname: demo-skill\ndescription: >\n" *
+        "  Do the thing, and the other thing.\n" *
+        "  Invoke when the thing needs doing.\n---\n\nbody\n",
+    )
+    found = Agentif.discover_skills([dir])
+    @test length(found) == 1
+    @test only(found).description ==
+          "Do the thing, and the other thing. Invoke when the thing needs doing."
+end
+
 @testset "skill metadata unquoting is UTF-8 safe" begin
     @test Agentif.unquote("\"café\"") == "café"
     @test Agentif.unquote("'😀'") == "😀"

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -23,7 +23,7 @@ version = "0.1.1"
     Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [[deps.Agentif]]
-deps = ["Base64", "ConcurrentUtilities", "Dates", "Encid", "HTTP", "InteractiveUtils", "JSON", "JSONSchema", "LLMProviders", "Logging", "LoggingExtras", "PtySessions", "ScopedValues", "StructUtils"]
+deps = ["Base64", "ConcurrentUtilities", "Dates", "Encid", "HTTP", "InteractiveUtils", "JSON", "JSONSchema", "LLMProviders", "Logging", "LoggingExtras", "PtySessions", "ScopedValues", "StructUtils", "YAML"]
 path = "Agentif"
 uuid = "b1e21dde-9d8e-492f-89d0-ee48af23bfc5"
 version = "1.0.0"
@@ -289,6 +289,12 @@ version = "1.11.3+1"
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 version = "1.11.0"
 
+[[deps.Libiconv_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "be484f5c92fad0bd8acfef35fe017900b0b73809"
+uuid = "94ce4f54-9a6c-5748-9c1c-f9c7231a4531"
+version = "1.18.0+0"
+
 [[deps.LocalSearch]]
 deps = ["Dates", "Downloads", "Libdl", "SHA", "SQLite", "llama_cpp_jll", "sqlite_vec_jll"]
 git-tree-sha1 = "d82d515cc679ffe4d291c7d0f20a9bedc948715f"
@@ -476,6 +482,12 @@ git-tree-sha1 = "80cef67d2953e33935b41c6ab0a178b9987b1c99"
 uuid = "2133526b-2bfb-4018-ac12-889fb3908a75"
 version = "0.1.1"
 
+[[deps.StringEncodings]]
+deps = ["Libiconv_jll"]
+git-tree-sha1 = "b765e46ba27ecf6b44faf70df40c57aa3a547dcb"
+uuid = "69024149-9ee7-55f6-a4c4-859efe599b68"
+version = "0.3.7"
+
 [[deps.StructUtils]]
 deps = ["Dates", "UUIDs"]
 git-tree-sha1 = "2d0fc55c61321ba245c47be599570d11bac50303"
@@ -570,6 +582,12 @@ deps = ["DataAPI", "InlineStrings", "Parsers"]
 git-tree-sha1 = "0716e01c3b40413de5dedbc9c5c69f27cddfddfc"
 uuid = "ea10d353-3f73-51f8-a26c-33c1cb351aa5"
 version = "1.4.3"
+
+[[deps.YAML]]
+deps = ["Base64", "Dates", "Printf", "StringEncodings"]
+git-tree-sha1 = "a1c0c7585346251353cddede21f180b96388c403"
+uuid = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
+version = "0.4.16"
 
 [[deps.ZipFile]]
 deps = ["Libdl", "Printf", "Zlib_jll"]


### PR DESCRIPTION
## Summary

- Parse skill frontmatter with YAML.jl so folded and literal blocks work correctly.
- Normalize YAML values to the existing string metadata contract.
- Reject malformed YAML and non-mapping frontmatter.
- Add regression coverage for issue #19.

Fixes #19.

## Validation

- `julia --project=. -e 'using Pkg; Pkg.instantiate()'`
- `julia --project=. test/runtests.jl`
- Julia 1.8 parser compatibility check
- `git diff --check`

Co-authored by Codex