### PR TITLE
Honor Git ignore rules in file tools

### DIFF
--- a/LLMTools/Project.toml
+++ b/LLMTools/Project.toml
@@ -5,6 +5,7 @@ version = "1.0.0"
 [deps]
 Agentif = "b1e21dde-9d8e-492f-89d0-ee48af23bfc5"
 ConcurrentUtilities = "f0e56b4a-5159-44fe-b623-3e5288b988bb"
+GitIgnore = "a0010394-fc0d-43eb-a3e0-33caa976912f"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 PtySessions = "581b29ee-4021-4243-bea3-a8421693f905"
@@ -21,12 +22,13 @@ PtySessions = {url = "https://github.com/quinnj/PtySessions.jl.git"}
 [compat]
 Agentif = "1"
 ConcurrentUtilities = "2"
+GitIgnore = "0.1"
 HTTP = "2"
 JSON = "1.3"
 PtySessions = "0.1"
 ScopedValues = "1.3"
 UUIDs = "1"
-julia = "1.10"
+julia = "1.11"
 
 [extras]
 LLMProviders = "e1f4c4b3-4b8a-4e8c-9b4f-7b8e4e6e5b2a"

--- a/LLMTools/README.md
+++ b/LLMTools/README.md
@@ -10,6 +10,9 @@ Current tool areas include:
 - web fetch and search
 - Subagent helpers
 
+The `ls`, `find`, and `grep` tools omit `.git` and honor applicable
+`.gitignore` rules. Other dotfiles remain visible.
+
 Semantic/code-search experiments are no longer exposed from `LLMTools`; that work moved to `LocalSearch.jl`.
 
 ## Repo-Root Workflow

--- a/LLMTools/src/LLMTools.jl
+++ b/LLMTools/src/LLMTools.jl
@@ -3,6 +3,7 @@ module LLMTools
 using Agentif
 using Agentif: Agent, AgentTool, AssistantMessage, message_text, evaluate
 using HTTP, JSON, PtySessions, UUIDs
+using GitIgnore: IgnoreMatcher, walkfiltered
 using ConcurrentUtilities: Workers, Worker, remote_eval, remote_fetch
 using ScopedValues: ScopedValue, @with
 

--- a/LLMTools/src/predefined_tools.jl
+++ b/LLMTools/src/predefined_tools.jl
@@ -154,6 +154,19 @@ function resolve_search_path(base_dir::AbstractString, path::Union{Nothing, Stri
     return resolve_relative_path(base_dir, local_path)
 end
 
+function ignore_root(base_dir::AbstractString)
+    base = abspath(base_dir)
+    current = base
+    while true
+        ispath(joinpath(current, ".git")) && return current
+        parent = dirname(current)
+        parent == current && return base
+        current = parent
+    end
+end
+
+ignore_matcher(base_dir::AbstractString) = IgnoreMatcher(ignore_root(base_dir))
+
 function normalize_relpath(path::AbstractString)
     return replace(path, '\\' => '/')
 end
@@ -333,7 +346,7 @@ Arguments:
 - path (String or nothing, required): Directory path relative to the working directory, or nothing to list the working directory itself.
 - limit (Int, optional): Maximum number of entries to return. Defaults to 500.
 
-Entries are sorted alphabetically (case-insensitive). Directories have a trailing `/` suffix. Dotfiles are included. Output is truncated to 500 entries or 50KB, whichever is hit first.
+Entries are sorted alphabetically (case-insensitive). Directories have a trailing `/` suffix. `.git` and entries excluded by applicable `.gitignore` rules are omitted. Other dotfiles are included. Output is truncated to 500 entries or 50KB, whichever is hit first.
 
 Examples:
 - `ls(nothing)` — list the working directory
@@ -341,7 +354,13 @@ Examples:
         ls(path::Union{Nothing, String}, limit::Union{Nothing, Int} = nothing) = begin
             dir_path = resolve_search_path(base, path)
             isdir(dir_path) || throw(ArgumentError("not a directory: $(path === nothing ? "." : path)"))
-            entries = readdir(dir_path)
+            entries = String[]
+            matcher = ignore_matcher(base)
+            walkfiltered(matcher, dir_path) do _root, dirs, files
+                append!(entries, dirs)
+                append!(entries, files)
+                return false
+            end
             sort!(entries, lt = (a, b) -> lowercase(a) < lowercase(b))
             effective_limit = limit === nothing ? DEFAULT_LS_LIMIT : max(1, limit)
             results = String[]
@@ -446,7 +465,7 @@ Arguments:
 - path (String or nothing, optional): Directory to search within, relative to the working directory. Defaults to the working directory.
 - limit (Int, optional): Maximum number of results. Defaults to 1000.
 
-Matched directories have a trailing `/` suffix. Output is also capped at 50KB.
+Matched directories have a trailing `/` suffix. `.git` and entries excluded by applicable `.gitignore` rules are omitted. Output is also capped at 50KB.
 
 Examples:
 - `find("*.jl")` — find all Julia files recursively
@@ -456,10 +475,11 @@ Examples:
             search_dir = resolve_search_path(base, path)
             isdir(search_dir) || throw(ArgumentError("not a directory: $(path === nothing ? "." : path)"))
             regex = glob_to_regex(pattern)
+            matcher = ignore_matcher(base)
             effective_limit = limit === nothing ? DEFAULT_FIND_LIMIT : max(1, limit)
             results = String[]
             limit_reached = false
-            for (root, dirs, files) in walkdir(search_dir)
+            walk_result = walkfiltered(matcher, search_dir) do root, dirs, files
                 rel_root = relpath(root, search_dir)
                 rel_root = rel_root == "." ? "" : normalize_relpath(rel_root)
                 for dir in dirs
@@ -468,23 +488,23 @@ Examples:
                         push!(results, rel * "/")
                         if length(results) >= effective_limit
                             limit_reached = true
-                            break
+                            return false
                         end
                     end
                 end
-                limit_reached && break
                 for file in files
                     rel = rel_root == "" ? file : "$(rel_root)/$(file)"
                     if occursin(regex, rel)
                         push!(results, rel)
                         if length(results) >= effective_limit
                             limit_reached = true
-                            break
+                            return false
                         end
                     end
                 end
-                limit_reached && break
+                return true
             end
+            limit_reached = limit_reached || !walk_result.completed
             isempty(results) && return "No files found matching pattern"
             raw_output = join(results, "\n")
             truncation = truncate_head(raw_output; max_lines = typemax(Int))
@@ -517,7 +537,7 @@ Arguments:
 - context (Int or nothing, optional): Number of lines to show before and after each match (like `grep -C`).
 - limit (Int, optional): Maximum number of matches. Defaults to 100.
 
-Lines longer than 500 characters are truncated. Output is capped at 50KB.
+`.git` and files excluded by applicable `.gitignore` rules are not searched during recursive directory searches. Lines longer than 500 characters are truncated. Output is capped at 50KB.
 
 Examples:
 - `grep("function main")` — search all files for a regex pattern
@@ -538,22 +558,22 @@ Examples:
             effective_limit = limit === nothing ? DEFAULT_GREP_LIMIT : max(1, limit)
             context_value = context === nothing ? 0 : max(0, context)
             glob_regex = glob === nothing ? nothing : glob_to_regex(glob)
-            match_count = 0
-            match_limit_reached = false
-            lines_truncated = false
+            match_count = Ref(0)
+            match_limit_reached = Ref(false)
+            lines_truncated = Ref(false)
             output_lines = String[]
             search_root = isdir(search_path) ? search_path : dirname(search_path)
-            file_list = isdir(search_path) ? collect(walkdir(search_path)) : [(search_root, String[], [basename(search_path)])]
-            regex = nothing
-            if literal !== true
+            regex = if literal === true
+                nothing
+            else
                 try
                     flags = ignoreCase === true ? "i" : ""
-                    regex = Regex(pattern, flags)
+                    Regex(pattern, flags)
                 catch
                     throw(ArgumentError("invalid regex pattern"))
                 end
             end
-            for (root, _dirs, files) in file_list
+            function search_files(root, files)
                 for file in files
                     file_path = joinpath(root, file)
                     rel_path = normalize_relpath(relpath(file_path, search_root))
@@ -578,9 +598,9 @@ Examples:
                         end
                         if is_match
                             push!(match_lines, idx)
-                            match_count += 1
-                            if match_count >= effective_limit
-                                match_limit_reached = true
+                            match_count[] += 1
+                            if match_count[] >= effective_limit
+                                match_limit_reached[] = true
                                 break
                             end
                         end
@@ -595,7 +615,7 @@ Examples:
                         for line_idx in start_line:end_line
                             line_text = lines[line_idx]
                             truncated = truncate_line(line_text)
-                            truncated.was_truncated && (lines_truncated = true)
+                            truncated.was_truncated && (lines_truncated[] = true)
                             if line_idx in match_set
                                 push!(output_lines, "$(rel_path):$(line_idx): $(truncated.text)")
                             else
@@ -604,17 +624,25 @@ Examples:
                         end
                         last_printed = max(last_printed, end_line)
                     end
-                    match_limit_reached && break
+                    match_limit_reached[] && return false
                 end
-                match_limit_reached && break
+                return true
+            end
+            if isdir(search_path)
+                matcher = ignore_matcher(base)
+                walkfiltered(matcher, search_path) do root, _dirs, files
+                    return search_files(root, files)
+                end
+            else
+                search_files(search_root, [basename(search_path)])
             end
             isempty(output_lines) && return "No matches found"
             raw_output = join(output_lines, "\n")
             truncation = truncate_head(raw_output; max_lines = typemax(Int))
             output = truncation.content
             notices = String[]
-            match_limit_reached && push!(notices, "$(effective_limit) matches limit reached. Use limit=$(effective_limit * 2) for more, or refine pattern")
-            lines_truncated && push!(notices, "some lines were truncated")
+            match_limit_reached[] && push!(notices, "$(effective_limit) matches limit reached. Use limit=$(effective_limit * 2) for more, or refine pattern")
+            lines_truncated[] && push!(notices, "some lines were truncated")
             truncation.truncated && push!(notices, "$(format_size(DEFAULT_MAX_BYTES)) limit reached")
             if !isempty(notices)
                 output *= "\n\n[$(join(notices, ". "))]"

--- a/LLMTools/test/file_tools_test.jl
+++ b/LLMTools/test/file_tools_test.jl
@@ -67,6 +67,86 @@ end
             grep_regex = grep_files("^buy", ".", "**/*.txt", false, false, 0, 20)
             @test occursin("notes/todo.txt:1: buy milk", grep_regex)
         end
+
+        @testset "ls/find/grep honor git ignore rules" begin
+            write_file(".gitignore", "*.log\nbuild/\n")
+            write_file(".env", "needle visible dotfile")
+            write_file("visible.txt", "needle visible")
+            write_file("ignored.log", "needle ignored")
+            write_file("build/output.txt", "needle ignored")
+            write_file("nested/.gitignore", "ignored.txt\n!keep.log\n")
+            write_file("nested/ignored.txt", "needle ignored")
+            write_file("nested/keep.log", "needle visible")
+            write_file("nested/visible.md", "needle visible")
+            write_file(".git/objects/blob", "needle ignored")
+
+            listing = ls_dir(".", 50)
+            @test occursin(".env", listing)
+            @test occursin(".gitignore", listing)
+            @test occursin("visible.txt", listing)
+            @test !occursin(".git/", listing)
+            @test !occursin("ignored.log", listing)
+            @test !occursin("build/", listing)
+
+            nested_listing = ls_dir("nested", 50)
+            @test occursin("keep.log", nested_listing)
+            @test occursin("visible.md", nested_listing)
+            @test !occursin("ignored.txt", nested_listing)
+
+            found = find_files("**", nothing, 50)
+            @test occursin(".env", found)
+            @test occursin("visible.txt", found)
+            @test occursin("nested/keep.log", found)
+            @test !occursin(".git/", found)
+            @test !occursin("ignored.log", found)
+            @test !occursin("build/", found)
+            @test !occursin("nested/ignored.txt", found)
+
+            matches = grep_files("needle", ".", nothing, false, true, 0, 50)
+            @test occursin(".env:1: needle visible dotfile", matches)
+            @test occursin("visible.txt:1: needle visible", matches)
+            @test occursin("nested/keep.log:1: needle visible", matches)
+            @test occursin("nested/visible.md:1: needle visible", matches)
+            @test !occursin(".git/", matches)
+            @test !occursin("ignored.log", matches)
+            @test !occursin("build/", matches)
+            @test !occursin("nested/ignored.txt", matches)
+
+            explicit_listing = ls_dir("build", 50)
+            @test occursin("output.txt", explicit_listing)
+
+            explicitly_found = find_files("**", "build", 50)
+            @test occursin("output.txt", explicitly_found)
+
+            explicit_match = grep_files("needle", "ignored.log", nothing, false, true, 0, 50)
+            @test occursin("ignored.log:1: needle ignored", explicit_match)
+        end
+    end
+end
+
+@testset "File tools honor repository rules above base" begin
+    mktempdir() do repo
+        mkpath(joinpath(repo, ".git"))
+        mkpath(joinpath(repo, "src"))
+        write(joinpath(repo, ".gitignore"), "src/*.log\n")
+        write(joinpath(repo, "src", "ignored.log"), "needle ignored")
+        write(joinpath(repo, "src", "visible.txt"), "needle visible")
+
+        funcs = file_funcs(joinpath(repo, "src"))
+        listing = funcs["ls"](".", 20)
+        @test occursin("visible.txt", listing)
+        @test !occursin("ignored.log", listing)
+
+        found = funcs["find"]("**", nothing, 20)
+        @test occursin("visible.txt", found)
+        @test !occursin("ignored.log", found)
+
+        matches = funcs["grep"]("needle", ".", nothing, false, true, 0, 20)
+        @test occursin("visible.txt:1: needle visible", matches)
+        @test !occursin("ignored.log", matches)
+
+        explicit_match = funcs["grep"]("needle", "ignored.log", nothing, false, true, 0, 20)
+        @test occursin("ignored.log:1: needle ignored", explicit_match)
     end
 end
 

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -157,6 +157,11 @@ git-tree-sha1 = "33de1bc5665494f0a9669fd6027e28180709d874"
 uuid = "bc5e4493-9b4d-5f90-b8aa-2b2bcaad7a26"
 version = "5.13.0"
 
+[[deps.GitIgnore]]
+git-tree-sha1 = "55daea4f28753322302c1ccf03990cf6e9502264"
+uuid = "a0010394-fc0d-43eb-a3e0-33caa976912f"
+version = "0.1.1"
+
 [[deps.HTTP]]
 deps = ["Base64", "CodecZlib", "Dates", "EnumX", "PrecompileTools", "Random", "Reseau", "SHA", "URIs", "UUIDs", "Zlib_jll"]
 git-tree-sha1 = "0a58fbbdee93d132a2fb1159b7f5e1b5c2465e71"
@@ -253,7 +258,7 @@ uuid = "e1f4c4b3-4b8a-4e8c-9b4f-7b8e4e6e5b2a"
 version = "1.0.0"
 
 [[deps.LLMTools]]
-deps = ["Agentif", "ConcurrentUtilities", "HTTP", "JSON", "PtySessions", "ScopedValues", "Sockets", "UUIDs"]
+deps = ["Agentif", "ConcurrentUtilities", "GitIgnore", "HTTP", "JSON", "PtySessions", "ScopedValues", "Sockets", "UUIDs"]
 path = "LLMTools"
 uuid = "d2f4c4b3-4b8a-4e8c-9b4f-7b8e4e6e5b2c"
 version = "1.0.0"


### PR DESCRIPTION
## Summary

- make the LLMTools `ls`, `find`, and `grep` tools honor Git ignore rules
- prune `.git` and ignored directory trees before recursive search
- support repository-root and nested `.gitignore` rules through GitIgnore.jl
- keep other dotfiles and explicitly named ignored paths accessible
- document the behavior and align the LLMTools Julia minimum with the root project

## Root cause

The file tools used `readdir` and `walkdir` directly. They had no shared ignore
filter. Broad searches therefore entered `.git` and files excluded by
`.gitignore`.

## Validation

- regression test failed in 12 assertions before the implementation
- focused file-tool tests passed: 69/69 on Julia 1.11 and 1.12
- full LLMTools tests passed: 451/451 on Julia 1.11 and 1.12
- full monorepo tests passed for LLMProviders, LLMOAuth, Agentif, LLMTools, and Claw
- compiler check found no `Core.Box` or `Any` on the changed grep path
- `git diff --check` passed

Fixes #18

Co-authored by Codex
